### PR TITLE
HS-878: Return more descriptive error messages on azure credential cr…

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/AzureCredentialService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/AzureCredentialService.java
@@ -41,6 +41,7 @@ import org.opennms.horizon.inventory.service.taskset.ScannerTaskSetService;
 import org.opennms.horizon.inventory.service.taskset.TaskUtils;
 import org.opennms.horizon.shared.azure.http.AzureHttpClient;
 import org.opennms.horizon.shared.azure.http.AzureHttpException;
+import org.opennms.horizon.shared.azure.http.dto.error.AzureErrorDescription;
 import org.opennms.horizon.shared.azure.http.dto.login.AzureOAuthToken;
 import org.opennms.horizon.shared.azure.http.dto.subscription.AzureSubscription;
 import org.opennms.horizon.shared.constants.GrpcConstants;
@@ -84,13 +85,21 @@ public class AzureCredentialService {
             token = client.login(request.getDirectoryId(), request.getClientId(),
                 request.getClientSecret(), TaskUtils.AZURE_DEFAULT_TIMEOUT_MS, TaskUtils.AZURE_DEFAULT_RETRIES);
         } catch (AzureHttpException e) {
+            if (e.hasDescription()) {
+                AzureErrorDescription description = e.getDescription();
+                throw new InventoryRuntimeException(description.toString(), e);
+            }
             throw new InventoryRuntimeException("Failed to login with azure credentials", e);
         }
         AzureSubscription subscription;
         try {
-           subscription = client.getSubscription(token, request.getSubscriptionId(),
-               TaskUtils.AZURE_DEFAULT_TIMEOUT_MS, TaskUtils.AZURE_DEFAULT_RETRIES);
+            subscription = client.getSubscription(token, request.getSubscriptionId(),
+                TaskUtils.AZURE_DEFAULT_TIMEOUT_MS, TaskUtils.AZURE_DEFAULT_RETRIES);
         } catch (AzureHttpException e) {
+            if (e.hasDescription()) {
+                AzureErrorDescription description = e.getDescription();
+                throw new InventoryRuntimeException(description.toString(), e);
+            }
             String message = String.format("Failed to get azure subscription %s", request.getSubscriptionId());
             throw new InventoryRuntimeException(message, e);
         }

--- a/shared-lib/azure/azure-http/src/main/java/org/opennms/horizon/shared/azure/http/AzureHttpException.java
+++ b/shared-lib/azure/azure-http/src/main/java/org/opennms/horizon/shared/azure/http/AzureHttpException.java
@@ -28,13 +28,29 @@
 
 package org.opennms.horizon.shared.azure.http;
 
+import lombok.Getter;
+import org.opennms.horizon.shared.azure.http.dto.error.AzureErrorDescription;
+
+@Getter
 public class AzureHttpException extends Exception {
+    private final transient AzureErrorDescription description;
+
+    public AzureHttpException(String message, AzureErrorDescription description) {
+        super(message);
+        this.description = description;
+    }
 
     public AzureHttpException(String message) {
         super(message);
+        this.description = null;
     }
 
     public AzureHttpException(String message, Throwable t) {
         super(message, t);
+        this.description = null;
+    }
+
+    public boolean hasDescription() {
+        return this.description != null;
     }
 }

--- a/shared-lib/azure/azure-http/src/main/java/org/opennms/horizon/shared/azure/http/dto/error/AzureErrorDescription.java
+++ b/shared-lib/azure/azure-http/src/main/java/org/opennms/horizon/shared/azure/http/dto/error/AzureErrorDescription.java
@@ -1,0 +1,20 @@
+package org.opennms.horizon.shared.azure.http.dto.error;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AzureErrorDescription {
+
+    @SerializedName("code")
+    private String code;
+    @SerializedName("message")
+    private String message;
+
+    @Override
+    public String toString() {
+        return String.format("%s: %s", code, message);
+    }
+}

--- a/shared-lib/azure/azure-http/src/main/java/org/opennms/horizon/shared/azure/http/dto/error/AzureHttpError.java
+++ b/shared-lib/azure/azure-http/src/main/java/org/opennms/horizon/shared/azure/http/dto/error/AzureHttpError.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.shared.azure.http.dto.error;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AzureHttpError {
+
+    @SerializedName("error")
+    private AzureErrorDescription error;
+}


### PR DESCRIPTION
…eate


## Description

As part of feedback, we want to raise the actual issue better to the user

![image](https://user-images.githubusercontent.com/8379423/214366744-7a4867a5-d7a6-462e-9b2c-cb1e60785b5b.png)

## Jira link(s)
- https://issues.opennms.org/browse/HS-878

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
