### PR TITLE
External IT - verify minion echo measurements reported by BFF for at …

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -152,12 +152,21 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ inputs.image-registry || 'ghcr.io' }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Cache Maven dependencies
         uses: ./.github/actions/maven-cache
         with:
           cache-key-hash: ${{ hashFiles('external-it/**/pom.xml') }}
 
       - name: Create & set up cluster
+        shell: bash
+        working-directory: install-local
         run: |          
           # Setup localhost DNS
           sudo echo "127.0.0.1 onmshs" | sudo tee -a /etc/hosts
@@ -165,27 +174,53 @@ jobs:
           # Build cluster with Horizon Stream installed.
           ./install-local.sh cicd onmshs "${{ inputs.image-tag || github.sha }}" "${{ inputs.image-registry || 'ghcr.io' }}/opennms-cloud"
 
-        shell: bash
-        working-directory: install-local
+          echo ""
+          echo "=================="
+          echo "K8S CLUSTER STATUS"
+          echo "=================="
+          date
+          kubectl -n hs-instance get all
 
       - name: Set up & run Cucumber tests
+        shell: bash
+        working-directory: external-it
         run: |
           # Cucumber test
           mvn install
-          HORIZON_STREAM_BASE_URL=http://localhost:11080 
+          INGRESS_BASE_URL=https://onmshs
           KEYCLOAK_BASE_URL=https://onmshs/auth
           KEYCLOAK_REALM=opennms
           KEYCLOAK_USERNAME=admin
           KEYCLOAK_PASSWORD=admin
-          export HORIZON_STREAM_BASE_URL KEYCLOAK_BASE_URL KEYCLOAK_REALM KEYCLOAK_USERNAME KEYCLOAK_PASSWORD
+          KEYCLOAK_CLIENT_ID=horizon-stream
+          export INGRESS_BASE_URL KEYCLOAK_BASE_URL KEYCLOAK_REALM KEYCLOAK_USERNAME KEYCLOAK_PASSWORD KEYCLOAK_CLIENT_ID
           PROJECT_VERSION="$(mvn -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive -q org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)"
           java -jar "external-horizon-stream-it/target/external-horizon-stream-it-${PROJECT_VERSION}.jar"
-          
+
           ## If fail, exit which kills the ci-cd workflow.
           ##for i in $(jq '.[0].elements[].steps[].result.status' external-it/external-horizon-stream-it/cucumber.reports/cucumber-report.json);do
           ##  if [[ $i != '"passed"' ]];then
           ##    exit;
           ##  fi
           ##done
+
+      - name: Diag after failure
+        if: ${{ failure() }}
         shell: bash
-        working-directory: external-it
+        run: |
+            echo "K8S CLUSTER STATUS"
+            kubectl -n hs-instance get all
+
+            echo ""
+
+            for pod in $(kubectl -n hs-instance get pod | awk '$1 != "NAME" { print $1; }')
+            do
+                echo ""
+                echo "=== DIAG POD ${pod} ==="
+                echo ""
+                kubectl -n hs-instance describe "pod/${pod#pod/}" | sed 's,^,    ,'
+            done
+
+            echo ""
+            echo "=== K8S APPLICATION LOGS ==="
+            kubectl logs -n hs-instance -l appdomain=opennms

--- a/charts/opennms/templates/opennms/alarm/alarm-deployment.yaml
+++ b/charts/opennms/templates/opennms/alarm/alarm-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Alarm.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.API.ServiceName }}
     spec:
       {{ if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.DataChoices.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Events.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Inventory.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         run: {{ .Values.OpenNMS.MetricsProcessor.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}
         ignite-cluster: core
     spec:

--- a/charts/opennms/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Minion.ServiceName }}
       annotations:
         linkerd.io/inject: enabled

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.MinionGateway.ServiceName }}
         ignite-cluster: core
     spec:

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.Notification.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/ui/ui-deployment.yaml
+++ b/charts/opennms/templates/opennms/ui/ui-deployment.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        appdomain: opennms
         app: {{ .Values.OpenNMS.UI.ServiceName }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/external-it/external-horizon-stream-it/README.md
+++ b/external-it/external-horizon-stream-it/README.md
@@ -5,11 +5,12 @@
     * Keycloak user "user001", password "passw0rd", in realm "opennms"
 
     $ mvn clean install
-    $ HORIZON_STREAM_BASE_URL=http://localhost:8080
-    $ KEYCLOAK_BASE_URL=http://localhost:9000
+    $ INGRESS_BASE_URL=http://localhost:8123
+    $ KEYCLOAK_BASE_URL=http://localhost:8123/auth
     $ KEYCLOAK_REALM=opennms
     $ KEYCLOAK_USERNAME=user001
     $ KEYCLOAK_PASSWORD=passw0rd
+    $ KEYCLOAK_CLIENT_ID=horizon-stream
     $ export HORIZON_STREAM_BASE_URL KEYCLOAK_BASE_URL KEYCLOAK_REALM KEYCLOAK_USERNAME KEYCLOAK_PASSWORD
     $ PROJECT_VERSION="$(mvn -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive -q org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)"
     $ java -jar "external-horizon-stream-it/target/external-horizon-stream-it-${PROJECT_VERSION}.jar"

--- a/external-it/external-horizon-stream-it/pom.xml
+++ b/external-it/external-horizon-stream-it/pom.xml
@@ -104,9 +104,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>1.7.0</version>
+            <version>4.1.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/GQLQueryConstants.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/GQLQueryConstants.java
@@ -1,0 +1,12 @@
+package org.opennms.horizon.it;
+
+public abstract class GQLQueryConstants {
+    public static final String LIST_MINIONS_QUERY = "{ \"query\": \"{ findAllMinions {id, systemId, systemId, location { location } } }\" }";
+
+    public static final String GET_LABELED_METRICS_QUERY =
+        "query { metric(name:\"%s\", labels: {%s:\"%s\"}) { status, data { result { metric, value }}} }";
+
+    public static final String LIST_MINION_INSTANCE_ECHO_METRICS_QUERY =
+        "query { metric(name:\"response_time_msec\", labels: {monitor:\"ECHO\", instance:\"%s\"}) { status, data { result { metric }}} }";
+
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/HorizonStreamTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/HorizonStreamTestSteps.java
@@ -1,172 +1,54 @@
 package org.opennms.horizon.it;
 
 import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.restassured.RestAssured;
-import io.restassured.config.HttpClientConfig;
-import io.restassured.config.RestAssuredConfig;
-import io.restassured.config.SSLConfig;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
-import org.hamcrest.Matchers;
 
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.keycloak.admin.client.Keycloak;
-import org.keycloak.admin.client.KeycloakBuilder;
-import org.keycloak.representations.AccessTokenResponse;
-import org.opennms.horizon.utils.TestTrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
-import javax.ws.rs.core.HttpHeaders;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
-
-import static com.jayway.awaitility.Awaitility.await;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-
-import static io.restassured.RestAssured.given;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.keycloak.OAuth2Constants.PASSWORD;
-
 public class HorizonStreamTestSteps {
-
-    public static final int DEFAULT_HTTP_SOCKET_TIMEOUT = 15_000;
 
     private static final Logger log = LoggerFactory.getLogger(HorizonStreamTestSteps.class);
 
-    private String horizonStreamBaseUrl;
-    private String keycloakBaseUrl;
-    private String keycloakRealm;
-    private String keycloakUsername;
-    private String keycloakPassword;
+    private final KeycloakTestSteps keycloakTestSteps;
+    private final InventoryTestSteps inventoryTestSteps;
+    private final MetricsTestSteps metricsTestSteps;
 
-    private Keycloak keycloakClient;
-    private Response restResponse;
-    private String keycloakToken;
+    private String ingressBaseUrl;
+
+//========================================
+// Constructor
+//----------------------------------------
+
+    public HorizonStreamTestSteps(KeycloakTestSteps keycloakTestSteps, InventoryTestSteps inventoryTestSteps, MetricsTestSteps metricsTestSteps) {
+        this.keycloakTestSteps = keycloakTestSteps;
+        this.inventoryTestSteps = inventoryTestSteps;
+        this.metricsTestSteps = metricsTestSteps;
+
+        this.inventoryTestSteps.setUserAccessTokenSupplier(this.keycloakTestSteps::getKeycloakAccessToken);
+        this.inventoryTestSteps.setIngressUrlSupplier(this::getIngressBaseUrl);
+
+        this.metricsTestSteps.setUserAccessTokenSupplier(this.keycloakTestSteps::getKeycloakAccessToken);
+        this.metricsTestSteps.setIngressUrlSupplier(this::getIngressBaseUrl);
+        this.metricsTestSteps.setMinionsAtLocationSupplier(this.inventoryTestSteps::getMinionsAtLocation);
+    }
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public String getIngressBaseUrl() {
+        return ingressBaseUrl;
+    }
+
 
 //========================================
 // Test Step Definitions
 //----------------------------------------
 
-    @Given("horizon stream server base url in environment variable {string}")
+    @Given("Ingress base url in environment variable {string}")
     public void horizonStreamServerBaseUrlInEnvironmentVariable(String variableName) {
-        horizonStreamBaseUrl = System.getenv(variableName);
+        ingressBaseUrl = System.getenv(variableName);
 
-        log.info("HORIZON STREAM BASE URL: {}", horizonStreamBaseUrl);
-    }
-
-    @Given("Keycloak server base url in environment variable {string}")
-    public void keycloakServerBaseUrlInEnvironmentVariable(String variableName) {
-        keycloakBaseUrl = System.getenv(variableName);
-
-        log.info("KEYCLOAK BASE URL: {}", keycloakBaseUrl);
-    }
-
-    @Given("Keycloak realm in environment variable {string}")
-    public void keycloakRealmInEnvironmentVariable(String variableName) {
-        keycloakRealm = System.getenv(variableName);
-
-        log.info("KEYCLOAK REALM: {}", keycloakRealm);
-    }
-
-    @Given("Keycloak username in environment variable {string}")
-    public void keycloakUsernameInEnvironmentVariable(String variableName) {
-        keycloakUsername = System.getenv(variableName);
-
-        log.info("KEYCLOAK USERNAME: {}", keycloakUsername);
-    }
-
-    @Given("Keycloak password in environment variable {string}")
-    public void keycloakPasswordInEnvironmentVariable(String variableName) {
-        keycloakPassword = System.getenv(variableName);
-    }
-
-    @Then("Say {string}")
-    public void say(String text) {
-        log.info("{}", text);
-    }
-
-    @Then("login to Keycloak")
-    public void loginToKeycloak() throws NoSuchAlgorithmException, KeyManagementException {
-        ResteasyClientBuilder restClientBuilder = new ResteasyClientBuilder();
-        restClientBuilder.disableTrustManager();
-        SSLContext sslContext = SSLContext.getInstance("SSL");
-        sslContext.init(null, new TestTrustManager[]{new TestTrustManager()}, new SecureRandom());
-        restClientBuilder.sslContext(sslContext);
-
-        keycloakClient =
-                KeycloakBuilder.builder()
-                    .serverUrl(keycloakBaseUrl)
-                    .grantType(PASSWORD)
-                    .realm(keycloakRealm)
-                    .username(keycloakUsername)
-                    .password(keycloakPassword)
-                    .clientId("admin-cli")// TBD
-                    .resteasyClient(restClientBuilder.build())
-                    .build()
-        ;
-
-        AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
-        keycloakToken = accessTokenResponse.getToken();
-
-        assertNotNull(keycloakToken);
-    }
-
-    @Then("send GET request to horizon-stream at path {string}")
-    public void sendGETRequestToHorizonStreamAtPath(String path) throws MalformedURLException {
-        URL requestUrl = new URL(new URL(horizonStreamBaseUrl), path);
-
-        RestAssuredConfig restAssuredConfig = createRestAssuredTestConfig();
-
-        RequestSpecification requestSpecification =
-                RestAssured
-                    .given()
-                    .config(restAssuredConfig)
-                    ;
-
-        if (keycloakToken != null) {
-            requestSpecification.header(HttpHeaders.AUTHORIZATION, "Bearer " + keycloakToken);
-        }
-
-        restResponse =
-                requestSpecification
-                        .get(requestUrl)
-                        .thenReturn()
-        ;
-    }
-
-    @Then("verify HTTP response code = {int}")
-    public void verifyHTTPResponseCode(int expectedResponseCode) {
-        // Wait till Minion is registered to Horizon Core
-        await().atMost(180, TimeUnit.SECONDS).pollDelay(0, TimeUnit.SECONDS)
-            .pollInterval(5, TimeUnit.SECONDS)
-            .until(()-> restResponse.getStatusCode(), Matchers.is(expectedResponseCode));
-    }
-
-    @Then("verify response has Minion location = {string}")
-    public void verifyMinionResponse(String location) {
-        // Wait till Minion is registered to Horizon Core
-        await().atMost(180, TimeUnit.SECONDS).pollDelay(0, TimeUnit.SECONDS)
-            .pollInterval(5, TimeUnit.SECONDS)
-            .until(()-> restResponse.getBody().print(), Matchers.containsString(location));
-    }
-
-//========================================
-// Internals
-//----------------------------------------
-
-    private RestAssuredConfig createRestAssuredTestConfig() {
-        return RestAssuredConfig.config()
-            .sslConfig(SSLConfig.sslConfig().relaxedHTTPSValidation("SSL"))
-                .httpClient(HttpClientConfig.httpClientConfig()
-                        .setParam("http.connection.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
-                        .setParam("http.socket.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
-                );
+        log.info("INGRESS BASE URL: {}", ingressBaseUrl);
     }
 }

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/InventoryTestSteps.java
@@ -1,0 +1,194 @@
+package org.opennms.horizon.it;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.config.SSLConfig;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HTTP;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.opennms.horizon.it.gqlmodels.querywrappers.FindAllMinionsQueryResult;
+import org.opennms.horizon.it.gqlmodels.MinionData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InventoryTestSteps {
+
+    public static final int DEFAULT_HTTP_SOCKET_TIMEOUT = 15_000;
+
+    private static final Logger LOG = LoggerFactory.getLogger(InventoryTestSteps.class);
+
+    // Operations to access data from other TestSteps
+    private Supplier<String> userAccessTokenSupplier;
+    private Supplier<String> ingressUrlSupplier;
+
+    // Runtime Data
+    private String minionLocation;
+    private FindAllMinionsQueryResult findAllMinionsQueryResult;
+    private List<MinionData> minionsAtLocation;
+    private String lastMinionQueryResultBody;
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public Supplier<String> getUserAccessTokenSupplier() {
+        return userAccessTokenSupplier;
+    }
+
+    public void setUserAccessTokenSupplier(Supplier<String> userAccessTokenSupplier) {
+        this.userAccessTokenSupplier = userAccessTokenSupplier;
+    }
+
+    public Supplier<String> getIngressUrlSupplier() {
+        return ingressUrlSupplier;
+    }
+
+    public void setIngressUrlSupplier(Supplier<String> ingressUrlSupplier) {
+        this.ingressUrlSupplier = ingressUrlSupplier;
+    }
+
+    public List<MinionData> getMinionsAtLocation() {
+        return minionsAtLocation;
+    }
+
+//========================================
+// Test Step Definitions
+//----------------------------------------
+
+    @Given("At least one Minion is running with location {string}")
+    public void atLeastOneMinionIsRunningWithLocation(String location) {
+        minionLocation = location;
+    }
+
+
+    @Then("Wait for at least one minion for the given location reported by inventory with timeout {int}ms")
+    public void waitForAtLeastOneMinionForTheGivenLocationReportedByInventoryWithTimeoutMs(int timeout) {
+        try {
+            Awaitility
+                .await()
+                .atMost(timeout, TimeUnit.MILLISECONDS)
+                .ignoreExceptions()
+                .until(this::checkAtLeastOneMinionAtGivenLocation)
+                ;
+        } finally {
+            LOG.info("LAST CHECK MINION RESPONSE BODY: {}", lastMinionQueryResultBody);
+        }
+    }
+
+    /** @noinspection rawtypes*/
+    @Then("Read the list of connected Minions from the BFF")
+    public void readTheListOfConnectedMinionsFromInventory() throws MalformedURLException {
+        findAllMinionsQueryResult = commonQueryMinions();
+    }
+
+    @Then("Find the minions running in the given location")
+    public void findTheMinionsRunningInTheGivenLocation() {
+        minionsAtLocation = commonFilterMinionsAtLocation(findAllMinionsQueryResult);
+    }
+
+    @Then("Verify at least one minion was found for the location")
+    public void verifyAtLeastOneMinionWasFoundForTheLocation() {
+        assertTrue(minionsAtLocation.size() > 0);
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private RestAssuredConfig createRestAssuredTestConfig() {
+        return RestAssuredConfig.config()
+            .sslConfig(SSLConfig.sslConfig().relaxedHTTPSValidation("SSL"))
+            .httpClient(HttpClientConfig.httpClientConfig()
+                .setParam("http.connection.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+                .setParam("http.socket.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+            );
+    }
+
+    private URL formatIngressUrl(String path) throws MalformedURLException {
+        String baseUrl = ingressUrlSupplier.get();
+
+        return new URL(new URL(baseUrl), path);
+    }
+
+    private String formatAuthorizationHeader(String token) {
+        return "Bearer " + token;
+    }
+
+    private Response executePost(URL url, String accessToken, Object body) {
+        RestAssuredConfig restAssuredConfig = createRestAssuredTestConfig();
+
+        RequestSpecification requestSpecification =
+            RestAssured
+                .given()
+                .config(restAssuredConfig)
+            ;
+
+        Response restAssuredResponse =
+            requestSpecification
+                .header(HttpHeaders.AUTHORIZATION, formatAuthorizationHeader(accessToken))
+                .header(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .body(body)
+                .post(url)
+                .thenReturn()
+            ;
+
+        return restAssuredResponse;
+    }
+
+    private boolean checkAtLeastOneMinionAtGivenLocation() throws MalformedURLException {
+        FindAllMinionsQueryResult findAllMinionsQueryResult = commonQueryMinions();
+        List<MinionData> filtered = commonFilterMinionsAtLocation(findAllMinionsQueryResult);
+
+        LOG.debug("MINIONS for location: count={}; location={}", filtered.size(), minionLocation);
+
+        return ( ! filtered.isEmpty() );
+    }
+
+    /** @noinspection rawtypes*/
+    private FindAllMinionsQueryResult commonQueryMinions() throws MalformedURLException {
+        String accessToken = userAccessTokenSupplier.get();
+
+        URL url = formatIngressUrl("/api/graphql");
+
+        Response restAssuredResponse = executePost(url, accessToken, GQLQueryConstants.LIST_MINIONS_QUERY);
+
+        lastMinionQueryResultBody = restAssuredResponse.getBody().asString();
+
+        Assert.assertEquals(200, restAssuredResponse.getStatusCode());
+
+        return restAssuredResponse.getBody().as(FindAllMinionsQueryResult.class);
+    }
+
+    private List<MinionData> commonFilterMinionsAtLocation(FindAllMinionsQueryResult findAllMinionsQueryResult) {
+        List<MinionData> minionData = findAllMinionsQueryResult.getData().getFindAllMinions();
+
+        List<MinionData> minionsAtLocation =
+            minionData.stream()
+                .filter((md) -> Objects.equals(md.getLocation().getLocation(), minionLocation))
+                .collect(Collectors.toList())
+        ;
+
+        LOG.debug("MINIONS for location: count={}; location={}", minionsAtLocation.size(), minionLocation);
+
+        return minionsAtLocation;
+    }
+
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/KeycloakTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/KeycloakTestSteps.java
@@ -1,0 +1,122 @@
+package org.opennms.horizon.it;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.restassured.response.Response;
+import org.awaitility.Awaitility;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.representations.AccessTokenResponse;
+import org.opennms.horizon.utils.TestTrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.keycloak.OAuth2Constants.PASSWORD;
+
+public class KeycloakTestSteps {
+
+    private static final Logger log = LoggerFactory.getLogger(KeycloakTestSteps.class);
+
+    private String keycloakBaseUrl;
+    private String keycloakRealm;
+    private String keycloakUsername;
+    private String keycloakPassword;
+    private String keycloakClientId;
+
+    private Keycloak keycloakClient;
+    private Response restResponse;
+    private String keycloakAccessToken;
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public String getKeycloakAccessToken() {
+        return keycloakAccessToken;
+    }
+
+
+//========================================
+// Test Step Definitions
+//----------------------------------------
+
+    @Given("Keycloak server base url in environment variable {string}")
+    public void keycloakServerBaseUrlInEnvironmentVariable(String variableName) {
+        keycloakBaseUrl = System.getenv(variableName);
+
+        log.info("KEYCLOAK BASE URL: {}", keycloakBaseUrl);
+    }
+
+    @Given("Keycloak realm in environment variable {string}")
+    public void keycloakRealmInEnvironmentVariable(String variableName) {
+        keycloakRealm = System.getenv(variableName);
+
+        log.info("KEYCLOAK REALM: {}", keycloakRealm);
+    }
+
+    @Given("Keycloak username in environment variable {string}")
+    public void keycloakUsernameInEnvironmentVariable(String variableName) {
+        keycloakUsername = System.getenv(variableName);
+
+        log.info("KEYCLOAK USERNAME: {}", keycloakUsername);
+    }
+
+    @Given("Keycloak password in environment variable {string}")
+    public void keycloakPasswordInEnvironmentVariable(String variableName) {
+        keycloakPassword = System.getenv(variableName);
+    }
+
+    @Given("Keycloak client-id in environment variable {string}")
+    public void keycloakClientIdInEnvironmentVariable(String variableName) {
+        keycloakClientId = System.getenv(variableName);
+    }
+
+    @Then("login to Keycloak with timeout {int}ms")
+    public void loginToKeycloak(long timeout) {
+        Awaitility
+            .await()
+            .timeout(timeout, TimeUnit.MILLISECONDS)
+            .ignoreExceptions()
+            .until(this::commonLoginToKeycloak)
+            ;
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private boolean commonLoginToKeycloak() throws NoSuchAlgorithmException, KeyManagementException {
+        ResteasyClientBuilder restClientBuilder = new ResteasyClientBuilder();
+        restClientBuilder.disableTrustManager();
+        SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(null, new TestTrustManager[]{new TestTrustManager()}, new SecureRandom());
+        restClientBuilder.sslContext(sslContext);
+
+        keycloakClient =
+            KeycloakBuilder.builder()
+                .serverUrl(keycloakBaseUrl)
+                .grantType(PASSWORD)
+                .realm(keycloakRealm)
+                .username(keycloakUsername)
+                .password(keycloakPassword)
+                .clientId(keycloakClientId)
+                .resteasyClient(restClientBuilder.build())
+                .build()
+        ;
+
+        AccessTokenResponse accessTokenResponse = keycloakClient.tokenManager().getAccessToken();
+        keycloakAccessToken = accessTokenResponse.getToken();
+
+        assertNotNull(keycloakAccessToken);
+
+        return true;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/MetricsTestSteps.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/MetricsTestSteps.java
@@ -1,0 +1,170 @@
+package org.opennms.horizon.it;
+
+import io.cucumber.java.en.Then;
+import io.restassured.RestAssured;
+import io.restassured.config.HttpClientConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.config.SSLConfig;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HTTP;
+import org.awaitility.Awaitility;
+import org.opennms.horizon.it.gqlmodels.GQLQuery;
+import org.opennms.horizon.it.gqlmodels.MinionData;
+import org.opennms.horizon.it.gqlmodels.querywrappers.MetricQueryResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetricsTestSteps {
+
+    public static final int DEFAULT_HTTP_SOCKET_TIMEOUT = 15_000;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetricsTestSteps.class);
+
+    // Operations to access data from other TestSteps
+    private Supplier<String> userAccessTokenSupplier;
+    private Supplier<String> ingressUrlSupplier;
+    private Supplier<List<MinionData>> minionsAtLocationSupplier;
+
+//========================================
+// Getters and Setters
+//----------------------------------------
+
+    public Supplier<String> getUserAccessTokenSupplier() {
+        return userAccessTokenSupplier;
+    }
+
+    public void setUserAccessTokenSupplier(Supplier<String> userAccessTokenSupplier) {
+        this.userAccessTokenSupplier = userAccessTokenSupplier;
+    }
+
+    public Supplier<List<MinionData>> getMinionsAtLocationSupplier() {
+        return minionsAtLocationSupplier;
+    }
+
+    public void setMinionsAtLocationSupplier(Supplier<List<MinionData>> minionsAtLocationSupplier) {
+        this.minionsAtLocationSupplier = minionsAtLocationSupplier;
+    }
+
+    public Supplier<String> getIngressUrlSupplier() {
+        return ingressUrlSupplier;
+    }
+
+    public void setIngressUrlSupplier(Supplier<String> ingressUrlSupplier) {
+        this.ingressUrlSupplier = ingressUrlSupplier;
+    }
+
+//========================================
+// Test Step Definitions
+//----------------------------------------
+
+    @Then("Read the {string} from Prometheus with label {string} set to the Minion System ID for each Minion found with timeout {int}ms")
+    public void readTheFromPrometheusWithLabelSetToTheMinionSystemID(String metricName, String labelName, long timeout) throws MalformedURLException {
+        Awaitility
+            .await()
+            .ignoreExceptions()
+            .atMost(timeout, TimeUnit.MILLISECONDS)
+            .until(() -> this.commonCheckMinionMetrics(metricName, labelName))
+            ;
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private RestAssuredConfig createRestAssuredTestConfig() {
+        return RestAssuredConfig.config()
+            .sslConfig(SSLConfig.sslConfig().relaxedHTTPSValidation("SSL"))
+            .httpClient(HttpClientConfig.httpClientConfig()
+                .setParam("http.connection.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+                .setParam("http.socket.timeout", DEFAULT_HTTP_SOCKET_TIMEOUT)
+            );
+    }
+
+    private URL formatIngressUrl(String path) throws MalformedURLException {
+        String baseUrl = ingressUrlSupplier.get();
+
+        return new URL(new URL(baseUrl), path);
+    }
+
+    private String formatAuthorizationHeader(String token) {
+        return "Bearer " + token;
+    }
+
+    private Response executePost(URL url, String accessToken, Object body) {
+        RestAssuredConfig restAssuredConfig = createRestAssuredTestConfig();
+
+        RequestSpecification requestSpecification =
+            RestAssured
+                .given()
+                .config(restAssuredConfig)
+            ;
+
+        Response restAssuredResponse =
+            requestSpecification
+                .header(HttpHeaders.AUTHORIZATION, formatAuthorizationHeader(accessToken))
+                .header(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .body(body)
+                .post(url)
+                .thenReturn()
+            ;
+
+        return restAssuredResponse;
+    }
+
+    private List<Pair<MinionData, MetricQueryResult>> commonQueryMetrics(String metricName, String labelName) throws MalformedURLException {
+        String accessToken = userAccessTokenSupplier.get();
+
+        URL url = formatIngressUrl("/api/graphql");
+
+        List<MinionData> minionsAtLocation = minionsAtLocationSupplier.get();
+        List<Pair<MinionData, MetricQueryResult>> results = new LinkedList<>();
+        for (MinionData oneMinion : minionsAtLocation) {
+            String query =
+                String.format(GQLQueryConstants.GET_LABELED_METRICS_QUERY, metricName, labelName, oneMinion.getSystemId());
+
+            GQLQuery gqlQuery = new GQLQuery();
+            gqlQuery.setQuery(query);
+
+            Response restAssuredResponse = executePost(url, accessToken, gqlQuery);
+
+            assertEquals(200, restAssuredResponse.getStatusCode());
+
+            MetricQueryResult metricQueryResult = restAssuredResponse.getBody().as(MetricQueryResult.class);
+
+            results.add(Pair.of(oneMinion, metricQueryResult));
+        }
+
+        return results;
+    }
+
+    private boolean commonCheckMinionMetrics(String metricName, String labelName) throws MalformedURLException {
+        List<Pair<MinionData, MetricQueryResult>> minionMetrics = commonQueryMetrics(metricName, labelName);
+        for (Pair<MinionData, MetricQueryResult> oneMinionMetric : minionMetrics) {
+            MetricQueryResult metricQueryResult = oneMinionMetric.getRight();
+
+            LOG.info("METRIC FOR MINION: metric-name={}; monitor={}; value={}",
+                metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("__name__"),
+                metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("monitor"),
+                metricQueryResult.getData().getMetric().getData().getResult().get(0).getValue().get(0)
+            );
+
+            assertEquals(1, metricQueryResult.getData().getMetric().getData().getResult().size());
+            assertEquals("response_time_msec", metricQueryResult.getData().getMetric().getData().getResult().get(0).getMetric().get("__name__"));
+        }
+
+        return true;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/GQLQuery.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/GQLQuery.java
@@ -1,0 +1,31 @@
+package org.opennms.horizon.it.gqlmodels;
+
+public class GQLQuery {
+    private String query;
+    private String variables;
+    private String operationName;
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getVariables() {
+        return variables;
+    }
+
+    public void setVariables(String variables) {
+        this.variables = variables;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/LocationData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/LocationData.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.it.gqlmodels;
+
+public class LocationData {
+    private String location;
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MetricIdentityData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MetricIdentityData.java
@@ -1,0 +1,22 @@
+package org.opennms.horizon.it.gqlmodels;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MetricIdentityData {
+    private String __name__;
+    private String instance;
+    private String location;
+    private String monitor;
+
+    @JsonProperty("node_id")
+    private String nodeId;
+
+    @JsonProperty("pushgateway_instance")
+    private String pushgatewayInstance;
+
+    @JsonProperty("system_id")
+    private String systemId;
+
+    @JsonProperty("tenant_id")
+    private String tenantId;
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MinionData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/MinionData.java
@@ -1,0 +1,31 @@
+package org.opennms.horizon.it.gqlmodels;
+
+public class MinionData {
+    private long id;
+    private String systemId;
+    private LocationData location;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getSystemId() {
+        return systemId;
+    }
+
+    public void setSystemId(String systemId) {
+        this.systemId = systemId;
+    }
+
+    public LocationData getLocation() {
+        return location;
+    }
+
+    public void setLocation(LocationData location) {
+        this.location = location;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsData.java
@@ -1,0 +1,17 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+import org.opennms.horizon.it.gqlmodels.MinionData;
+
+import java.util.List;
+
+public class FindAllMinionsData {
+    private List<MinionData> findAllMinions;
+
+    public List<MinionData> getFindAllMinions() {
+        return findAllMinions;
+    }
+
+    public void setFindAllMinions(List<MinionData> findAllMinions) {
+        this.findAllMinions = findAllMinions;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsQueryResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/FindAllMinionsQueryResult.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+public class FindAllMinionsQueryResult {
+    private FindAllMinionsData data;
+
+    public FindAllMinionsData getData() {
+        return data;
+    }
+
+    public void setData(FindAllMinionsData data) {
+        this.data = data;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryData.java
@@ -1,0 +1,15 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+import org.opennms.horizon.it.gqlmodels.tsdata.TimeSeriesQueryResult;
+
+public class MetricQueryData {
+    private TimeSeriesQueryResult metric;
+
+    public TimeSeriesQueryResult getMetric() {
+        return metric;
+    }
+
+    public void setMetric(TimeSeriesQueryResult metric) {
+        this.metric = metric;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/querywrappers/MetricQueryResult.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.it.gqlmodels.querywrappers;
+
+public class MetricQueryResult {
+    private MetricQueryData data;
+
+    public MetricQueryData getData() {
+        return data;
+    }
+
+    public void setData(MetricQueryData data) {
+        this.data = data;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSData.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSData.java
@@ -1,0 +1,24 @@
+package org.opennms.horizon.it.gqlmodels.tsdata;
+
+import java.util.List;
+
+public class TSData {
+    private String resultType;
+    private List<TSResult> result;
+
+    public String getResultType() {
+        return resultType;
+    }
+
+    public void setResultType(String resultType) {
+        this.resultType = resultType;
+    }
+
+    public List<TSResult> getResult() {
+        return result;
+    }
+
+    public void setResult(List<TSResult> result) {
+        this.result = result;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TSResult.java
@@ -1,0 +1,34 @@
+package org.opennms.horizon.it.gqlmodels.tsdata;
+
+import java.util.List;
+import java.util.Map;
+
+public class TSResult {
+    private Map<String, String> metric;
+    private List<Double> value;
+    private List<List<Double>> values;
+
+    public Map<String, String> getMetric() {
+        return metric;
+    }
+
+    public void setMetric(Map<String, String> metric) {
+        this.metric = metric;
+    }
+
+    public List<Double> getValue() {
+        return value;
+    }
+
+    public void setValue(List<Double> value) {
+        this.value = value;
+    }
+
+    public List<List<Double>> getValues() {
+        return values;
+    }
+
+    public void setValues(List<List<Double>> values) {
+        this.values = values;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TimeSeriesQueryResult.java
+++ b/external-it/external-horizon-stream-it/src/main/java/org/opennms/horizon/it/gqlmodels/tsdata/TimeSeriesQueryResult.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.it.gqlmodels.tsdata;
+
+public class TimeSeriesQueryResult {
+    private String status;
+    private TSData data;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public TSData getData() {
+        return data;
+    }
+
+    public void setData(TSData data) {
+        this.data = data;
+    }
+}

--- a/external-it/external-horizon-stream-it/src/main/resources/org/opennms/horizon/it/horizon-stream.feature
+++ b/external-it/external-horizon-stream-it/src/main/resources/org/opennms/horizon/it/horizon-stream.feature
@@ -1,4 +1,22 @@
-Feature: Hello World
+Feature: Minion Monitoring via Echo Messages Logged in Prometheus
 
-  Scenario: Say Hello
-    Then Say "Hello World"
+  Background: Login to Keycloak
+    Given Ingress base url in environment variable "INGRESS_BASE_URL"
+    Given Keycloak server base url in environment variable "KEYCLOAK_BASE_URL"
+    Given Keycloak realm in environment variable "KEYCLOAK_REALM"
+    Given Keycloak username in environment variable "KEYCLOAK_USERNAME"
+    Given Keycloak password in environment variable "KEYCLOAK_PASSWORD"
+    Given Keycloak client-id in environment variable "KEYCLOAK_CLIENT_ID"
+    Then login to Keycloak with timeout 120000ms
+
+  Scenario: Wait for at least one minion to connect from location Default
+    Given At least one Minion is running with location "Default"
+    # NOTE: there is redundant processing between this step and the ones that follow it
+    Then Wait for at least one minion for the given location reported by inventory with timeout 600000ms
+
+  Scenario: Verify Minion echo measurements are recorded into prometheus for a running Minion
+    Given At least one Minion is running with location "Default"
+    Then Read the list of connected Minions from the BFF
+    Then Find the minions running in the given location
+    Then Verify at least one minion was found for the location
+    Then Read the "response_time_msec" from Prometheus with label "system_id" set to the Minion System ID for each Minion found with timeout 120000ms

--- a/install-local/install-local.sh
+++ b/install-local/install-local.sh
@@ -3,6 +3,8 @@
 
 set -e
 
+LOCAL_DOCKER_CONFIG_JSON="${HOME}/.docker/config.json"
+
 #### ENV VARS
 ################################
 
@@ -46,6 +48,16 @@ cluster_ready_check () {
 
 }
 
+cluster_install_kubelet_config() {
+  # Copy the docker config.json file into the kind-control-plane container
+  if [ -f "${LOCAL_DOCKER_CONFIG_JSON}" ]
+  then
+    docker cp "${LOCAL_DOCKER_CONFIG_JSON}" "${KIND_CLUSTER_NAME}-control-plane:/var/lib/kubelet/config.json"
+  else
+    echo "NO ${HOME}/.docker/config.json: not configuring kind for external docker registry access"
+  fi
+}
+
 create_ssl_cert_secret () {
 
   # Create SSL Certificate
@@ -60,20 +72,80 @@ create_ssl_cert_secret () {
 
 }
 
-load_images () {
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-alarm:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-datachoices:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-events:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-grafana:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-inventory:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-keycloak:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-metrics-processor:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-minion:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-minion-gateway:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-minion-gateway-grpc-proxy:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-notification:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-rest-server:${IMAGE_TAG} &
-    kind load docker-image --name $KIND_CLUSTER_NAME ${IMAGE_PREFIX}/horizon-stream-ui:${IMAGE_TAG} &
+# WHEN kind fixes the bug, https://github.com/kubernetes-sigs/kind/issues/3063,
+# THEN changing this to load multiple images in a single command can save a huge amount of data transfer and time
+load_images_to_kind_using_slow_kind () {
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-alarm:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-datachoices:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-events:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-grafana:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-inventory:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-keycloak:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-metrics-processor:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-minion:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-minion-gateway:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-minion-gateway-grpc-proxy:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-notification:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-rest-server:${IMAGE_TAG}" &
+    kind load docker-image --name "$KIND_CLUSTER_NAME" "${IMAGE_PREFIX}/horizon-stream-ui:${IMAGE_TAG}" &
+}
+
+pull_docker_images () {
+	for image in \
+		"${IMAGE_PREFIX}/horizon-stream-alarm:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-datachoices:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-events:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-grafana:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-inventory:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-keycloak:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-metrics-processor:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-minion-gateway-grpc-proxy:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-minion-gateway:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-minion:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-notification:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-rest-server:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-ui:${IMAGE_TAG}"
+	do
+		if docker inspect "${image}" >/dev/null
+		then
+			echo "Already have ${image} locally"
+		else
+			docker pull "${image}"
+		fi
+	done
+}
+
+save_part_of_normal_docker_image_load () {
+	docker save \
+		"${IMAGE_PREFIX}/horizon-stream-alarm:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-datachoices:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-events:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-grafana:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-inventory:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-keycloak:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-metrics-processor:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-minion-gateway-grpc-proxy:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-minion-gateway:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-minion:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-notification:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-rest-server:${IMAGE_TAG}" \
+		"${IMAGE_PREFIX}/horizon-stream-ui:${IMAGE_TAG}"
+}
+
+load_part_of_normal_docker_image_load () {
+	docker exec -i "${KIND_CLUSTER_NAME}-control-plane" ctr --namespace="${NAMESPACE}" images import --snapshotter overlayfs -
+}
+
+load_images_to_kind_using_normal_docker () {
+	# Pull the images in case they are not yet available locally
+	pull_docker_images
+
+	### DEBUGGING
+	echo =====
+	docker images || crictl images || true
+	echo =====
+
+	save_part_of_normal_docker_image_load | load_part_of_normal_docker_image_load
 }
 
 install_helm_chart_custom_images () {
@@ -87,9 +159,9 @@ install_helm_chart_custom_images () {
   --set OpenNMS.Alarm.Image=${IMAGE_PREFIX}/horizon-stream-alarm:${IMAGE_TAG} \
   --set OpenNMS.DataChoices.Image=${IMAGE_PREFIX}/horizon-stream-datachoices:${IMAGE_TAG} \
   --set OpenNMS.Events.Image=${IMAGE_PREFIX}/horizon-stream-events:${IMAGE_TAG} \
-  --set Grafana.Image=${IMAGE_PREFIX}/horizon-stream-grafana-dev:${IMAGE_TAG} \
+  --set Grafana.Image=${IMAGE_PREFIX}/horizon-stream-grafana:${IMAGE_TAG} \
   --set OpenNMS.Inventory.Image=${IMAGE_PREFIX}/horizon-stream-inventory:${IMAGE_TAG} \
-  --set Keycloak.Image=${IMAGE_PREFIX}/horizon-stream-keycloak-dev:${IMAGE_TAG} \
+  --set Keycloak.Image=${IMAGE_PREFIX}/horizon-stream-keycloak:${IMAGE_TAG} \
   --set OpenNMS.MetricsProcessor.Image=${IMAGE_PREFIX}/horizon-stream-metrics-processor:${IMAGE_TAG} \
   --set OpenNMS.Minion.Image=${IMAGE_PREFIX}/horizon-stream-minion:${IMAGE_TAG} \
   --set OpenNMS.MinionGateway.Image=${IMAGE_PREFIX}/horizon-stream-minion-gateway:${IMAGE_TAG} \
@@ -101,6 +173,16 @@ install_helm_chart_custom_images () {
 
 #### MAIN
 ################################
+
+# LOG some useful info
+
+echo "STARTUP CONFIG"
+echo "CONTEXT=${CONTEXT}"
+echo "DOMAIN=${DOMAIN}"
+echo "IMAGE_TAG=${IMAGE_TAG}"
+echo "IMAGE_PREFIX=${IMAGE_PREFIX}"
+echo "KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME}"
+echo "NAMESPACE=${NAMESPACE}"
 
 # Swap Domain in YAML files
 mkdir -p tmp
@@ -114,6 +196,7 @@ cat install-local-opennms-horizon-stream-custom-images-values.yaml | sed "s/onms
 if [ $CONTEXT == "local" ]; then
 
   create_cluster
+  cluster_install_kubelet_config
 
   echo
   echo ________________Installing Horizon Stream________________
@@ -127,11 +210,14 @@ if [ $CONTEXT == "local" ]; then
 elif [ "$CONTEXT" == "custom-images" ]; then
 
   create_cluster
+  cluster_install_kubelet_config
 
-  load_images
+  # Will add a kind-registry here at some point, see .github/ for sample script.
+  echo "START LOADING IMAGES INTO KIND AT $(date)"
 
-  # Need to wait for the images to be loaded.
-  sleep 120
+  time load_images_to_kind_using_normal_docker
+
+  echo "FINISHED LOADING IMAGES INTO KIND AT $(date)"
 
   install_helm_chart_custom_images
 
@@ -143,6 +229,7 @@ elif [ "$CONTEXT" == "custom-images" ]; then
 elif [ "$CONTEXT" == "cicd" ]; then
 
   create_cluster
+  cluster_install_kubelet_config
 
   # assumes remote docker registry, no need to load images into cluster
   install_helm_chart_custom_images

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -43,7 +43,6 @@
         Main executable for the Minion Gateway gRPC Proxy.
     </description>
 
-
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/minion-gateway/docker-it/src/test/java/org/opennms/horizon/kafkahelper/internals/KafkaProcessor.java
+++ b/minion-gateway/docker-it/src/test/java/org/opennms/horizon/kafkahelper/internals/KafkaProcessor.java
@@ -69,7 +69,23 @@ public class KafkaProcessor<K,V> implements Runnable {
                 }
             } catch (Exception exc) {
                 LOG.error("Error reading records from kafka", exc);
+
+                // Add a delay between iterations to reduce spamming the logs when consumer.poll() fails immediately,
+                //  such as at startup when Kafka is not yet fully started.
+                delay();
             }
+        }
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private void delay() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException interruptedException) {
+            LOG.debug("delay interrupted", interruptedException);
         }
     }
 }

--- a/minion-gateway/docker-it/src/test/java/org/opennms/horizon/testcontainers/TestContainerRunnerClassRule.java
+++ b/minion-gateway/docker-it/src/test/java/org/opennms/horizon/testcontainers/TestContainerRunnerClassRule.java
@@ -53,14 +53,12 @@ public class TestContainerRunnerClassRule extends ExternalResource {
     private String confluentPlatformVersion = "7.3.0";
 
     private KafkaContainer kafkaContainer;
-    private GenericContainer zookeeperContainer;
     private GenericContainer applicationContainer;
 
     private Network network;
 
     public TestContainerRunnerClassRule() {
         kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka").withTag(confluentPlatformVersion));
-        zookeeperContainer = new GenericContainer(DockerImageName.parse("confluentinc/cp-zookeeper").withTag(confluentPlatformVersion));
         applicationContainer = new GenericContainer(DockerImageName.parse(dockerImage).toString());
     }
 
@@ -72,7 +70,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
 
         LOG.info("USING TEST DOCKER NETWORK {}", network.getId());
 
-        startZookeeperContainer();
         startKafkaContainer();
         startApplicationContainer();
     }
@@ -81,31 +78,17 @@ public class TestContainerRunnerClassRule extends ExternalResource {
     protected void after() {
         applicationContainer.stop();
         kafkaContainer.stop();
-        zookeeperContainer.stop();
     }
 
 //========================================
 // Container Startups
 //----------------------------------------
 
-    private void startZookeeperContainer() {
-
-        zookeeperContainer
-            .withNetwork(network)
-            .withNetworkAliases("zookeeper")
-            .withEnv("ZOOKEEPER_CLIENT_PORT", String.valueOf(KafkaContainer.ZOOKEEPER_PORT))
-            .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("ZOOKEEPER"))
-        ;
-
-    }
-
     private void startKafkaContainer() {
         kafkaContainer
             .withEmbeddedZookeeper()
             .withNetwork(network)
             .withNetworkAliases("kafka", "kafka-host")
-            .dependsOn(zookeeperContainer)
-            .withExternalZookeeper("zookeeper:" + KafkaContainer.ZOOKEEPER_PORT)
             .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("KAFKA"))
             .start();
         ;
@@ -119,7 +102,6 @@ public class TestContainerRunnerClassRule extends ExternalResource {
         applicationContainer
             .withNetwork(network)
             .withNetworkAliases("application", "application-host")
-            .dependsOn(zookeeperContainer, kafkaContainer)
             .withExposedPorts(8080, 8990, 8991, 5005)
             .withStartupTimeout(Duration.ofMinutes(5))
             .withEnv("JAVA_TOOL_OPTIONS", "-Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005")

--- a/tools/KC.login
+++ b/tools/KC.login
@@ -13,12 +13,12 @@
 ##
 ########################################################################################################################
 
-HOST_PORT=localhost:9000
+HOST_PORT=localhost:8123
 REALM=opennms
 CLIENT_ID=admin-cli
 USERNAME=admin
 PASSWORD=admin
-CONTEXT=""
+CONTEXT="auth/"
 
 usage()
 {


### PR DESCRIPTION
…least 1 minion in location Default.

- Update version of Awaitility so failure exceptions are logged on timeout.
- Use "docker save" + "docker load" to load images into the kind cluster instead of "kind load" (see kind github issue re: images loading multiple times)
- IT: Alarms - increase timeout of startup.  Minion-Gateway and Alarms, use embedded zookeeper for Kafka instead of external one.
- IT: Add a delay on kafka consumer exceptions to limit the noise during startup while Kafka is not yet available.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
