### PR TITLE
HS-976: Display nodes without IPs on inventory

### DIFF
--- a/ui/src/store/Queries/appliancesQueries.ts
+++ b/ui/src/store/Queries/appliancesQueries.ts
@@ -6,7 +6,6 @@ import {
   ListMinionsAndDevicesForTablesDocument,
   ListMinionMetricsDocument,
   ListNodeMetricsDocument,
-  TsResult,
   Minion,
   Node,
   TimeRangeUnit

--- a/ui/src/store/Queries/inventoryQueries.ts
+++ b/ui/src/store/Queries/inventoryQueries.ts
@@ -48,6 +48,41 @@ export const useInventoryQueries = defineStore('inventoryQueries', () => {
 
     if (allNodes?.length) {
       allNodes.forEach(async ({ id, nodeLabel, location, ipInterfaces }) => {
+
+        // stop-gap measure to display nodes without IP addresses
+        // may be removed once BE disassociates instance with IP
+        if (!ipInterfaces?.[0]?.ipAddress) {
+          nodes.value.push({
+            id: id,
+            label: nodeLabel,
+            status: '',
+            metrics: [
+              {
+                type: 'latency',
+                label: 'Latency',
+                value: 0,
+                status: ''
+              },
+              {
+                type: 'status',
+                label: 'Status',
+                status: 'NO IP'
+              }
+            ],
+            anchor: {
+              profileValue: '--',
+              profileLink: '',
+              locationValue: location?.location || '--',
+              locationLink: '',
+              managementIpValue: '',
+              managementIpLink: '',
+              tagValue: '--',
+              tagLink: ''
+            }
+          })
+          return
+        }
+
         const { data, isFetching } = await fetchNodeMetrics(id, ipInterfaces?.[0].ipAddress as string) // currently only 1 interface per node
 
         if (data.value && !isFetching.value) {


### PR DESCRIPTION
## Description
Display nodes without IPs. Metrics will not work with these nodes until further BE/FE changes.

## Jira link(s)
- https://issues.opennms.org/browse/HS-976

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
