### PR TITLE
HS-775 - Add a configurable deadline to all gRPC call

### DIFF
--- a/events/grpc/src/main/java/org/opennms/horizon/events/grpc/client/InventoryClient.java
+++ b/events/grpc/src/main/java/org/opennms/horizon/events/grpc/client/InventoryClient.java
@@ -28,6 +28,8 @@
 
 package org.opennms.horizon.events.grpc.client;
 
+import java.util.concurrent.TimeUnit;
+
 import org.opennms.horizon.inventory.dto.NodeIdQuery;
 import org.opennms.horizon.inventory.dto.NodeServiceGrpc;
 import org.opennms.horizon.shared.constants.GrpcConstants;
@@ -40,6 +42,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InventoryClient {
     private final ManagedChannel channel;
+    private final long deadline;
     private NodeServiceGrpc.NodeServiceBlockingStub nodeStub;
 
     protected void initialStubs() {
@@ -60,6 +63,7 @@ public class InventoryClient {
         NodeIdQuery query = NodeIdQuery.newBuilder()
             .setIpAddress(ipAddress).setLocation(location).build();
         return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))
+            .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS)
             .getNodeIdFromQuery(query).getValue();
     }
 }

--- a/events/grpc/src/main/java/org/opennms/horizon/events/grpc/config/ConfigurationUtil.java
+++ b/events/grpc/src/main/java/org/opennms/horizon/events/grpc/config/ConfigurationUtil.java
@@ -28,14 +28,15 @@
 
 package org.opennms.horizon.events.grpc.config;
 
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.opennms.horizon.events.grpc.client.InventoryClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
@@ -43,6 +44,8 @@ public class ConfigurationUtil {
 
     @Value("${grpc.url.inventory}")
     private String inventoryGrpcAddress;
+    @Value("${grpc.server.deadline:60000}")
+    private long deadline;
 
     @Bean(name = "inventory")
     public ManagedChannel createInventoryChannel() {
@@ -53,6 +56,6 @@ public class ConfigurationUtil {
 
     @Bean(destroyMethod = "shutdown", initMethod = "initialStubs")
     public InventoryClient createInventoryClient(@Qualifier("inventory") ManagedChannel channel) {
-        return new InventoryClient(channel);
+        return new InventoryClient(channel, deadline);
     }
 }

--- a/events/main/src/main/resources/application.yml
+++ b/events/main/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
 grpc:
   server:
     port: 6565
+    deadline: 60000
   url:
     inventory: localhost:29065
 

--- a/inventory/src/main/java/org/opennms/horizon/inventory/component/MinionRpcClient.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/component/MinionRpcClient.java
@@ -91,8 +91,8 @@ public class MinionRpcClient {
                 });
             });
         } catch (Exception e) {
-            throw new RuntimeException("Failed to call minion", e);
+            future.completeExceptionally(new RuntimeException("Failed to call minion", e));
         }
-        return future.orTimeout(deadline, TimeUnit.MILLISECONDS);
+        return future;
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/component/MinionRpcClient.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/component/MinionRpcClient.java
@@ -48,10 +48,12 @@ public class MinionRpcClient {
 
     private final ManagedChannel channel;
     private final TenantLookup tenantLookup;
+    private final long deadline;
 
-    public MinionRpcClient(@Qualifier("minion-gateway") ManagedChannel channel, TenantLookup tenantLookup) {
+    public MinionRpcClient(@Qualifier("minion-gateway") ManagedChannel channel, TenantLookup tenantLookup, long deadline) {
         this.channel = channel;
         this.tenantLookup = tenantLookup;
+        this.deadline = deadline;
     }
 
     private RpcRequestServiceStub rpcStub;
@@ -72,7 +74,7 @@ public class MinionRpcClient {
         Context withCredential = Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId);
         try {
             withCredential.run(() -> {
-                rpcStub.request(request, new StreamObserver<>() {
+                rpcStub.withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).request(request, new StreamObserver<>() {
                     @Override
                     public void onNext(RpcResponseProto value) {
                         future.complete(value);
@@ -91,6 +93,6 @@ public class MinionRpcClient {
         } catch (Exception e) {
             throw new RuntimeException("Failed to call minion", e);
         }
-        return future.orTimeout(60, TimeUnit.SECONDS);
+        return future.orTimeout(deadline, TimeUnit.MILLISECONDS);
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/config/MinionGatewayGrpcClientConfig.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/config/MinionGatewayGrpcClientConfig.java
@@ -1,7 +1,5 @@
 package org.opennms.horizon.inventory.config;
 
-import io.grpc.ManagedChannel;
-import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import org.opennms.horizon.inventory.component.MinionRpcClient;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.grpc.TenantLookup;
@@ -11,6 +9,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+
+import io.grpc.ManagedChannel;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 
 @Configuration
 public class MinionGatewayGrpcClientConfig {
@@ -28,6 +29,9 @@ public class MinionGatewayGrpcClientConfig {
 
     @Value("${grpc.client.minion-gateway.maxMessageSize:10485760}")
     private int maxMessageSize;
+
+    @Value("${grpc.server.deadline:60000}")
+    private long deadline;
 
 
     @Bean(name = MINION_GATEWAY_GRPC_CHANNEL)
@@ -48,11 +52,11 @@ public class MinionGatewayGrpcClientConfig {
 
     @Bean(initMethod = "init", name = GrpcTaskSetPublisher.TASK_SET_PUBLISH_BEAN_NAME)
     public GrpcTaskSetPublisher taskSetPublisher(@Qualifier(MINION_GATEWAY_GRPC_CHANNEL) ManagedChannel channel, @Lazy TenantLookup tenantLookup) {
-        return new GrpcTaskSetPublisher(channel, tenantLookup);
+        return new GrpcTaskSetPublisher(channel, tenantLookup, deadline);
     }
 
     @Bean(initMethod = "init", destroyMethod = "shutdown")
     public MinionRpcClient createMinionRpcClient(@Qualifier(MINION_GATEWAY_GRPC_CHANNEL) ManagedChannel channel, TenantLookup tenantLookup) {
-        return new MinionRpcClient(channel, tenantLookup);
+        return new MinionRpcClient(channel, tenantLookup, deadline);
     }
 }

--- a/inventory/src/main/resources/application.yml
+++ b/inventory/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
 grpc:
   server:
     port: 6565
+    deadline: 60000
 
   client:
     minion-gateway:

--- a/inventory/src/test/java/org/opennms/horizon/inventory/component/MinionRpcClientTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/component/MinionRpcClientTest.java
@@ -92,7 +92,7 @@ class MinionRpcClientTest {
             .addService(mockRequestService)
             .directExecutor().build().start());
         ManagedChannel channel = grpcCleanup.register(InProcessChannelBuilder.forName(MinionRpcClientTest.class.getName()).directExecutor().build());
-        client = new MinionRpcClient(channel, (ctx) -> Optional.ofNullable(GrpcConstants.TENANT_ID_CONTEXT_KEY.get()), 1000);
+        client = new MinionRpcClient(channel, (ctx) -> Optional.ofNullable(GrpcConstants.TENANT_ID_CONTEXT_KEY.get()), 5000);
         client.init();
     }
 

--- a/inventory/src/test/java/org/opennms/horizon/inventory/component/MinionRpcClientTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/component/MinionRpcClientTest.java
@@ -92,7 +92,7 @@ class MinionRpcClientTest {
             .addService(mockRequestService)
             .directExecutor().build().start());
         ManagedChannel channel = grpcCleanup.register(InProcessChannelBuilder.forName(MinionRpcClientTest.class.getName()).directExecutor().build());
-        client = new MinionRpcClient(channel, (ctx) -> Optional.ofNullable(GrpcConstants.TENANT_ID_CONTEXT_KEY.get()));
+        client = new MinionRpcClient(channel, (ctx) -> Optional.ofNullable(GrpcConstants.TENANT_ID_CONTEXT_KEY.get()), 1000);
         client.init();
     }
 

--- a/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/GrpcClientConstants.java
+++ b/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/GrpcClientConstants.java
@@ -41,4 +41,6 @@ public interface GrpcClientConstants {
     String CLIENT_CERTIFICATE_FILE_PATH = "client.cert.filepath";
     String CLIENT_PRIVATE_KEY_FILE_PATH = "client.private.key.filepath";
     String TRUST_CERTIFICATE_FILE_PATH = "trust.cert.filepath";
+    String GRPC_DEADLINE = "deadline";
+    long DEFAULT_GRPC_DEADLINE = 60000;
 }

--- a/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/GrpcClientConstants.java
+++ b/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/GrpcClientConstants.java
@@ -42,5 +42,5 @@ public interface GrpcClientConstants {
     String CLIENT_PRIVATE_KEY_FILE_PATH = "client.private.key.filepath";
     String TRUST_CERTIFICATE_FILE_PATH = "trust.cert.filepath";
     String GRPC_DEADLINE = "deadline";
-    long DEFAULT_GRPC_DEADLINE = 60000;
+    long DEFAULT_GRPC_DEADLINE = 6000000;
 }

--- a/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/GrpcClientConstants.java
+++ b/minion/minion-grpc/grpc-client/src/main/java/org/opennms/horizon/minion/grpc/GrpcClientConstants.java
@@ -32,7 +32,7 @@ public interface GrpcClientConstants {
 
     String GRPC_CLIENT_PID = "org.opennms.core.ipc.grpc.client";
     String GRPC_HOST = "host";
-    String DEFAULT_GRPC_HOST  = "localhost";
+    String DEFAULT_GRPC_HOST = "localhost";
     String GRPC_PORT = "port";
     int DEFAULT_GRPC_PORT = 8990;
     String TLS_ENABLED = "tls.enabled";
@@ -41,6 +41,4 @@ public interface GrpcClientConstants {
     String CLIENT_CERTIFICATE_FILE_PATH = "client.cert.filepath";
     String CLIENT_PRIVATE_KEY_FILE_PATH = "client.private.key.filepath";
     String TRUST_CERTIFICATE_FILE_PATH = "trust.cert.filepath";
-    String GRPC_DEADLINE = "deadline";
-    long DEFAULT_GRPC_DEADLINE = 6000000;
 }

--- a/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,6 +12,7 @@
         <cm:default-properties>
             <cm:property name="host" value="localhost"/>
             <cm:property name="port" value="8990"/>
+            <cm:property name="deadline" value="60000"/>
         </cm:default-properties>
     </cm:property-placeholder>
 

--- a/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,7 +12,7 @@
         <cm:default-properties>
             <cm:property name="host" value="localhost"/>
             <cm:property name="port" value="8990"/>
-            <cm:property name="deadline" value="60000"/>
+            <cm:property name="deadline" value="600000"/>
         </cm:default-properties>
     </cm:property-placeholder>
 

--- a/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/minion/minion-grpc/grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -12,7 +12,6 @@
         <cm:default-properties>
             <cm:property name="host" value="localhost"/>
             <cm:property name="port" value="8990"/>
-            <cm:property name="deadline" value="600000"/>
         </cm:default-properties>
     </cm:property-placeholder>
 

--- a/rest-server/src/main/java/org/opennms/horizon/server/config/ConfigurationUtil.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/config/ConfigurationUtil.java
@@ -53,6 +53,10 @@ public class ConfigurationUtil {
     @Value("${grpc.url.events}")
     private String eventsGrpcAddress;
 
+    @Value("${grpc.server.deadline:60000}")
+    private long deadline;
+
+
     @Bean
     public ServerHeaderUtil createHeaderUtil(JWTValidator validator) {
         return new ServerHeaderUtil(validator);
@@ -79,11 +83,11 @@ public class ConfigurationUtil {
 
     @Bean(destroyMethod = "shutdown", initMethod = "initialStubs")
     public InventoryClient createInventoryClient(@Qualifier("inventory") ManagedChannel channel) {
-        return new InventoryClient(channel);
+        return new InventoryClient(channel, deadline);
     }
 
     @Bean(destroyMethod = "shutdown", initMethod = "initialStubs")
     public EventsClient createEventsClient(@Qualifier("events") ManagedChannel channel) {
-        return new EventsClient(channel);
+        return new EventsClient(channel, deadline);
     }
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/EventsClient.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/EventsClient.java
@@ -1,6 +1,7 @@
 package org.opennms.horizon.server.service.grpc;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.opennms.horizon.events.proto.EventDTO;
 import org.opennms.horizon.events.proto.EventServiceGrpc;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EventsClient {
     private final ManagedChannel channel;
+    private final long deadline;
 
     private EventServiceGrpc.EventServiceBlockingStub eventsStub;
 
@@ -33,12 +35,12 @@ public class EventsClient {
     public List<EventDTO> listEvents(String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return eventsStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).listEvents(Empty.newBuilder().build()).getEventsList();
+        return eventsStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).listEvents(Empty.newBuilder().build()).getEventsList();
     }
 
     public List<EventDTO> getEventsByNodeId(long nodeId, String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return eventsStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).getEventsByNodeId(Int64Value.of(nodeId)).getEventsList();
+        return eventsStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getEventsByNodeId(Int64Value.of(nodeId)).getEventsList();
     }
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/InventoryClient.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/InventoryClient.java
@@ -30,6 +30,7 @@ package org.opennms.horizon.server.service.grpc;
 
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.opennms.horizon.inventory.dto.IdList;
@@ -55,6 +56,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InventoryClient {
     private final ManagedChannel channel;
+    private final long deadline;
     private MonitoringLocationServiceGrpc.MonitoringLocationServiceBlockingStub locationStub;
     private NodeServiceGrpc.NodeServiceBlockingStub nodeStub;
     private MonitoringSystemServiceGrpc.MonitoringSystemServiceBlockingStub systemStub;
@@ -74,43 +76,43 @@ public class InventoryClient {
     public NodeDTO createNewNode(NodeCreateDTO node, String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).createNode(node);
+        return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).createNode(node);
     }
 
     public List<NodeDTO> listNodes(String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).listNodes(Empty.newBuilder().build()).getNodesList();
+        return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).listNodes(Empty.newBuilder().build()).getNodesList();
     }
 
     public NodeDTO getNodeById(long id, String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).getNodeById(Int64Value.of(id));
+        return nodeStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getNodeById(Int64Value.of(id));
     }
 
     public List<MonitoringLocationDTO> listLocations(String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return locationStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).listLocations(Empty.newBuilder().build()).getLocationsList();
+        return locationStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).listLocations(Empty.newBuilder().build()).getLocationsList();
     }
 
     public MonitoringLocationDTO getLocationById(long id, String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return locationStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).getLocationById(Int64Value.of(id));
+        return locationStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getLocationById(Int64Value.of(id));
     }
 
     public List<MonitoringSystemDTO> listMonitoringSystems(String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return systemStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).listMonitoringSystem(Empty.newBuilder().build()).getSystemsList();
+        return systemStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).listMonitoringSystem(Empty.newBuilder().build()).getSystemsList();
     }
 
     public MonitoringSystemDTO getSystemBySystemId(String systemId, String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
-        return systemStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).getMonitoringSystemById(StringValue.of(systemId));
+        return systemStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getMonitoringSystemById(StringValue.of(systemId));
     }
 
     public List<MonitoringLocationDTO> listLocationsByIds(List<DataLoaderFactory.Key> keys) {
@@ -118,7 +120,7 @@ public class InventoryClient {
             Metadata metadata = new Metadata();
             metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
             List<Int64Value> idValues = keys.stream().map(k->Int64Value.of(k.getId())).collect(Collectors.toList());
-            return locationStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).listLocationsByIds(IdList.newBuilder().addAllIds(idValues).build()).getLocationsList();
+            return locationStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).listLocationsByIds(IdList.newBuilder().addAllIds(idValues).build()).getLocationsList();
         }).orElseThrow();
     }
 }

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -33,3 +33,5 @@ grpc:
   url:
     inventory: localhost:29065
     events: localhost:30065
+  server:
+    deadline: 60000

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientDeadlineTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientDeadlineTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.server.service.grpc;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opennms.horizon.inventory.dto.MonitoringLocationList;
+import org.opennms.horizon.inventory.dto.MonitoringLocationServiceGrpc;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+
+public class InventoryClientDeadlineTest {
+    @Rule
+    public static final GrpcCleanupRule grpcCleanUp = new GrpcCleanupRule();
+
+    private static InventoryClient client;
+    private static MockServerInterceptor mockInterceptor;
+    private static MonitoringLocationServiceGrpc.MonitoringLocationServiceImplBase mockLocationService;
+    private final String accessToken = "test-token";
+
+    @BeforeAll
+    public static void startGrpc() throws IOException {
+        mockInterceptor = new MockServerInterceptor();
+
+        mockLocationService = mock(MonitoringLocationServiceGrpc.MonitoringLocationServiceImplBase.class, delegatesTo(
+            new MonitoringLocationServiceGrpc.MonitoringLocationServiceImplBase() {
+                @Override
+                public void listLocations(Empty request, StreamObserver<MonitoringLocationList> responseObserver) {
+                    CompletableFuture.delayedExecutor(2000, TimeUnit.MILLISECONDS).execute(() -> {
+                        responseObserver.onNext(MonitoringLocationList.newBuilder().build());
+                        responseObserver.onCompleted();
+                    });
+                }
+            }
+        ));
+
+        grpcCleanUp.register(InProcessServerBuilder.forName("InventoryClientTest").intercept(mockInterceptor)
+            .addService(mockLocationService)
+            .directExecutor()
+            .build()
+            .start());
+        ManagedChannel channel = grpcCleanUp.register(InProcessChannelBuilder.forName("InventoryClientTest").directExecutor().build());
+        client = new InventoryClient(channel, 1000);
+        client.initialStubs();
+    }
+
+    @AfterEach
+    public void afterTest() {
+        verifyNoMoreInteractions(mockLocationService);
+        reset(mockLocationService);
+        mockInterceptor.reset();
+    }
+
+    @Test
+    public void testListLocation() {
+        String methodName = new Object() {
+        }.getClass().getEnclosingMethod().getName();
+        ArgumentCaptor<Empty> captor = ArgumentCaptor.forClass(Empty.class);
+        StatusRuntimeException thrown = assertThrows(
+            StatusRuntimeException.class,
+            () -> client.listLocations(accessToken + methodName),
+            "Expected listLocations() to throw, but it didn't"
+        );
+        assertThat(thrown.getStatus().getCode()).isEqualTo(Status.Code.DEADLINE_EXCEEDED);
+        verify(mockLocationService).listLocations(captor.capture(), any());
+        assertThat(captor.getValue()).isNotNull();
+        assertThat(mockInterceptor.getAuthHeader()).isEqualTo(accessToken + methodName);
+    }
+
+    private static class MockServerInterceptor implements ServerInterceptor {
+        private String authHeader;
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            authHeader = headers.get(GrpcConstants.AUTHORIZATION_METADATA_KEY);
+            return next.startCall(call, headers);
+        }
+
+        public String getAuthHeader() {
+            return authHeader;
+        }
+
+        public void reset() {
+            authHeader = null;
+        }
+    }
+
+}

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientDeadlineTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientDeadlineTest.java
@@ -89,12 +89,12 @@ public class InventoryClientDeadlineTest {
             }
         ));
 
-        grpcCleanUp.register(InProcessServerBuilder.forName("InventoryClientTest").intercept(mockInterceptor)
+        grpcCleanUp.register(InProcessServerBuilder.forName("InventoryClientDeadlineTest").intercept(mockInterceptor)
             .addService(mockLocationService)
             .directExecutor()
             .build()
             .start());
-        ManagedChannel channel = grpcCleanUp.register(InProcessChannelBuilder.forName("InventoryClientTest").directExecutor().build());
+        ManagedChannel channel = grpcCleanUp.register(InProcessChannelBuilder.forName("InventoryClientDeadlineTest").directExecutor().build());
         client = new InventoryClient(channel, 1000);
         client.initialStubs();
     }

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientTest.java
@@ -146,13 +146,12 @@ public class InventoryClientTest {
                 }
             }));
 
-
         grpcCleanUp.register(InProcessServerBuilder.forName("InventoryClientTest").intercept(mockInterceptor)
             .addService(mockLocationService)
             .addService(mockSystemService)
             .addService(mockNodeService).directExecutor().build().start());
         ManagedChannel channel = grpcCleanUp.register(InProcessChannelBuilder.forName("InventoryClientTest").directExecutor().build());
-        client = new InventoryClient(channel);
+        client = new InventoryClient(channel, 1000);
         client.initialStubs();
     }
 

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/grpc/InventoryClientTest.java
@@ -151,7 +151,7 @@ public class InventoryClientTest {
             .addService(mockSystemService)
             .addService(mockNodeService).directExecutor().build().start());
         ManagedChannel channel = grpcCleanUp.register(InProcessChannelBuilder.forName("InventoryClientTest").directExecutor().build());
-        client = new InventoryClient(channel, 1000);
+        client = new InventoryClient(channel, 5000);
         client.initialStubs();
     }
 


### PR DESCRIPTION
default value 60000 milliseconds

HS-775

## Description
Add a configurable deadline to all gRPC call, it's default value is 60 seconds. see [https://grpc.io/blog/deadlines/](url)

## Jira link(s)
- https://issues.opennms.org/browse/HS-775

## Flagged for review


## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
