### PR TITLE
HS-957 Replace h2database with hsqldb

### DIFF
--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -263,9 +263,9 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>2.1.212</version>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <version>2.7.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/notifications/src/test/resources/application.yml
+++ b/notifications/src/test/resources/application.yml
@@ -3,8 +3,8 @@ spring:
     name: integration-test
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
+    driver-class-name: org.hsqldb.jdbc.JDBCDriver
+    url: jdbc:hsqldb:mem:db
     username: sa
     password: sa
 


### PR DESCRIPTION
## Description
The h2database dependency causes dependabot's security scanner to rise red flag. Switching it to another embedded database gets backend services clear of major CVEs.

## Jira link(s)
- https://issues.opennms.org/browse/HS-957

## Flagged for review

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
