### PR TITLE
HS-836: Use new Monitor Type AZURE in Monitor and Collector

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
@@ -66,7 +66,7 @@ public class ScannerResponseService {
 
             // other scan types
 
-            case AZURE: {
+            case AZURE_SCAN -> {
                 AzureScanResponse azureResponse = result.unpack(AzureScanResponse.class);
                 List<AzureScanItem> resultsList = azureResponse.getResultsList();
 
@@ -80,18 +80,15 @@ public class ScannerResponseService {
 
                     processAzureScanItem(tenantId, location, ipAddress, item);
                 }
-                break;
             }
-            case UNRECOGNIZED: {
-                log.warn("Unrecognized scan type");
-            }
+            case UNRECOGNIZED -> log.warn("Unrecognized scan type");
         }
     }
 
     private ScanType getType(ScannerResponse response) {
         Any result = response.getResult();
         if (result.is(AzureScanResponse.class)) {
-            return ScanType.AZURE;
+            return ScanType.AZURE_SCAN;
         }
         return ScanType.UNRECOGNIZED;
     }

--- a/metrics-processor/main-metrics/src/test/java/org/opennms/horizon/tsdata/TSDataProcessorTest.java
+++ b/metrics-processor/main-metrics/src/test/java/org/opennms/horizon/tsdata/TSDataProcessorTest.java
@@ -1,0 +1,77 @@
+package org.opennms.horizon.tsdata;
+
+import com.google.protobuf.Any;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opennms.horizon.azure.api.AzureResponseMetric;
+import org.opennms.horizon.azure.api.AzureResultMetric;
+import org.opennms.horizon.azure.api.AzureValueMetric;
+import org.opennms.horizon.azure.api.AzureValueType;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+import org.opennms.horizon.timeseries.cortex.CortexTSS;
+import org.opennms.taskset.contract.CollectorResponse;
+import org.opennms.taskset.contract.MonitorType;
+import org.opennms.taskset.contract.TaskResult;
+import org.opennms.taskset.contract.TaskSetResults;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TSDataProcessorTest {
+
+    @Mock
+    private CortexTSS cortexTSS;
+
+    @InjectMocks
+    private TSDataProcessor processor;
+
+    @Test
+    void testConsumeAzure() throws Exception {
+
+        List<TaskResult> taskResultList = new ArrayList<>();
+
+        List<AzureResultMetric> azureResultMetrics = new ArrayList<>();
+        azureResultMetrics.add(AzureResultMetric.newBuilder()
+            .setResourceName("resource-name")
+            .setResourceGroup("resource-group")
+            .setAlias("netInBytes")
+            .setValue(AzureValueMetric.newBuilder()
+                .setType(AzureValueType.INT64)
+                .setUint64(1234L)
+                .build())
+            .build());
+
+        CollectorResponse collectorResponse = CollectorResponse.newBuilder()
+            .setResult(Any.pack(AzureResponseMetric.newBuilder()
+                .addAllResults(azureResultMetrics)
+                .build()))
+            .setMonitorType(MonitorType.AZURE)
+            .build();
+        taskResultList.add(TaskResult.newBuilder()
+            .setCollectorResponse(collectorResponse)
+            .build());
+
+        TaskSetResults taskSetResults = TaskSetResults.newBuilder()
+            .addAllResults(taskResultList)
+            .build();
+
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(GrpcConstants.TENANT_ID_KEY, "opennms-prime");
+
+        processor.consume(taskSetResults.toByteArray(), headers);
+
+        verify(cortexTSS, timeout(5000).only()).store(anyString(), any(prometheus.PrometheusTypes.TimeSeries.Builder.class));
+
+    }
+}

--- a/metrics-processor/timeseries/pom.xml
+++ b/metrics-processor/timeseries/pom.xml
@@ -42,6 +42,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.opennms.horizon.shared.azure</groupId>
+            <artifactId>proto</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>${snappy-java.version}</version>

--- a/minion/plugins/azure-plugin/src/main/java/org/opennms/horizon/minion/azure/AzureMonitor.java
+++ b/minion/plugins/azure-plugin/src/main/java/org/opennms/horizon/minion/azure/AzureMonitor.java
@@ -76,7 +76,7 @@ public class AzureMonitor extends AbstractServiceMonitor {
 
                 future.complete(
                     ServiceMonitorResponseImpl.builder()
-                        .monitorType(MonitorType.ICMP) // HACK: using ICMP because the UI makes a query with ICMP for status
+                        .monitorType(MonitorType.AZURE)
                         .status(ServiceMonitorResponse.Status.Up)
                         .responseTime(System.currentTimeMillis() - startMs)
                         .nodeId(svc.getNodeId())
@@ -86,7 +86,7 @@ public class AzureMonitor extends AbstractServiceMonitor {
             } else {
                 future.complete(
                     ServiceMonitorResponseImpl.builder()
-                        .monitorType(MonitorType.ICMP)
+                        .monitorType(MonitorType.AZURE)
                         .status(ServiceMonitorResponse.Status.Down)
                         .nodeId(svc.getNodeId())
                         .ipAddress(request.getHost())
@@ -99,7 +99,7 @@ public class AzureMonitor extends AbstractServiceMonitor {
             future.complete(
                 ServiceMonitorResponseImpl.builder()
                     .reason("Failed to monitor for azure resource: " + e.getMessage())
-                    .monitorType(MonitorType.ICMP)
+                    .monitorType(MonitorType.AZURE)
                     .status(ServiceMonitorResponse.Status.Down)
                     .nodeId(svc.getNodeId())
                     .build()

--- a/minion/plugins/azure-plugin/src/main/java/org/opennms/horizon/minion/azure/AzureScanner.java
+++ b/minion/plugins/azure-plugin/src/main/java/org/opennms/horizon/minion/azure/AzureScanner.java
@@ -46,7 +46,6 @@ import org.slf4j.LoggerFactory;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 public class AzureScanner implements Scanner {
     private static final Logger log = LoggerFactory.getLogger(AzureScanner.class);
@@ -92,7 +91,7 @@ public class AzureScanner implements Scanner {
                         .setResourceGroup(resourceGroup)
                         .setCredentialId(request.getCredentialId())
                         .build())
-                    .collect(Collectors.toList()));
+                    .toList());
             }
 
             future.complete(

--- a/shared-lib/azure/proto/src/main/proto/azure-api.proto
+++ b/shared-lib/azure/proto/src/main/proto/azure-api.proto
@@ -43,3 +43,25 @@ message AzureScanItem {
   string resourceGroup = 3;
   int64 credential_id = 4;
 }
+
+message AzureResponseMetric {
+  repeated AzureResultMetric results = 2;
+}
+
+enum AzureValueType {
+  INT64 = 0;
+}
+
+message AzureValueMetric {
+  AzureValueType type = 1;
+  oneof value {
+    uint64 uint64 = 2;
+  };
+}
+
+message AzureResultMetric {
+  string resourceName = 1;
+  string resourceGroup = 2;
+  AzureValueMetric value = 3;
+  string alias = 4;
+}

--- a/shared-lib/protobuf/src/main/proto/taskSet.proto
+++ b/shared-lib/protobuf/src/main/proto/taskSet.proto
@@ -51,7 +51,7 @@ enum TaskType {
 
 
 enum ScanType {
-  AZURE = 0;
+  AZURE_SCAN = 0;
   NODE_SCAN = 1;
 }
 
@@ -60,6 +60,7 @@ enum MonitorType {
   ICMP = 1;
   SNMP = 2;
   ECHO = 3;
+  AZURE = 4;
 }
 
 message TaskDefinition {


### PR DESCRIPTION
## Description
REQUEST:

```
GET /prometheus/api/v1/query?query=ifOutOctets{instance="127.0.0.2", monitor="AZURE", node_id="2"}[1000s]
X-Scope-OrgID: opennms-prime
```

RESPONSE:

```
{
    "status": "success",
    "data": {
        "resultType": "matrix",
        "result": [
            {
                "metric": {
                    "__name__": "ifOutOctets",
                    "instance": "127.0.0.2",
                    "location": "Default",
                    "monitor": "AZURE",
                    "node_id": "2",
                    "system_id": "opennms-minion-5885b9df75-hf5kn"
                },
                "values": [
                    [
                        1674221552.342,
                        "123605"
                    ]
                ]
            }
        ]
    }
}
```

## Jira link(s)
- https://issues.opennms.org/browse/HS-836

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
