### PR TITLE
HS-903: Use correct port number for notifications grpc

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -113,7 +113,7 @@ jib_project(
     'opennms/horizon-stream-notification',
     'notifications',
     'opennms-notifications',
-    port_forwards=['31065:6565', '15050:5005'],
+    port_forwards=['15065:6565', '15050:5005'],
 )
 
 ### Vue.js App ###

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -28,6 +28,6 @@ grpc:
   url:
     inventory: localhost:29065
     events: localhost:30065
-    notification: localhost:31065
+    notification: localhost:15065
   server:
     deadline: 60000

--- a/rest-server/src/test/resources/application.yml
+++ b/rest-server/src/test/resources/application.yml
@@ -9,4 +9,4 @@ grpc:
   url:
     inventory: localhost:29065
     events: localhost:30065
-    notification: localhost:31065
+    notification: localhost:15065


### PR DESCRIPTION
## Description
Was using incorrect port number according to our conventions

## Jira link(s)
- https://issues.opennms.org/browse/HS-903

## Flagged for review
n/a

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
