### PR TITLE
External IT and Pipeline updates

### DIFF
--- a/.github/actions/alarm/action.yml
+++ b/.github/actions/alarm/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Dimage=opennms/horizon-stream-alarm:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       working-directory: ${{ inputs.dir-location }}
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Dimage=opennms/horizon-stream-alarm:local
+        mvn install jib:dockerBuild
 
       working-directory: ${{ inputs.dir-location }}
       shell: bash

--- a/.github/actions/datachoices/action.yml
+++ b/.github/actions/datachoices/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Dimage=opennms/horizon-stream-datachoices:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       working-directory: ${{ inputs.dir-location }}
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Dimage=opennms/horizon-stream-datachoices:local
+        mvn install jib:dockerBuild
 
       working-directory: ${{ inputs.dir-location }}
       shell: bash

--- a/.github/actions/events/action.yml
+++ b/.github/actions/events/action.yml
@@ -24,7 +24,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-events:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       shell: bash
@@ -38,7 +38,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-events:local
+        mvn install jib:dockerBuild
 
       shell: bash
       working-directory: events

--- a/.github/actions/external-it/action.yml
+++ b/.github/actions/external-it/action.yml
@@ -30,13 +30,17 @@ runs:
         # Cucumber test
         cd ${{ inputs.dir-location }}
 
+        ###--- kubectl --context kind-kind -n hs-instance port-forward --pod-running-timeout 1s services/ingress-nginx-controller 8123:80 &
+        kubectl logs -f --ignore-errors=true -l appdomain=opennms --max-log-requests 20 &
+
         mvn install
-        HORIZON_STREAM_BASE_URL=http://localhost:11080 
+        INGRESS_BASE_URL=https://onmshs
         KEYCLOAK_BASE_URL=https://onmshs/auth
         KEYCLOAK_REALM=opennms
         KEYCLOAK_USERNAME=admin
         KEYCLOAK_PASSWORD=admin
-        export HORIZON_STREAM_BASE_URL KEYCLOAK_BASE_URL KEYCLOAK_REALM KEYCLOAK_USERNAME KEYCLOAK_PASSWORD
+        KEYCLOAK_CLIENT_ID=horizon-stream
+        export INGRESS_BASE_URL KEYCLOAK_BASE_URL KEYCLOAK_REALM KEYCLOAK_USERNAME KEYCLOAK_PASSWORD KEYCLOAK_CLIENT_ID
         PROJECT_VERSION="$(mvn -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive -q org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)"
         java -jar "external-horizon-stream-it/target/external-horizon-stream-it-${PROJECT_VERSION}.jar"
 

--- a/.github/actions/inventory/action.yml
+++ b/.github/actions/inventory/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Dimage=opennms/horizon-stream-inventory:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       working-directory: ${{ inputs.dir-location }}
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Dimage=opennms/horizon-stream-inventory:local
+        mvn install jib:dockerBuild
 
       working-directory: ${{ inputs.dir-location }}
       shell: bash

--- a/.github/actions/metrics-processor/action.yml
+++ b/.github/actions/metrics-processor/action.yml
@@ -24,7 +24,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-metrics-processor:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       working-directory: metrics-processor
@@ -38,7 +38,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-metrics-processor:local
+        mvn install jib:dockerBuild
 
       working-directory: metrics-processor
       shell: bash

--- a/.github/actions/minion-gateway-grpc-proxy/action.yml
+++ b/.github/actions/minion-gateway-grpc-proxy/action.yml
@@ -29,7 +29,7 @@ runs:
 #      if: ${{ inputs.enable-sonar-scan == 'true' }}
 #      run: |
 #
-#        mvn -Pcoverage verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-minion-gateway-grpc-proxy:local \
+#        mvn -Pcoverage install jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-minion-gateway-grpc-proxy:local \
 #          org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 #
 #      shell: bash
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-minion-gateway-grpc-proxy:local
+        mvn install jib:dockerBuild
 
       working-directory: minion-gateway-grpc-proxy
       shell: bash

--- a/.github/actions/minion-gateway/action.yml
+++ b/.github/actions/minion-gateway/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-minion-gateway:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       shell: bash
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dimage=opennms/horizon-stream-minion-gateway:local
+        mvn install jib:dockerBuild
 
       working-directory: minion-gateway
       shell: bash

--- a/.github/actions/minion/action.yml
+++ b/.github/actions/minion/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify -Ddocker.image=opennms/horizon-stream-minion:local -Ddocker.skipPush=true \
+        mvn -Pcoverage install \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       shell: bash
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify -Ddocker.image=opennms/horizon-stream-minion:local -Ddocker.skipPush=true
+        mvn install
 
       working-directory: minion
       shell: bash

--- a/.github/actions/notifications/action.yml
+++ b/.github/actions/notifications/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Dimage=opennms/horizon-stream-notification:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       working-directory: ${{ inputs.dir-location }}
@@ -44,7 +44,7 @@ runs:
       run: |
 
         # Test and create the docker image.
-        mvn verify jib:dockerBuild -Dimage=opennms/horizon-stream-notification:local
+        mvn install jib:dockerBuild
 
       working-directory: ${{ inputs.dir-location }}
       shell: bash

--- a/.github/actions/rest-server/action.yml
+++ b/.github/actions/rest-server/action.yml
@@ -29,7 +29,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'true' }}
       run: |
 
-        mvn -Pcoverage verify jib:dockerBuild -Dimage=opennms/horizon-stream-rest-server:local \
+        mvn -Pcoverage install jib:dockerBuild \
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=$SONAR_PROJECT_KEY
 
       working-directory: ${{ inputs.dir-location }}
@@ -43,7 +43,7 @@ runs:
       if: ${{ inputs.enable-sonar-scan == 'false' }}
       run: |
 
-        mvn verify jib:dockerBuild -Dimage=opennms/horizon-stream-rest-server:local
+        mvn install jib:dockerBuild
 
       working-directory: ${{ inputs.dir-location }}
       shell: bash

--- a/alarm/src/test/java/org/opennms/horizon/alarmservice/testcontainers/TestContainerRunnerClassRule.java
+++ b/alarm/src/test/java/org/opennms/horizon/alarmservice/testcontainers/TestContainerRunnerClassRule.java
@@ -52,7 +52,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
     private String confluentPlatformVersion = "7.3.0";
 
     private KafkaContainer kafkaContainer;
-    private GenericContainer zookeeperContainer;
     private GenericContainer applicationContainer;
     private PostgreSQLContainer postgreSQLContainer;
 
@@ -60,7 +59,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
 
     public TestContainerRunnerClassRule() {
         kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka").withTag(confluentPlatformVersion));
-        zookeeperContainer = new GenericContainer(DockerImageName.parse("confluentinc/cp-zookeeper").withTag(confluentPlatformVersion));
         applicationContainer = new GenericContainer(DockerImageName.parse("opennms/horizon-stream-alarm").withTag("local").toString());
         postgreSQLContainer = new PostgreSQLContainer(DockerImageName.parse("postgres").withTag("14.5-alpine").toString());
     }
@@ -73,7 +71,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
 
         LOG.info("USING TEST DOCKER NETWORK {}", network.getId());
 
-        startZookeeperContainer();
         startKafkaContainer();
         startPostgresContainer();
         startApplicationContainer();
@@ -84,23 +81,11 @@ public class TestContainerRunnerClassRule extends ExternalResource {
         applicationContainer.stop();
         postgreSQLContainer.stop();
         kafkaContainer.stop();
-        zookeeperContainer.stop();
     }
 
 //========================================
 // Container Startups
 //----------------------------------------
-
-    private void startZookeeperContainer() {
-
-        zookeeperContainer
-            .withNetwork(network)
-            .withNetworkAliases("zookeeper")
-            .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(KafkaContainer.ZOOKEEPER_PORT))
-            .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("ZOOKEEPER"))
-        ;
-
-    }
 
     private void startPostgresContainer() {
 
@@ -118,8 +103,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
             .withEmbeddedZookeeper()
             .withNetwork(network)
             .withNetworkAliases("kafka", "kafka-host")
-            .dependsOn(zookeeperContainer)
-            .withExternalZookeeper("zookeeper:" + KafkaContainer.ZOOKEEPER_PORT)
             .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("KAFKA"))
             .start();
         ;
@@ -133,9 +116,9 @@ public class TestContainerRunnerClassRule extends ExternalResource {
         applicationContainer
             .withNetwork(network)
             .withNetworkAliases("application", "application-host")
-            .dependsOn(zookeeperContainer, kafkaContainer, postgreSQLContainer)
+            .dependsOn(kafkaContainer, postgreSQLContainer)
             .withExposedPorts(8080, 5005)
-            .withStartupTimeout(Duration.ofMinutes(5))
+            .withStartupTimeout(Duration.ofMinutes(2))
             .withEnv("JAVA_TOOL_OPTIONS", "-Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005")
             .withEnv("SPRING_KAFKA_BOOTSTRAP_SERVERS", "kafka-host:9092")
             .withEnv("SPRING_DATASOURCE_URL", "jdbc:postgresql://postgres:5432/" + postgreSQLContainer.getDatabaseName())
@@ -143,7 +126,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
             .withEnv("SPRING_DATASOURCE_PASSWORD", postgreSQLContainer.getPassword())
             .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("APPLICATION"))
             .waitingFor(Wait.forLogMessage(".*Started AlarmServiceMain.*", 1)
-            .withStartupTimeout(Duration.ofSeconds(45))
         );
             ;
 

--- a/charts/opennms/templates/opennms/alarm/alarm-deployment.yaml
+++ b/charts/opennms/templates/opennms/alarm/alarm-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Alarm.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.API.ServiceName }}
     spec:
       {{ if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.DataChoices.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Events.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Inventory.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         run: {{ .Values.OpenNMS.MetricsProcessor.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}
         ignite-cluster: core
     spec:

--- a/charts/opennms/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Minion.ServiceName }}
       annotations:
         linkerd.io/inject: enabled

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.MinionGateway.ServiceName }}
         ignite-cluster: core
     spec:

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Notification.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/ui/ui-deployment.yaml
+++ b/charts/opennms/templates/opennms/ui/ui-deployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.UI.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>datachoices</artifactId>
     <name>OpenNMS Horizon :: DataChoices</name>
     <description>datachoices</description>
+    <properties>
+        <docker.image.name>opennms/horizon-stream-datachoices</docker.image.name>
+        <docker.image.tag>local</docker.image.tag>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -263,6 +267,11 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>${jib.version}</version>
+                <configuration>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -14,6 +14,10 @@
     <name>OpenNMS Horizon Stream :: Events :: Main</name>
     <version>0.1.0-SNAPSHOT</version>
     <description>Events Service</description>
+    <properties>
+        <docker.image.name>opennms/horizon-stream-events</docker.image.name>
+        <docker.image.tag>local</docker.image.tag>
+    </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -132,9 +136,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib.version}</version>
                 <configuration>
                     <!-- override skip=false from minion-gateway parent so jib executes here -->
                     <skip>false</skip>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
                 </configuration>
             </plugin>
         </plugins>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -61,6 +61,9 @@
                          This disables jib by default, which allows you to run jib goals on this parent pom without
                          specifying a submodule. Set skip=false on submodules that need jib. -->
                     <skip>true</skip>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
                 </configuration>
             </plugin>
         </plugins>

--- a/external-it/external-horizon-stream-it/README.md
+++ b/external-it/external-horizon-stream-it/README.md
@@ -5,11 +5,12 @@
     * Keycloak user "user001", password "passw0rd", in realm "opennms"
 
     $ mvn clean install
-    $ HORIZON_STREAM_BASE_URL=http://localhost:8080
-    $ KEYCLOAK_BASE_URL=http://localhost:9000
+    $ INGRESS_BASE_URL=http://localhost:8123
+    $ KEYCLOAK_BASE_URL=http://localhost:8123/auth
     $ KEYCLOAK_REALM=opennms
     $ KEYCLOAK_USERNAME=user001
     $ KEYCLOAK_PASSWORD=passw0rd
+    $ KEYCLOAK_CLIENT_ID=horizon-stream
     $ export HORIZON_STREAM_BASE_URL KEYCLOAK_BASE_URL KEYCLOAK_REALM KEYCLOAK_USERNAME KEYCLOAK_PASSWORD
     $ PROJECT_VERSION="$(mvn -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive -q org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)"
     $ java -jar "external-horizon-stream-it/target/external-horizon-stream-it-${PROJECT_VERSION}.jar"

--- a/external-it/external-horizon-stream-it/pom.xml
+++ b/external-it/external-horizon-stream-it/pom.xml
@@ -107,9 +107,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
+            <version>4.1.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/GQLQueryConstants.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/GQLQueryConstants.java
@@ -1,0 +1,12 @@
+package org.opennms.horizon.it;
+
+public abstract class GQLQueryConstants {
+    public static final String LIST_MINIONS_QUERY = "{ \"query\": \"{ findAllMinions {id, systemId, systemId, location { location } } }\" }";
+
+    public static final String GET_LABELED_METRICS_QUERY =
+        "query { metric(name:\"%s\", labels: {%s:\"%s\"}) { status, data { result { metric, value }}} }";
+
+    public static final String LIST_MINION_INSTANCE_ECHO_METRICS_QUERY =
+        "query { metric(name:\"response_time_msec\", labels: {monitor:\"ECHO\", instance:\"%s\"}) { status, data { result { metric }}} }";
+
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/HorizonStreamTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/HorizonStreamTestSteps.java
@@ -1,172 +1,54 @@
 package org.opennms.horizon.it;
 
 import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.restassured.RestAssured;
-import io.restassured.config.HttpClientConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.config.SSLConfig;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
-import org.hamcrest.Matchers;
 
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.KeycloakBuilder;
-import org.keycloak.representations.AccessTokenResponse;
-import org.opennms.horizon.utils.TestTrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
-import javax.ws.rs.core.HttpHeaders;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
-
-import static com.jayway.awaitility.Awaitility.await;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-
-import static io.restassured.RestAssured.given;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.keycloak.OAuth2Constants.PASSWORD;
-
 public class HorizonStreamTestSteps {
-
-    public static final int DEFAULT_HTTP_SOCKET_TIMEOUT = 15_000;
 
     private static final Logger log = LoggerFactory.getLogger(HorizonStreamTestSteps.class);
 
-    private String horizonStreamBaseUrl;
-    private String keycloakBaseUrl;
-    private String keycloakRealm;
-    private String keycloakUsername;
-    private String keycloakPassword;
+    private final KeycloakTestSteps keycloakTestSteps;
+    private final InventoryTestSteps inventoryTestSteps;
+    private final MetricsTestSteps metricsTestSteps;
 
-    private Keycloak keycloakClient;
-    private Response restResponse;
-    private String keycloakToken;
+    private String ingressBaseUrl;
+
+//========================================
+// Constructor
+//----------------------------------------
+
+    public HorizonStreamTestSteps(KeycloakTestSteps keycloakTestSteps, InventoryTestSteps inventoryTestSteps, MetricsTestSteps metricsTestSteps) {
+        this.keycloakTestSteps = keycloakTestSteps;
+        this.inventoryTestSteps = inventoryTestSteps;
+        this.metricsTestSteps = metricsTestSteps;
+
+        this.inventoryTestSteps.setUserAccessTokenSupplier(this.keycloakTestSteps::getKeycloakAccessToken);
+        this.inventoryTestSteps.setIngressUrlSupplier(this::getIngressBaseUrl);
+
+        this.metricsTestSteps.setUserAccessTokenSupplier(this.keycloakTestSteps::getKeycloakAccessToken);
+        this.metricsTestSteps.setIngressUrlSupplier(this::getIngressBaseUrl);
+        this.metricsTestSteps.setMinionsAtLocationSupplier(this.inventoryTestSteps::getMinionsAtLocation);
+    }
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public String getIngressBaseUrl() {
+        return ingressBaseUrl;
+    }
+
 
 //========================================
 // Test Step Definitions
 //----------------------------------------
 
-    @Given("horizon stream server base url in environment variable {string}")
+    @Given("Ingress base url in environment variable {string}")
     public void horizonStreamServerBaseUrlInEnvironmentVariable(String variableName) {
-        horizonStreamBaseUrl = System.getenv(variableName);
+        ingressBaseUrl = System.getenv(variableName);
 
-        log.info("HORIZON STREAM BASE URL: {}", horizonStreamBaseUrl);
-    }
-
-    @Given("Keycloak server base url in environment variable {string}")
-    public void keycloakServerBaseUrlInEnvironmentVariable(String variableName) {
-        keycloakBaseUrl = System.getenv(variableName);
-
-        log.info("KEYCLOAK BASE URL: {}", keycloakBaseUrl);
-    }
-
-    @Given("Keycloak realm in environment variable {string}")
-    public void keycloakRealmInEnvironmentVariable(String variableName) {
-        keycloakRealm = System.getenv(variableName);
-
-        log.info("KEYCLOAK REALM: {}", keycloakRealm);
-    }
-
-    @Given("Keycloak username in environment variable {string}")
-    public void keycloakUsernameInEnvironmentVariable(String variableName) {
-        keycloakUsername = System.getenv(variableName);
-
-        log.info("KEYCLOAK USERNAME: {}", keycloakUsername);
-    }
-
-    @Given("Keycloak password in environment variable {string}")
-    public void keycloakPasswordInEnvironmentVariable(String variableName) {
-        keycloakPassword = System.getenv(variableName);
-    }
-
-    @Then("Say {string}")
-    public void say(String text) {
-        log.info("{}", text);
-    }
-
-    @Then("login to Keycloak")
-    public void loginToKeycloak() throws NoSuchAlgorithmException, KeyManagementException {
-        ResteasyClientBuilder restClientBuilder = new ResteasyClientBuilder();
-        restClientBuilder.disableTrustManager();
-        SSLContext sslContext = SSLContext.getInstance("SSL");
-        sslContext.init(null, new TestTrustManager[]{new TestTrustManager()}, new SecureRandom());
-        restClientBuilder.sslContext(sslContext);
-
-        keycloakClient =
-                KeycloakBuilder.builder()
-                    .serverUrl(keycloakBaseUrl)
-                    .grantType(PASSWORD)
-                    .realm(keycloakRealm)
-                    .username(keycloakUsername)
-                    .password(keycloakPassword)
-                    .clientId("admin-cli")// TBD
-                    .resteasyClient(restClientBuilder.build())
-                    .build()
-        ;
-
-        AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
-        keycloakToken = accessTokenResponse.getToken();
-
-        assertNotNull(keycloakToken);
-    }
-
-    @Then("send GET request to horizon-stream at path {string}")
-    public void sendGETRequestToHorizonStreamAtPath(String path) throws MalformedURLException {
-        URL requestUrl = new URL(new URL(horizonStreamBaseUrl), path);
-
-        RestAssuredConfig restAssuredConfig = createRestAssuredTestConfig();
-
-        RequestSpecification requestSpecification =
-                RestAssured
-                    .given()
-                    .config(restAssuredConfig)
-                    ;
-
-        if (keycloakToken != null) {
-            requestSpecification.header(HttpHeaders.AUTHORIZATION, "Bearer " + keycloakToken);
-        }
-
-        restResponse =
-                requestSpecification
-                        .get(requestUrl)
-                        .thenReturn()
-        ;
-    }
-
-    @Then("verify HTTP response code = {int}")
-    public void verifyHTTPResponseCode(int expectedResponseCode) {
-        // Wait till Minion is registered to Horizon Core
-        await().atMost(180, TimeUnit.SECONDS).pollDelay(0, TimeUnit.SECONDS)
-            .pollInterval(5, TimeUnit.SECONDS)
-            .until(()-> restResponse.getStatusCode(), Matchers.is(expectedResponseCode));
-    }
-
-    @Then("verify response has Minion location = {string}")
-    public void verifyMinionResponse(String location) {
-        // Wait till Minion is registered to Horizon Core
-        await().atMost(180, TimeUnit.SECONDS).pollDelay(0, TimeUnit.SECONDS)
-            .pollInterval(5, TimeUnit.SECONDS)
-            .until(()-> restResponse.getBody().print(), Matchers.containsString(location));
-    }
-
-//========================================
-// Internals
-//----------------------------------------
-
-    private RestAssuredConfig createRestAssuredTestConfig() {
-        return RestAssuredConfig.config()
-            .sslConfig(SSLConfig.sslConfig().relaxedHTTPSValidation("SSL"))
-                .httpClient(HttpClientConfig.httpClientConfig()
-                        .setParam("http.connection.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
-                        .setParam("http.socket.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
-                );
+        log.info("INGRESS BASE URL: {}", ingressBaseUrl);
     }
 }

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
@@ -1,0 +1,194 @@
+package org.opennms.horizon.it;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.config.SSLConfig;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HTTP;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.opennms.horizon.it.gqlmodels.querywrappers.FindAllMinionsQueryResult;
+import org.opennms.horizon.it.gqlmodels.MinionData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InventoryTestSteps {
+
+    public static final int DEFAULT_HTTP_SOCKET_TIMEOUT = 15_000;
+
+    private static final Logger LOG = LoggerFactory.getLogger(InventoryTestSteps.class);
+
+    // Operations to access data from other TestSteps
+    private Supplier<String> userAccessTokenSupplier;
+    private Supplier<String> ingressUrlSupplier;
+
+    // Runtime Data
+    private String minionLocation;
+    private FindAllMinionsQueryResult findAllMinionsQueryResult;
+    private List<MinionData> minionsAtLocation;
+    private String lastMinionQueryResultBody;
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public Supplier<String> getUserAccessTokenSupplier() {
+        return userAccessTokenSupplier;
+    }
+
+    public void setUserAccessTokenSupplier(Supplier<String> userAccessTokenSupplier) {
+        this.userAccessTokenSupplier = userAccessTokenSupplier;
+    }
+
+    public Supplier<String> getIngressUrlSupplier() {
+        return ingressUrlSupplier;
+    }
+
+    public void setIngressUrlSupplier(Supplier<String> ingressUrlSupplier) {
+        this.ingressUrlSupplier = ingressUrlSupplier;
+    }
+
+    public List<MinionData> getMinionsAtLocation() {
+        return minionsAtLocation;
+    }
+
+//========================================
+// Test Step Definitions
+//----------------------------------------
+
+    @Given("At least one Minion is running with location {string}")
+    public void atLeastOneMinionIsRunningWithLocation(String location) {
+        minionLocation = location;
+    }
+
+
+    @Then("Wait for at least one minion for the given location reported by inventory with timeout {int}ms")
+    public void waitForAtLeastOneMinionForTheGivenLocationReportedByInventoryWithTimeoutMs(int timeout) {
+        try {
+            Awaitility
+                .await()
+                .atMost(timeout, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .until(this::checkAtLeastOneMinionAtGivenLocation)
+                ;
+        } finally {
+            LOG.info("LAST CHECK MINION RESPONSE BODY: {}", lastMinionQueryResultBody);
+        }
+    }
+
+    /** @noinspection rawtypes*/
+    @Then("Read the list of connected Minions from the BFF")
+    public void readTheListOfConnectedMinionsFromInventory() throws MalformedURLException {
+        findAllMinionsQueryResult = commonQueryMinions();
+    }
+
+    @Then("Find the minions running in the given location")
+    public void findTheMinionsRunningInTheGivenLocation() {
+        minionsAtLocation = commonFilterMinionsAtLocation(findAllMinionsQueryResult);
+    }
+
+    @Then("Verify at least one minion was found for the location")
+    public void verifyAtLeastOneMinionWasFoundForTheLocation() {
+        assertTrue(minionsAtLocation.size() > 0);
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private RestAssuredConfig createRestAssuredTestConfig() {
+        return RestAssuredConfig.config()
+            .sslConfig(SSLConfig.sslConfig().relaxedHTTPSValidation("SSL"))
+            .httpClient(HttpClientConfig.httpClientConfig()
+                .setParam("http.connection.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+                .setParam("http.socket.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+            );
+    }
+
+    private URL formatIngressUrl(String path) throws MalformedURLException {
+        String baseUrl = ingressUrlSupplier.get();
+
+        return new URL(new URL(baseUrl), path);
+    }
+
+    private String formatAuthorizationHeader(String token) {
+        return "Bearer " + token;
+    }
+
+    private Response executePost(URL url, String accessToken, Object body) {
+        RestAssuredConfig restAssuredConfig = createRestAssuredTestConfig();
+
+        RequestSpecification requestSpecification =
+            RestAssured
+                .given()
+                .config(restAssuredConfig)
+            ;
+
+        Response restAssuredResponse =
+            requestSpecification
+                .header(HttpHeaders.AUTHORIZATION, formatAuthorizationHeader(accessToken))
+                .header(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .body(body)
+                .post(url)
+                .thenReturn()
+            ;
+
+        return restAssuredResponse;
+    }
+
+    private boolean checkAtLeastOneMinionAtGivenLocation() throws MalformedURLException {
+        FindAllMinionsQueryResult findAllMinionsQueryResult = commonQueryMinions();
+        List<MinionData> filtered = commonFilterMinionsAtLocation(findAllMinionsQueryResult);
+
+        LOG.debug("MINIONS for location: count={}; location={}", filtered.size(), minionLocation);
+
+        return ( ! filtered.isEmpty() );
+    }
+
+    /** @noinspection rawtypes*/
+    private FindAllMinionsQueryResult commonQueryMinions() throws MalformedURLException {
+        String accessToken = userAccessTokenSupplier.get();
+
+        URL url = formatIngressUrl("/api/graphql");
+
+        Response restAssuredResponse = executePost(url, accessToken, GQLQueryConstants.LIST_MINIONS_QUERY);
+
+        lastMinionQueryResultBody = restAssuredResponse.getBody().asString();
+
+        Assert.assertEquals(200, restAssuredResponse.getStatusCode());
+
+        return restAssuredResponse.getBody().as(FindAllMinionsQueryResult.class);
+    }
+
+    private List<MinionData> commonFilterMinionsAtLocation(FindAllMinionsQueryResult findAllMinionsQueryResult) {
+        List<MinionData> minionData = findAllMinionsQueryResult.getData().getFindAllMinions();
+
+        List<MinionData> minionsAtLocation =
+            minionData.stream()
+                .filter((md) -> Objects.equals(md.getLocation().getLocation(), minionLocation))
+                .collect(Collectors.toList())
+        ;
+
+        LOG.debug("MINIONS for location: count={}; location={}", minionsAtLocation.size(), minionLocation);
+
+        return minionsAtLocation;
+    }
+
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/KeycloakTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/KeycloakTestSteps.java
@@ -1,0 +1,122 @@
+package org.opennms.horizon.it;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.restassured.response.Response;
+import org.awaitility.Awaitility;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.AccessTokenResponse;
+import org.opennms.horizon.utils.TestTrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
+public class KeycloakTestSteps {
+
+    private static final Logger log = LoggerFactory.getLogger(KeycloakTestSteps.class);
+
+    private String keycloakBaseUrl;
+    private String keycloakRealm;
+    private String keycloakUsername;
+    private String keycloakPassword;
+    private String keycloakClientId;
+
+    private Keycloak keycloakClient;
+    private Response restResponse;
+    private String keycloakAccessToken;
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public String getKeycloakAccessToken() {
+        return keycloakAccessToken;
+    }
+
+
+//========================================
+// Test Step Definitions
+//----------------------------------------
+
+    @Given("Keycloak server base url in environment variable {string}")
+    public void keycloakServerBaseUrlInEnvironmentVariable(String variableName) {
+        keycloakBaseUrl = System.getenv(variableName);
+
+        log.info("KEYCLOAK BASE URL: {}", keycloakBaseUrl);
+    }
+
+    @Given("Keycloak realm in environment variable {string}")
+    public void keycloakRealmInEnvironmentVariable(String variableName) {
+        keycloakRealm = System.getenv(variableName);
+
+        log.info("KEYCLOAK REALM: {}", keycloakRealm);
+    }
+
+    @Given("Keycloak username in environment variable {string}")
+    public void keycloakUsernameInEnvironmentVariable(String variableName) {
+        keycloakUsername = System.getenv(variableName);
+
+        log.info("KEYCLOAK USERNAME: {}", keycloakUsername);
+    }
+
+    @Given("Keycloak password in environment variable {string}")
+    public void keycloakPasswordInEnvironmentVariable(String variableName) {
+        keycloakPassword = System.getenv(variableName);
+    }
+
+    @Given("Keycloak client-id in environment variable {string}")
+    public void keycloakClientIdInEnvironmentVariable(String variableName) {
+        keycloakClientId = System.getenv(variableName);
+    }
+
+    @Then("login to Keycloak with timeout {int}ms")
+    public void loginToKeycloak(long timeout) {
+        Awaitility
+            .await()
+            .timeout(timeout, TimeUnit.MILLISECONDS)
+            .ignoreExceptions()
+            .until(this::commonLoginToKeycloak)
+            ;
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private boolean commonLoginToKeycloak() throws NoSuchAlgorithmException, KeyManagementException {
+        ResteasyClientBuilder restClientBuilder = new ResteasyClientBuilder();
+        restClientBuilder.disableTrustManager();
+        SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(null, new TestTrustManager[]{new TestTrustManager()}, new SecureRandom());
+        restClientBuilder.sslContext(sslContext);
+
+        keycloakClient =
+            KeycloakBuilder.builder()
+                .serverUrl(keycloakBaseUrl)
+                .grantType(PASSWORD)
+                .realm(keycloakRealm)
+                .username(keycloakUsername)
+                .password(keycloakPassword)
+                .clientId(keycloakClientId)
+                .resteasyClient(restClientBuilder.build())
+                .build()
+        ;
+
+        AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
+        keycloakAccessToken = accessTokenResponse.getToken();
+
+        assertNotNull(keycloakAccessToken);
+
+        return true;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/MetricsTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/MetricsTestSteps.java
@@ -1,0 +1,184 @@
+package org.opennms.horizon.it;
+
+import io.cucumber.java.en.Then;
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.config.SSLConfig;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HTTP;
+import org.awaitility.Awaitility;
+import org.opennms.horizon.it.gqlmodels.GQLQuery;
+import org.opennms.horizon.it.gqlmodels.MinionData;
+import org.opennms.horizon.it.gqlmodels.querywrappers.MetricQueryResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetricsTestSteps {
+
+    public static final int DEFAULT_HTTP_SOCKET_TIMEOUT = 15_000;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsTestSteps.class);
+
+    // Operations to access data from other TestSteps
+    private Supplier<String> userAccessTokenSupplier;
+    private Supplier<String> ingressUrlSupplier;
+    private Supplier<List<MinionData>> minionsAtLocationSupplier;
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public Supplier<String> getUserAccessTokenSupplier() {
+        return userAccessTokenSupplier;
+    }
+
+    public void setUserAccessTokenSupplier(Supplier<String> userAccessTokenSupplier) {
+        this.userAccessTokenSupplier = userAccessTokenSupplier;
+    }
+
+    public Supplier<List<MinionData>> getMinionsAtLocationSupplier() {
+        return minionsAtLocationSupplier;
+    }
+
+    public void setMinionsAtLocationSupplier(Supplier<List<MinionData>> minionsAtLocationSupplier) {
+        this.minionsAtLocationSupplier = minionsAtLocationSupplier;
+    }
+
+    public Supplier<String> getIngressUrlSupplier() {
+        return ingressUrlSupplier;
+    }
+
+    public void setIngressUrlSupplier(Supplier<String> ingressUrlSupplier) {
+        this.ingressUrlSupplier = ingressUrlSupplier;
+    }
+
+//========================================
+// Test Step Definitions
+//----------------------------------------
+
+    @Then("Read the {string} from Prometheus with label {string} set to the Minion System ID for each Minion found with timeout {int}ms")
+    public void readTheFromPrometheusWithLabelSetToTheMinionSystemID(String metricName, String labelName, long timeout) throws MalformedURLException {
+        Awaitility
+            .await()
+            .ignoreExceptions()
+            .atMost(timeout, TimeUnit.MILLISECONDS)
+            .until(() -> this.commonCheckMinionMetrics(metricName, labelName))
+            ;
+
+        // List<Pair<MinionData, MetricQueryResult>> results = commonQueryMetrics(metricName, labelName);
+        // for (MinionData oneMinion : minionsAtLocation) {
+        //     MetricQueryResult metricQueryResult = restAssuredResponse.getBody().as(MetricQueryResult.class);
+        //
+        //     LOG.info("METRIC FOR MINION: metric-name={}; monitor={}; value={}",
+        //         metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("__name__"),
+        //         metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("monitor"),
+        //         metricQueryResult.getData().getMetric().getData().getResult().get(0).getValue().get(0)
+        //     );
+        //
+        //     assertEquals(1, metricQueryResult.getData().getMetric().getData().getResult().size());
+        //     assertEquals("response_time_msec", metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("__name__"));
+        // }
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private RestAssuredConfig createRestAssuredTestConfig() {
+        return RestAssuredConfig.config()
+            .sslConfig(SSLConfig.sslConfig().relaxedHTTPSValidation("SSL"))
+            .httpClient(HttpClientConfig.httpClientConfig()
+                .setParam("http.connection.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+                .setParam("http.socket.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+            );
+    }
+
+    private URL formatIngressUrl(String path) throws MalformedURLException {
+        String baseUrl = ingressUrlSupplier.get();
+
+        return new URL(new URL(baseUrl), path);
+    }
+
+    private String formatAuthorizationHeader(String token) {
+        return "Bearer " + token;
+    }
+
+    private Response executePost(URL url, String accessToken, Object body) {
+        RestAssuredConfig restAssuredConfig = createRestAssuredTestConfig();
+
+        RequestSpecification requestSpecification =
+            RestAssured
+                .given()
+                .config(restAssuredConfig)
+            ;
+
+        Response restAssuredResponse =
+            requestSpecification
+                .header(HttpHeaders.AUTHORIZATION, formatAuthorizationHeader(accessToken))
+                .header(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .body(body)
+                .post(url)
+                .thenReturn()
+            ;
+
+        return restAssuredResponse;
+    }
+
+    private List<Pair<MinionData, MetricQueryResult>> commonQueryMetrics(String metricName, String labelName) throws MalformedURLException {
+        String accessToken = userAccessTokenSupplier.get();
+
+        URL url = formatIngressUrl("/api/graphql");
+
+        List<MinionData> minionsAtLocation = minionsAtLocationSupplier.get();
+        List<Pair<MinionData, MetricQueryResult>> results = new LinkedList<>();
+        for (MinionData oneMinion : minionsAtLocation) {
+            String query =
+                String.format(GQLQueryConstants.GET_LABELED_METRICS_QUERY, metricName, labelName, oneMinion.getSystemId());
+
+            GQLQuery gqlQuery = new GQLQuery();
+            gqlQuery.setQuery(query);
+
+            Response restAssuredResponse = executePost(url, accessToken, gqlQuery);
+
+            assertEquals(200, restAssuredResponse.getStatusCode());
+
+            MetricQueryResult metricQueryResult = restAssuredResponse.getBody().as(MetricQueryResult.class);
+
+            results.add(Pair.of(oneMinion, metricQueryResult));
+        }
+
+        return results;
+    }
+
+    private boolean commonCheckMinionMetrics(String metricName, String labelName) throws MalformedURLException {
+        List<Pair<MinionData, MetricQueryResult>> minionMetrics = commonQueryMetrics(metricName, labelName);
+        for (Pair<MinionData, MetricQueryResult> oneMinionMetric : minionMetrics) {
+            MetricQueryResult metricQueryResult = oneMinionMetric.getRight();
+
+            LOG.info("METRIC FOR MINION: metric-name={}; monitor={}; value={}",
+                metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("__name__"),
+                metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("monitor"),
+                metricQueryResult.getData().getMetric().getData().getResult().get(0).getValue().get(0)
+            );
+
+            assertEquals(1, metricQueryResult.getData().getMetric().getData().getResult().size());
+            assertEquals("response_time_msec", metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("__name__"));
+        }
+
+        return true;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/GQLQuery.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/GQLQuery.java
@@ -1,0 +1,31 @@
+package org.opennms.horizon.it.gqlmodels;
+
+public class GQLQuery {
+    private String query;
+    private String variables;
+    private String operationName;
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getVariables() {
+        return variables;
+    }
+
+    public void setVariables(String variables) {
+        this.variables = variables;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/LocationData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/LocationData.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.it.gqlmodels;
+
+public class LocationData {
+    private String location;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MetricIdentityData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MetricIdentityData.java
@@ -1,0 +1,22 @@
+package org.opennms.horizon.it.gqlmodels;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MetricIdentityData {
+    private String __name__;
+    private String instance;
+    private String location;
+    private String monitor;
+
+    @JsonProperty("node_id")
+    private String nodeId;
+
+    @JsonProperty("pushgateway_instance")
+    private String pushgatewayInstance;
+
+    @JsonProperty("system_id")
+    private String systemId;
+
+    @JsonProperty("tenant_id")
+    private String tenantId;
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MinionData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MinionData.java
@@ -1,0 +1,31 @@
+package org.opennms.horizon.it.gqlmodels;
+
+public class MinionData {
+    private long id;
+    private String systemId;
+    private LocationData location;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public void setSystemId(String systemId) {
+        this.systemId = systemId;
+    }
+
+    public LocationData getLocation() {
+        return location;
+    }
+
+    public void setLocation(LocationData location) {
+        this.location = location;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsData.java
@@ -1,0 +1,17 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+import org.opennms.horizon.it.gqlmodels.MinionData;
+
+import java.util.List;
+
+public class FindAllMinionsData {
+    private List<MinionData> findAllMinions;
+
+    public List<MinionData> getFindAllMinions() {
+        return findAllMinions;
+    }
+
+    public void setFindAllMinions(List<MinionData> findAllMinions) {
+        this.findAllMinions = findAllMinions;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsQueryResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsQueryResult.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+public class FindAllMinionsQueryResult {
+    private FindAllMinionsData data;
+
+    public FindAllMinionsData getData() {
+        return data;
+    }
+
+    public void setData(FindAllMinionsData data) {
+        this.data = data;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryData.java
@@ -1,0 +1,15 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+import org.opennms.horizon.it.gqlmodels.tsdata.TimeSeriesQueryResult;
+
+public class MetricQueryData {
+    private TimeSeriesQueryResult metric;
+
+    public TimeSeriesQueryResult getMetric() {
+        return metric;
+    }
+
+    public void setMetric(TimeSeriesQueryResult metric) {
+        this.metric = metric;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryResult.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+public class MetricQueryResult {
+    private MetricQueryData data;
+
+    public MetricQueryData getData() {
+        return data;
+    }
+
+    public void setData(MetricQueryData data) {
+        this.data = data;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSData.java
@@ -1,0 +1,24 @@
+package org.opennms.horizon.it.gqlmodels.tsdata;
+
+import java.util.List;
+
+public class TSData {
+    private String resultType;
+    private List<TSResult> result;
+
+    public String getResultType() {
+        return resultType;
+    }
+
+    public void setResultType(String resultType) {
+        this.resultType = resultType;
+    }
+
+    public List<TSResult> getResult() {
+        return result;
+    }
+
+    public void setResult(List<TSResult> result) {
+        this.result = result;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSResult.java
@@ -1,0 +1,34 @@
+package org.opennms.horizon.it.gqlmodels.tsdata;
+
+import java.util.List;
+import java.util.Map;
+
+public class TSResult {
+    private Map<String, String> metric;
+    private List<Double> value;
+    private List<List<Double>> values;
+
+    public Map<String, String> getMetric() {
+        return metric;
+    }
+
+    public void setMetric(Map<String, String> metric) {
+        this.metric = metric;
+    }
+
+    public List<Double> getValue() {
+        return value;
+    }
+
+    public void setValue(List<Double> value) {
+        this.value = value;
+    }
+
+    public List<List<Double>> getValues() {
+        return values;
+    }
+
+    public void setValues(List<List<Double>> values) {
+        this.values = values;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TimeSeriesQueryResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TimeSeriesQueryResult.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.it.gqlmodels.tsdata;
+
+public class TimeSeriesQueryResult {
+    private String status;
+    private TSData data;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public TSData getData() {
+        return data;
+    }
+
+    public void setData(TSData data) {
+        this.data = data;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/resources/org/opennms/horizon/it/horizon-stream.feature
+++ b/external-it/external-horizon-stream-it/src/main/resources/org/opennms/horizon/it/horizon-stream.feature
@@ -1,4 +1,22 @@
-Feature: Hello World
+Feature: Minion Monitoring via Echo Messages Logged in Prometheus
 
-  Scenario: Say Hello
-    Then Say "Hello World"
+  Background: Login to Keycloak
+    Given Ingress base url in environment variable "INGRESS_BASE_URL"
+    Given Keycloak server base url in environment variable "KEYCLOAK_BASE_URL"
+    Given Keycloak realm in environment variable "KEYCLOAK_REALM"
+    Given Keycloak username in environment variable "KEYCLOAK_USERNAME"
+    Given Keycloak password in environment variable "KEYCLOAK_PASSWORD"
+    Given Keycloak client-id in environment variable "KEYCLOAK_CLIENT_ID"
+    Then login to Keycloak with timeout 120000ms
+
+  Scenario: Wait for at least one minion to connect from location Default
+    Given At least one Minion is running with location "Default"
+    # NOTE: there is redundant processing between this step and the ones that follow it
+    Then Wait for at least one minion for the given location reported by inventory with timeout 600000ms
+
+  Scenario: Verify Minion echo measurements are recorded into prometheus for a running Minion
+    Given At least one Minion is running with location "Default"
+    Then Read the list of connected Minions from the BFF
+    Then Find the minions running in the given location
+    Then Verify at least one minion was found for the location
+    Then Read the "response_time_msec" from Prometheus with label "system_id" set to the Minion System ID for each Minion found with timeout 120000ms

--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -19,6 +19,8 @@
 	<version>0.1.0-SNAPSHOT</version>
 
     <properties>
+        <docker.image.name>opennms/horizon-stream-metrics-processor</docker.image.name>
+        <docker.image.tag>local</docker.image.tag>
         <java.version>17</java.version>
     </properties>
     <dependencyManagement>
@@ -139,6 +141,11 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.2.1</version>
+                <configuration>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>kr.motd.maven</groupId>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -43,6 +43,10 @@
         Main executable for the Minion Gateway gRPC Proxy.
     </description>
 
+    <properties>
+        <docker.image.name>opennms/horizon-stream-minion-gateway-grpc-proxy</docker.image.name>
+        <docker.image.tag>local</docker.image.tag>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -145,6 +149,9 @@
                 <configuration>
                     <!-- override skip=false from minion-gateway parent so jib executes here -->
                     <skip>false</skip>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
                 </configuration>
             </plugin>
         </plugins>

--- a/minion-gateway/docker-it/src/test/java/org/opennms/horizon/kafkahelper/internals/KafkaProcessor.java
+++ b/minion-gateway/docker-it/src/test/java/org/opennms/horizon/kafkahelper/internals/KafkaProcessor.java
@@ -69,7 +69,20 @@ public class KafkaProcessor<K,V> implements Runnable {
                 }
             } catch (Exception exc) {
                 LOG.error("Error reading records from kafka", exc);
+                delay();
             }
+        }
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private void delay() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException interruptedException) {
+            LOG.debug("delay interrupted", interruptedException);
         }
     }
 }

--- a/minion-gateway/docker-it/src/test/java/org/opennms/horizon/testcontainers/TestContainerRunnerClassRule.java
+++ b/minion-gateway/docker-it/src/test/java/org/opennms/horizon/testcontainers/TestContainerRunnerClassRule.java
@@ -51,14 +51,12 @@ public class TestContainerRunnerClassRule extends ExternalResource {
     private String confluentPlatformVersion = "7.3.0";
 
     private KafkaContainer kafkaContainer;
-    private GenericContainer zookeeperContainer;
     private GenericContainer applicationContainer;
 
     private Network network;
 
     public TestContainerRunnerClassRule() {
         kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka").withTag(confluentPlatformVersion));
-        zookeeperContainer = new GenericContainer(DockerImageName.parse("confluentinc/cp-zookeeper").withTag(confluentPlatformVersion));
         applicationContainer = new GenericContainer(DockerImageName.parse("opennms/horizon-stream-minion-gateway").withTag("local").toString());
     }
 
@@ -70,7 +68,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
 
         LOG.info("USING TEST DOCKER NETWORK {}", network.getId());
 
-        startZookeeperContainer();
         startKafkaContainer();
         startApplicationContainer();
     }
@@ -79,31 +76,17 @@ public class TestContainerRunnerClassRule extends ExternalResource {
     protected void after() {
         applicationContainer.stop();
         kafkaContainer.stop();
-        zookeeperContainer.stop();
     }
 
 //========================================
 // Container Startups
 //----------------------------------------
 
-    private void startZookeeperContainer() {
-
-        zookeeperContainer
-            .withNetwork(network)
-            .withNetworkAliases("zookeeper")
-            .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(KafkaContainer.ZOOKEEPER_PORT))
-            .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("ZOOKEEPER"))
-        ;
-
-    }
-
     private void startKafkaContainer() {
         kafkaContainer
             .withEmbeddedZookeeper()
             .withNetwork(network)
             .withNetworkAliases("kafka", "kafka-host")
-            .dependsOn(zookeeperContainer)
-            .withExternalZookeeper("zookeeper:" + KafkaContainer.ZOOKEEPER_PORT)
             .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("KAFKA"))
             .start();
         ;
@@ -117,7 +100,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
         applicationContainer
             .withNetwork(network)
             .withNetworkAliases("application", "application-host")
-            .dependsOn(zookeeperContainer, kafkaContainer)
             .withExposedPorts(8080, 8990, 8991, 5005)
             .withStartupTimeout(Duration.ofMinutes(5))
             .withEnv("JAVA_TOOL_OPTIONS", "-Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005")

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -16,7 +16,10 @@
 
 	<artifactId>notifications</artifactId>
 	<version>0.1.0-SNAPSHOT</version>
-
+	<properties>
+            <docker.image.name>opennms/horizon-stream-notification</docker.image.name>
+            <docker.image.tag>local</docker.image.tag>
+	</properties>
 	<dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -144,6 +147,11 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.2.1</version>
+                <configuration>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -21,6 +21,8 @@
     <version>0.1.0-SNAPSHOT</version>
 
 	<properties>
+        <docker.image.name>opennms/horizon-stream-rest-server</docker.image.name>
+        <docker.image.tag>local</docker.image.tag>
 		<java.version>17</java.version>
 		<graphql.spqr.version>0.0.6</graphql.spqr.version>
 	</properties>
@@ -223,6 +225,11 @@
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
 				<version>3.2.1</version>
+                <configuration>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
+                </configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/tooling/ignite-tool/pom.xml
+++ b/tooling/ignite-tool/pom.xml
@@ -18,6 +18,7 @@
     <artifactId>opennms-ignite-tool</artifactId>
 
     <properties>
+        <docker.image.name>opennms/horizon-stream-ignite-tool</docker.image.name>
         <docker.image.tag>local</docker.image.tag>
         <docker.image.skipPush>false</docker.image.skipPush>
     </properties>
@@ -97,6 +98,11 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.2.1</version>
+                <configuration>
+                    <to>
+                        <image>${docker.image.name}:${docker.image.tag}</image>
+                    </to>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>

--- a/tools/KC.login
+++ b/tools/KC.login
@@ -13,12 +13,12 @@
 ##
 ########################################################################################################################
 
-HOST_PORT=localhost:9000
+HOST_PORT=localhost:8123
 REALM=opennms
 CLIENT_ID=admin-cli
 USERNAME=admin
 PASSWORD=admin
-CONTEXT=""
+CONTEXT="auth/"
 
 usage()
 {


### PR DESCRIPTION
…least 1 minion in location Default.

- Update version of Awaitility so failure exceptions are logged on timeout.
- Use "docker save" + "docker load" to load images into the kind cluster instead of "kind load" (see kind github issue re: images loading multiple times)
- Remove maven build tweaks from github actions.
- Remove reference to horizon-stream-core from build since it no longer exists.
- Actions - use "mvn install" instead of "mvn verify"
- JIB maven plugin config - set the default image name and tag for events, datachoices, metrics-processor, minion-gateway-grpc-proxy, notification(s), and rest-server
- IT: Alarms - increase timeout of startup.  Minion-Gateway and Alarms, use embedded zookeeper for Kafka instead of external one.
- IT: Add a delay on kafka consumer exceptions to limit the noise during startup while Kafka is not yet available.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
