### PR TITLE
HS-870: Use JPA instead of jdbcTemplate for notifications

### DIFF
--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -174,11 +174,6 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-admin-client</artifactId>
-            <version>${keycloak.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
             <version>${keycloak.version}</version>
         </dependency>
@@ -188,14 +183,42 @@
             <version>${keycloak.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>3.13.2.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>${lombok.binding.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>${jakarta.validation.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
         </dependency>
 
         <!-- test-->
@@ -245,11 +268,35 @@
             <version>2.1.212</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
 	<build>
 		<plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.9.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>${lombok.binding.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                </configuration>
+            </plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/notifications/src/main/java/org/opennms/horizon/notifications/mapper/PagerDutyConfigMapper.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/mapper/PagerDutyConfigMapper.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.mapper;
+
+
+import org.mapstruct.Mapper;
+import org.opennms.horizon.notifications.dto.PagerDutyConfigDTO;
+import org.opennms.horizon.notifications.model.PagerDutyConfig;
+
+@Mapper(componentModel = "spring")
+public interface PagerDutyConfigMapper {
+    PagerDutyConfig dtoToModel(PagerDutyConfigDTO dto);
+
+    PagerDutyConfigDTO modelToDTO(PagerDutyConfig model);
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/model/PagerDutyConfig.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/model/PagerDutyConfig.java
@@ -1,0 +1,25 @@
+package org.opennms.horizon.notifications.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@Entity
+public class PagerDutyConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotNull
+    @Column(name = "integrationkey")
+    private String integrationKey;
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/repository/PagerDutyConfigRepository.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/repository/PagerDutyConfigRepository.java
@@ -1,0 +1,9 @@
+package org.opennms.horizon.notifications.repository;
+
+import org.opennms.horizon.notifications.model.PagerDutyConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PagerDutyConfigRepository extends JpaRepository<PagerDutyConfig, Long> {
+}

--- a/notifications/src/main/resources/application.yml
+++ b/notifications/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
   liquibase:
     change-log: db/changelog/changelog.xml
 
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
 grpc:
   server:
     port: 6565

--- a/notifications/src/main/resources/db/changelog/changelog.xml
+++ b/notifications/src/main/resources/db/changelog/changelog.xml
@@ -6,6 +6,7 @@
 
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-	<include file="db/changelog/hs-0.1.0/tables/pagerDutyConfig.xml" />
+    <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfig.xml" />
+    <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfigUpdate.xml" />
 
 </databaseChangeLog>

--- a/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyConfigUpdate.xml
+++ b/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyConfigUpdate.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ 
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+	<changeSet author="jhutc" id="pager_duty_config_update">
+		<validCheckSum>ANY</validCheckSum>
+		<preConditions onFail="MARK_RAN">
+			<tableExists tableName="pager_duty_config" />
+		</preConditions> 
+
+		<addColumn tableName="pager_duty_config">
+            <column name="id" type="BIGINT" autoIncrement="true"/>
+		</addColumn>
+
+        <addPrimaryKey tableName="pager_duty_config" columnNames="id"
+                       constraintName="pk_pager_duty_config_id"/>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyAPIImplTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyAPIImplTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opennms.horizon.notifications.dto.PagerDutyConfigDTO;
+import org.opennms.horizon.notifications.repository.PagerDutyConfigRepository;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 import org.opennms.horizon.shared.dto.event.EventDTO;
 import org.opennms.horizon.shared.dto.event.EventParameterDTO;

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -60,6 +60,7 @@
         <jaeger.version>0.34.0</jaeger.version>
         <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <jakarta.activation.version>2.1.1</jakarta.activation.version>
+        <jakarta.validation.version>3.0.2</jakarta.validation.version>
         <jakarta.xml.version>4.0.0</jakarta.xml.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>


### PR DESCRIPTION
## Description
Use JPA instead of jdbcTemplate as that's what the rest of the application is using

## Jira link(s)
- https://issues.opennms.org/browse/HS-870

## Flagged for review
n/a

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
