### PR TITLE
HS-895: add tenant id to notifications

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/grpc/config/TenantIdentifierResolver.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/grpc/config/TenantIdentifierResolver.java
@@ -1,0 +1,45 @@
+package org.opennms.horizon.notifications.grpc.config;
+
+import io.grpc.Context;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+class TenantIdentifierResolver implements CurrentTenantIdentifierResolver, HibernatePropertiesCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(TenantIdentifierResolver.class);
+    private static final String DEFAULT_TENANT_ID = "opennms-prime";
+
+    @Autowired
+    TenantLookup tenantLookup;
+
+    @Override
+    public String resolveCurrentTenantIdentifier() {
+        Optional<String> tenantId = tenantLookup.lookupTenantId(Context.current());
+        if (tenantId.isPresent()) {
+            return tenantId.get();
+        } else {
+            // Much as I think we should possibly throw an exception here, the internet says we should provide a default value.
+            // Attempting to throw an exception results in a failure during spring initialization.
+            LOG.warn("No tenant ID present");
+            return DEFAULT_TENANT_ID;
+        }
+    }
+
+    @Override
+    public boolean validateExistingCurrentSessions() {
+        return false;
+    }
+
+    @Override
+    public void customize(Map<String, Object> hibernateProperties) {
+        hibernateProperties.put(AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER, this);
+    }
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/grpc/config/TenantIdentifierResolver.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/grpc/config/TenantIdentifierResolver.java
@@ -1,8 +1,37 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.horizon.notifications.grpc.config;
 
 import io.grpc.Context;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +44,6 @@ import java.util.Optional;
 @Component
 class TenantIdentifierResolver implements CurrentTenantIdentifierResolver, HibernatePropertiesCustomizer {
     private static final Logger LOG = LoggerFactory.getLogger(TenantIdentifierResolver.class);
-    private static final String DEFAULT_TENANT_ID = "opennms-prime";
 
     @Autowired
     TenantLookup tenantLookup;
@@ -29,7 +57,7 @@ class TenantIdentifierResolver implements CurrentTenantIdentifierResolver, Hiber
             // Much as I think we should possibly throw an exception here, the internet says we should provide a default value.
             // Attempting to throw an exception results in a failure during spring initialization.
             LOG.warn("No tenant ID present");
-            return DEFAULT_TENANT_ID;
+            return GrpcConstants.DEFAULT_TENANT_ID;
         }
     }
 

--- a/notifications/src/main/java/org/opennms/horizon/notifications/model/PagerDutyConfig.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/model/PagerDutyConfig.java
@@ -9,12 +9,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.TenantId;
 
 @Getter
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class PagerDutyConfig {
+public class PagerDutyConfig extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;

--- a/notifications/src/main/java/org/opennms/horizon/notifications/model/TenantAwareEntity.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/model/TenantAwareEntity.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.TenantId;
+
+@Getter
+@Setter
+@MappedSuperclass
+public abstract class TenantAwareEntity {
+    @TenantId
+    @Column(name = "tenant_id")
+    private String tenantId;
+}

--- a/notifications/src/main/resources/db/changelog/changelog.xml
+++ b/notifications/src/main/resources/db/changelog/changelog.xml
@@ -8,5 +8,6 @@
 
     <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfig.xml" />
     <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfigUpdate.xml" />
+    <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfigTenantUpdate.xml" />
 
 </databaseChangeLog>

--- a/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyConfigTenantUpdate.xml
+++ b/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyConfigTenantUpdate.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ 
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+	<changeSet author="jhutc" id="pager_duty_config_tenant_update">
+		<validCheckSum>ANY</validCheckSum>
+		<preConditions onFail="MARK_RAN">
+			<tableExists tableName="pager_duty_config" />
+		</preConditions> 
+
+		<addColumn tableName="pager_duty_config">
+            <column name="tenant_id" type="text" defaultValue="opennms-prime">
+                <constraints nullable="false"/>
+            </column>
+		</addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/notifications/src/test/java/org/opennms/horizon/notifications/GrpcTestBase.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/GrpcTestBase.java
@@ -55,6 +55,7 @@ public abstract class GrpcTestBase {
     }
 
     protected final String tenantId = "test-tenant";
+    protected final String alternativeTenantId = "other-tenant";
     protected final String authHeader = "Bearer esgs12345";
     protected final String headerWithoutTenant = "Bearer esgs12345invalid";
     protected final String differentTenantHeader = "Bearer esgs12345different";
@@ -67,7 +68,7 @@ public abstract class GrpcTestBase {
         channel = ManagedChannelBuilder.forAddress("localhost", 6767)
                 .usePlaintext().build();
         doReturn(Optional.of(tenantId)).when(spyInterceptor).verifyAccessToken(authHeader);
-        doReturn(Optional.of("invalid-tenant")).when(spyInterceptor).verifyAccessToken(differentTenantHeader);
+        doReturn(Optional.of(alternativeTenantId)).when(spyInterceptor).verifyAccessToken(differentTenantHeader);
         doReturn(Optional.empty()).when(spyInterceptor).verifyAccessToken(headerWithoutTenant);
         doThrow(new VerificationException()).when(spyInterceptor).verifyAccessToken(null);
     }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
@@ -3,6 +3,7 @@ package org.opennms.horizon.notifications;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.spring.CucumberContextConfiguration;
+import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -11,8 +12,10 @@ import org.keycloak.common.VerificationException;
 import org.opennms.horizon.notifications.api.PagerDutyDao;
 import org.opennms.horizon.notifications.dto.NotificationServiceGrpc;
 import org.opennms.horizon.notifications.dto.PagerDutyConfigDTO;
+import org.opennms.horizon.notifications.exceptions.NotificationConfigUninitializedException;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.service.NotificationService;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,29 +78,50 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
         serviceStub = NotificationServiceGrpc.newBlockingStub(channel);
     }
 
-    @Given("Integration key set to {string} via grpc")
-    public void setIntegrationKeyGrpc(String key) throws VerificationException {
-        saveConfig(key);
+    @Given("Integration {string} key set to {string} via grpc")
+    public void setIntegrationKeyGrpc(String tenantId, String key) throws VerificationException {
+        saveConfig(tenantId, key);
 
         verify(spyInterceptor).verifyAccessToken(authHeader);
         verify(spyInterceptor).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
 
-    @Given("Integration key set to {string} then {string} via grpc")
-    public void setIntegrationKeyGrpcTwice(String key, String secondKey) throws VerificationException {
-        saveConfig(key);
-        saveConfig(secondKey);
+    @Given("Integration {string} key set to {string} then {string} via grpc")
+    public void setIntegrationKeyGrpcTwice(String tenantId, String key, String secondKey) throws VerificationException {
+        saveConfig(tenantId, key);
+        saveConfig(tenantId, secondKey);
 
         verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
 
-    private void saveConfig(String key) {
+    @Given("Integration {string} then {string} key set to {string} then {string} via grpc")
+    public void setIntegrationKeyGrpcTwiceWithDifferentTenants(String tenantId, String otherTenantId, String key, String secondKey) throws VerificationException {
+        saveConfig(tenantId, key);
+        saveConfig(otherTenantId, secondKey);
+
+        verify(spyInterceptor, times(1)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(1)).verifyAccessToken(differentTenantHeader);
+        verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
+
+    private void saveConfig(String tenantId, String key) {
+        String header = getAuthHeader(tenantId);
         PagerDutyConfigDTO config = PagerDutyConfigDTO.newBuilder().setIntegrationKey(key).build();
 
         serviceStub.withInterceptors(MetadataUtils
-                .newAttachHeadersInterceptor(createAuthHeader(authHeader)))
+                .newAttachHeadersInterceptor(createAuthHeader(header)))
             .postPagerDutyConfig(config);
+    }
+
+    private String getAuthHeader(String tenantId) {
+        if ("test-tenant".equals(tenantId)) {
+            return authHeader;
+        } else if ("other-tenant".equals(tenantId)) {
+            return differentTenantHeader;
+        } else {
+            throw new RuntimeException("Invalid tenant: " + tenantId);
+        }
     }
 
     @Given("Integration key set to {string}")
@@ -121,6 +145,32 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
     public void verifyKey(String key) throws Exception {
         PagerDutyConfigDTO configDTO = pagerDutyDao.getConfig();
         assertEquals(key, configDTO.getIntegrationKey());
+    }
+
+    @Then("verify {string} key is {string}")
+    public void verifyKey(String tenantId, String key) {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            try {
+                PagerDutyConfigDTO configDTO = pagerDutyDao.getConfig();
+                assertEquals(key, configDTO.getIntegrationKey());
+            } catch (NotificationConfigUninitializedException e) {
+                fail("Config is not initialised as expected");
+            }
+        });
+    }
+
+    @Then("verify {string} key is not set")
+    public void verifyKeyIsNotSet(String tenantId) {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            try {
+                pagerDutyDao.getConfig();
+                fail("Config should not be initialised");
+            } catch (NotificationConfigUninitializedException e) {
+                assertEquals("PagerDuty config not initialized. Row count=0", e.getMessage());
+            }
+        });
     }
 
     @Then("verify pager duty rest method is called")

--- a/notifications/src/test/resources/org/opennms/horizon/notifications/notification-grpc-processing.feature
+++ b/notifications/src/test/resources/org/opennms/horizon/notifications/notification-grpc-processing.feature
@@ -5,11 +5,18 @@ Feature: Notification Grpc Processing
     Given grpc setup
 
   Scenario: Populate config via grpc
-    Given Integration key set to "abc" via grpc
-    Then verify key is "abc"
+    Given Integration "test-tenant" key set to "abc" via grpc
+    Then verify "test-tenant" key is "abc"
+    Then verify "other-tenant" key is not set
     Then tear down grpc setup
 
   Scenario: Populate config twice via grpc
-    Given Integration key set to "abc" then "abcd" via grpc
-    Then verify key is "abcd"
+    Given Integration "test-tenant" key set to "abc" then "abcd" via grpc
+    Then verify "test-tenant" key is "abcd"
+    Then tear down grpc setup
+
+  Scenario: Populate two different configs via grpc
+    Given Integration "test-tenant" then "other-tenant" key set to "abc" then "abcd" via grpc
+    Then verify "test-tenant" key is "abc"
+    Then verify "other-tenant" key is "abcd"
     Then tear down grpc setup


### PR DESCRIPTION
## Description
Multi tenancy for notification component

## Jira link(s)
- https://issues.opennms.org/browse/HS-895

## Flagged for review
Uses Hibernate TenantId annotation which does all the work for us.

Question: In TenantIdentifierResolver should we always have a tenant id? I'm guessing we should, but don't want to do a load of rework in the tests if this is not necessary.

After some investigation, it appears we have to provide a default if the there isn't one available.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
