### PR TITLE
HS-724: Add BFF endpoint to call new azure credentials gRPC endpoint

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/mapper/AzureCredentialMapper.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/mapper/AzureCredentialMapper.java
@@ -25,33 +25,23 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "google/protobuf/wrappers.proto";
+package org.opennms.horizon.server.mapper;
 
-package opennms.inventory;
-option java_multiple_files = true;
-option java_package = "org.opennms.horizon.inventory.dto";
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueCheckStrategy;
+import org.opennms.horizon.inventory.dto.AzureCredentialCreateDTO;
+import org.opennms.horizon.inventory.dto.AzureCredentialDTO;
+import org.opennms.horizon.server.model.inventory.AzureCredential;
+import org.opennms.horizon.server.model.inventory.AzureCredentialCreate;
 
-message AzureCredentialDTO {
-  int64 id = 1;
-  string location = 2;
-  string tenant_id = 3;
-  string client_id = 4;
-  string subscription_id = 5;
-  string directory_id = 6;
-  int64 create_time = 7;
-}
 
-message AzureCredentialCreateDTO {
-  string location = 1;
-  string client_id = 2;
-  string client_secret = 3;
-  string subscription_id = 4;
-  string directory_id = 5;
-}
+@Mapper(componentModel = "spring")
+public interface AzureCredentialMapper {
 
-service AzureCredentialService {
-  rpc createCredentials(AzureCredentialCreateDTO) returns (AzureCredentialDTO) {};
+    AzureCredential protoToAzureCredential(AzureCredentialDTO azureCredentialDTO);
+
+    @Mapping(target = "location", source = "location", nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+    AzureCredentialCreateDTO azureCredentialCreateToProto(AzureCredentialCreate request);
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/AzureCredential.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/AzureCredential.java
@@ -25,33 +25,20 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "google/protobuf/wrappers.proto";
+package org.opennms.horizon.server.model.inventory;
 
-package opennms.inventory;
-option java_multiple_files = true;
-option java_package = "org.opennms.horizon.inventory.dto";
+import lombok.Getter;
+import lombok.Setter;
 
-message AzureCredentialDTO {
-  int64 id = 1;
-  string location = 2;
-  string tenant_id = 3;
-  string client_id = 4;
-  string subscription_id = 5;
-  string directory_id = 6;
-  int64 create_time = 7;
-}
-
-message AzureCredentialCreateDTO {
-  string location = 1;
-  string client_id = 2;
-  string client_secret = 3;
-  string subscription_id = 4;
-  string directory_id = 5;
-}
-
-service AzureCredentialService {
-  rpc createCredentials(AzureCredentialCreateDTO) returns (AzureCredentialDTO) {};
+@Getter
+@Setter
+public class AzureCredential {
+    private Long id;
+    private String location;
+    private String tenantId;
+    private String clientId;
+    private String subscriptionId;
+    private String directoryId;
+    private Long createTime;
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/AzureCredentialCreate.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/inventory/AzureCredentialCreate.java
@@ -25,33 +25,18 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "google/protobuf/wrappers.proto";
+package org.opennms.horizon.server.model.inventory;
 
-package opennms.inventory;
-option java_multiple_files = true;
-option java_package = "org.opennms.horizon.inventory.dto";
+import lombok.Getter;
+import lombok.Setter;
 
-message AzureCredentialDTO {
-  int64 id = 1;
-  string location = 2;
-  string tenant_id = 3;
-  string client_id = 4;
-  string subscription_id = 5;
-  string directory_id = 6;
-  int64 create_time = 7;
-}
-
-message AzureCredentialCreateDTO {
-  string location = 1;
-  string client_id = 2;
-  string client_secret = 3;
-  string subscription_id = 4;
-  string directory_id = 5;
-}
-
-service AzureCredentialService {
-  rpc createCredentials(AzureCredentialCreateDTO) returns (AzureCredentialDTO) {};
+@Getter
+@Setter
+public class AzureCredentialCreate {
+    private String location;
+    private String clientId;
+    private String clientSecret;
+    private String subscriptionId;
+    private String directoryId;
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcAzureCredentialService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcAzureCredentialService.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.server.service;
+
+import io.leangen.graphql.annotations.GraphQLEnvironment;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.execution.ResolutionEnvironment;
+import io.leangen.graphql.spqr.spring.annotations.GraphQLApi;
+import lombok.RequiredArgsConstructor;
+import org.opennms.horizon.inventory.dto.AzureCredentialCreateDTO;
+import org.opennms.horizon.inventory.dto.AzureCredentialDTO;
+import org.opennms.horizon.server.mapper.AzureCredentialMapper;
+import org.opennms.horizon.server.model.inventory.AzureCredential;
+import org.opennms.horizon.server.model.inventory.AzureCredentialCreate;
+import org.opennms.horizon.server.service.grpc.InventoryClient;
+import org.opennms.horizon.server.utils.ServerHeaderUtil;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@GraphQLApi
+@Service
+public class GrpcAzureCredentialService {
+
+    private final InventoryClient client;
+    private final AzureCredentialMapper mapper;
+    private final ServerHeaderUtil headerUtil;
+
+    @GraphQLMutation
+    public Mono<AzureCredential> addAzureCredential(AzureCredentialCreate azureCredential, @GraphQLEnvironment ResolutionEnvironment env) {
+        System.out.println("GrpcAzureCredentialService.addAzureCredential");
+        System.out.println("azureCredential = " + azureCredential + ", env = " + env);
+        String authHeader = headerUtil.getAuthHeader(env);
+        AzureCredentialCreateDTO createDto = mapper.azureCredentialCreateToProto(azureCredential);
+        AzureCredentialDTO credentialDto = client.createNewAzureCredential(createDto, authHeader);
+        return Mono.just(mapper.protoToAzureCredential(credentialDto));
+    }
+}

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcAzureCredentialService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcAzureCredentialService.java
@@ -54,11 +54,8 @@ public class GrpcAzureCredentialService {
 
     @GraphQLMutation
     public Mono<AzureCredential> addAzureCredential(AzureCredentialCreate azureCredential, @GraphQLEnvironment ResolutionEnvironment env) {
-        System.out.println("GrpcAzureCredentialService.addAzureCredential");
-        System.out.println("azureCredential = " + azureCredential + ", env = " + env);
-        String authHeader = headerUtil.getAuthHeader(env);
         AzureCredentialCreateDTO createDto = mapper.azureCredentialCreateToProto(azureCredential);
-        AzureCredentialDTO credentialDto = client.createNewAzureCredential(createDto, authHeader);
+        AzureCredentialDTO credentialDto = client.createNewAzureCredential(createDto, headerUtil.getAuthHeader(env));
         return Mono.just(mapper.protoToAzureCredential(credentialDto));
     }
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/InventoryClient.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/InventoryClient.java
@@ -33,6 +33,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.opennms.horizon.inventory.dto.AzureCredentialCreateDTO;
+import org.opennms.horizon.inventory.dto.AzureCredentialDTO;
+import org.opennms.horizon.inventory.dto.AzureCredentialServiceGrpc;
 import org.opennms.horizon.inventory.dto.IdList;
 import org.opennms.horizon.inventory.dto.MonitoringLocationDTO;
 import org.opennms.horizon.inventory.dto.MonitoringLocationServiceGrpc;
@@ -60,11 +63,13 @@ public class InventoryClient {
     private MonitoringLocationServiceGrpc.MonitoringLocationServiceBlockingStub locationStub;
     private NodeServiceGrpc.NodeServiceBlockingStub nodeStub;
     private MonitoringSystemServiceGrpc.MonitoringSystemServiceBlockingStub systemStub;
+    private AzureCredentialServiceGrpc.AzureCredentialServiceBlockingStub azureCredentialStub;
 
     protected void initialStubs() {
         locationStub = MonitoringLocationServiceGrpc.newBlockingStub(channel);
         nodeStub = NodeServiceGrpc.newBlockingStub(channel);
         systemStub = MonitoringSystemServiceGrpc.newBlockingStub(channel);
+        azureCredentialStub = AzureCredentialServiceGrpc.newBlockingStub(channel);
     }
 
     public void shutdown() {
@@ -134,5 +139,11 @@ public class InventoryClient {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
         return systemStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).deleteMonitoringSystem(StringValue.of(systemId)).getValue();
+    }
+
+    public AzureCredentialDTO createNewAzureCredential(AzureCredentialCreateDTO azureCredential, String accessToken) {
+        Metadata metadata = new Metadata();
+        metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
+        return azureCredentialStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).createCredentials(azureCredential);
     }
 }

--- a/rest-server/src/test/java/org/opennms/horizon/server/RestServerApplicationTests.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/RestServerApplicationTests.java
@@ -3,6 +3,7 @@ package org.opennms.horizon.server;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.Test;
+import org.opennms.horizon.server.service.GrpcAzureCredentialService;
 import org.opennms.horizon.server.service.GrpcEventService;
 import org.opennms.horizon.server.service.GrpcLocationService;
 import org.opennms.horizon.server.service.GrpcMinionService;
@@ -23,6 +24,8 @@ class RestServerApplicationTests {
     private GrpcNodeService grpcNodeService;
     @Autowired
     private GrpcLocationService grpcLocationService;
+    @Autowired
+    private GrpcAzureCredentialService grpcAzureCredentialService;
 
 	@Test
 	void contextLoads() {
@@ -31,6 +34,7 @@ class RestServerApplicationTests {
         assertNotNull(grpcLocationService);
         assertNotNull(grpcEventService);
         assertNotNull(grpcNodeService);
+        assertNotNull(grpcAzureCredentialService);
 	}
 
 }

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/GraphQLAzureCredentialServiceTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/GraphQLAzureCredentialServiceTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.server.service;
+
+import io.leangen.graphql.execution.ResolutionEnvironment;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opennms.horizon.inventory.dto.AzureCredentialCreateDTO;
+import org.opennms.horizon.inventory.dto.AzureCredentialDTO;
+import org.opennms.horizon.server.RestServerApplication;
+import org.opennms.horizon.server.service.grpc.InventoryClient;
+import org.opennms.horizon.server.utils.ServerHeaderUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT, classes = RestServerApplication.class)
+class GraphQLAzureCredentialServiceTest {
+    private static final String GRAPHQL_PATH = "/graphql";
+    @MockBean
+    private InventoryClient mockClient;
+    @Autowired
+    private WebTestClient webClient;
+    @MockBean
+    private ServerHeaderUtil mockHeaderUtil;
+    private final String accessToken = "test-token-12345";
+    private AzureCredentialDTO azureCredentialDTO1;
+
+    @BeforeEach
+    public void setUp() {
+        azureCredentialDTO1 = AzureCredentialDTO.newBuilder()
+            .setId(1L)
+            .setLocation("Default")
+            .setTenantId("tenant-id")
+            .setClientId("client-id")
+            .setDirectoryId("directory-id")
+            .setSubscriptionId("subscription-id")
+            .setCreateTime(Instant.now().toEpochMilli())
+            .build();
+
+        doReturn(accessToken).when(mockHeaderUtil).getAuthHeader(any(ResolutionEnvironment.class));
+    }
+
+    @AfterEach
+    public void afterTest() {
+        verifyNoMoreInteractions(mockClient);
+        verifyNoMoreInteractions(mockHeaderUtil);
+    }
+
+    @Test
+    void testCreateAzureCredential() throws JSONException {
+        doReturn(azureCredentialDTO1).when(mockClient).createNewAzureCredential(any(AzureCredentialCreateDTO.class), eq(accessToken));
+
+        String request = createPayload("mutation { " +
+            "    addAzureCredential( " +
+            "        azureCredential: { " +
+            "            location: \"Default\", " +
+            "            clientId: \"client-id\", " +
+            "            clientSecret: \"client-secret\", " +
+            "            subscriptionId: \"subscription-id\", " +
+            "            directoryId: \"directory-id\" " +
+            "        } " +
+            "    ) { " +
+            "        id, " +
+            "        location, " +
+            "        tenantId, " +
+            "        clientId, " +
+            "        subscriptionId, " +
+            "        directoryId, " +
+            "        createTime " +
+            "    } " +
+            "}");
+
+        webClient.post()
+            .uri(GRAPHQL_PATH)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody()
+            .jsonPath("$.data.addAzureCredential.id").isEqualTo(azureCredentialDTO1.getId())
+            .jsonPath("$.data.addAzureCredential.location").isEqualTo(azureCredentialDTO1.getLocation())
+            .jsonPath("$.data.addAzureCredential.tenantId").isEqualTo(azureCredentialDTO1.getTenantId())
+            .jsonPath("$.data.addAzureCredential.clientId").isEqualTo(azureCredentialDTO1.getClientId())
+            .jsonPath("$.data.addAzureCredential.subscriptionId").isEqualTo(azureCredentialDTO1.getSubscriptionId())
+            .jsonPath("$.data.addAzureCredential.directoryId").isEqualTo(azureCredentialDTO1.getDirectoryId())
+            .jsonPath("$.data.addAzureCredential.createTime").isEqualTo(azureCredentialDTO1.getCreateTime());
+        verify(mockClient).createNewAzureCredential(any(AzureCredentialCreateDTO.class), eq(accessToken));
+        verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
+    }
+
+    private String createPayload(String request) throws JSONException {
+        return new JSONObject().put("query", request).toString();
+    }
+}


### PR DESCRIPTION
## Description
HS-724: Add BFF endpoint to call new azure credentials gRPC endpoint

REQUEST:
```
mutation {
    addAzureCredential(
        azureCredential: { 
            location: "Default",
            clientId: "client-id",
            clientSecret: "client-secret",
            subscriptionId: "subscription-id",
            directoryId: "directory-id"
        }
    ) {
        id,
        location,
        tenantId,
        clientId,
        subscriptionId,
        directoryId,
        createTime
    }
}
```
RESPONSE:
```
{
    "data": {
        "addAzureCredential": {
            "id": 1,
            "location": "Default",
            "tenantId": "opennms-prime",
            "clientId": "client-id",
            "subscriptionId": "subscription-id",
            "directoryId": "directory-id",
            "createTime": 1674055949256
        }
    }
}
```

Note:  Client Secret doesnt return in response.

## Jira link(s)
- https://issues.opennms.org/browse/HS-724

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
