### PR TITLE
HS-993: Remove locations when all monitoring systems are deleted

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/repository/MonitoringSystemRepository.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/repository/MonitoringSystemRepository.java
@@ -1,15 +1,16 @@
 package org.opennms.horizon.inventory.repository;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.opennms.horizon.inventory.model.MonitoringSystem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MonitoringSystemRepository extends JpaRepository<MonitoringSystem, Long> {
     List<MonitoringSystem> findByTenantId(String tenantId);
     Optional<MonitoringSystem> findBySystemId(String systemId);
     Optional<MonitoringSystem> findBySystemIdAndTenantId(String systemId, String tenantId);
+    List<MonitoringSystem> findByMonitoringLocationIdAndTenantId(long locationId, String tenantId);
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/FlowsConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/FlowsConfigService.java
@@ -54,6 +54,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FlowsConfigService {
     private static final Logger LOG = LoggerFactory.getLogger(FlowsConfigService.class);
+    public final static String FLOWS_CONFIG  = "flows-config";
     private final MonitoringLocationService monitoringLocationService;
     private final TaskSetPublisher taskSetPublisher;
 
@@ -79,7 +80,7 @@ public class FlowsConfigService {
 
     private void publishFlowsConfig(String tenantId, String location, FlowsConfig flowsConfig) {
         TaskDefinition taskDefinition = TaskDefinition.newBuilder()
-            .setId(TaskUtils.identityForConfig("flows-config", location))
+            .setId(TaskUtils.identityForConfig(FLOWS_CONFIG, location))
             .setPluginName("flows.parsers.config")
             .setType(TaskType.LISTENER)
             .setConfiguration(Any.pack(flowsConfig))

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
@@ -24,13 +24,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class MonitoringSystemService {
-    private final MonitoringSystemRepository modelRepo;
+    private final MonitoringSystemRepository systemRepository;
     private final MonitoringLocationRepository locationRepository;
     private final MonitoringSystemMapper mapper;
     private final ConfigUpdateService configUpdateService;
 
     public List<MonitoringSystemDTO> findByTenantId(String tenantId) {
-        List<MonitoringSystem> all = modelRepo.findByTenantId(tenantId);
+        List<MonitoringSystem> all = systemRepository.findByTenantId(tenantId);
         return all
             .stream()
             .map(mapper::modelToDTO)
@@ -38,12 +38,12 @@ public class MonitoringSystemService {
     }
 
     public Optional<MonitoringSystemDTO> findBySystemId(String systemId, String tenantId) {
-        return modelRepo.findBySystemIdAndTenantId(systemId, tenantId).map(mapper::modelToDTO);
+        return systemRepository.findBySystemIdAndTenantId(systemId, tenantId).map(mapper::modelToDTO);
     }
 
     public Optional<Long> addMonitoringSystemFromHeartbeat(HeartbeatMessage message, String tenantId) {
         Identity identity = message.getIdentity();
-        Optional<MonitoringSystem> msOp = modelRepo.findBySystemIdAndTenantId(identity.getSystemId(), tenantId);
+        Optional<MonitoringSystem> msOp = systemRepository.findBySystemIdAndTenantId(identity.getSystemId(), tenantId);
         if(msOp.isEmpty()) {
             Optional<MonitoringLocation> locationOp = locationRepository.findByLocationAndTenantId(identity.getLocation(), tenantId);
             MonitoringLocation location = new MonitoringLocation();
@@ -64,12 +64,12 @@ public class MonitoringSystemService {
             monitoringSystem.setLastCheckedIn(LocalDateTime.now());
             monitoringSystem.setLabel(identity.getSystemId().toUpperCase());
             monitoringSystem.setMonitoringLocationId(location.getId());
-            modelRepo.save(monitoringSystem);
+            systemRepository.save(monitoringSystem);
             return Optional.of(monitoringSystem.getId()); //only return new ID
         } else {
             MonitoringSystem monitoringSystem = msOp.get();
             monitoringSystem.setLastCheckedIn(LocalDateTime.now());
-            modelRepo.save(monitoringSystem);
+            systemRepository.save(monitoringSystem);
             return Optional.empty();
         }
 
@@ -79,16 +79,30 @@ public class MonitoringSystemService {
     @Transactional
     public List<MonitoringSystemBean> listAllForMonitoring() {
         List<MonitoringSystemBean> list = new ArrayList<>();
-        modelRepo.findAll().forEach(s->list.add(new MonitoringSystemBean(s.getSystemId(), s.getTenantId(), s.getMonitoringLocation().getLocation())));
+        systemRepository.findAll().forEach(s->list.add(new MonitoringSystemBean(s.getSystemId(), s.getTenantId(), s.getMonitoringLocation().getLocation())));
         return list;
     }
 
     @Transactional
     public Optional<MonitoringSystemBean> getByIdForMonitoring(long id) {
-        return modelRepo.findById(id).map(s->new MonitoringSystemBean(s.getSystemId(), s.getTenantId(), s.getMonitoringLocation().getLocation()));
+        return systemRepository.findById(id).map(s->new MonitoringSystemBean(s.getSystemId(), s.getTenantId(), s.getMonitoringLocation().getLocation()));
     }
 
+    @Transactional
     public void deleteMonitoringSystem(long id) {
-        modelRepo.deleteById(id);
+
+        var optionalMS = systemRepository.findById(id);
+        if (optionalMS.isPresent()) {
+            var monitoringSystem = optionalMS.get();
+            var location = monitoringSystem.getMonitoringLocation().getLocation();
+            var tenantId = monitoringSystem.getTenantId();
+
+            var retrieved = systemRepository.findByMonitoringLocationIdAndTenantId(optionalMS.get().getMonitoringLocationId(), tenantId);
+            systemRepository.deleteById(id);
+            if (retrieved.size() == 1 && retrieved.get(0).getSystemId().equals(monitoringSystem.getSystemId())) {
+                locationRepository.delete(monitoringSystem.getMonitoringLocation());
+                configUpdateService.removeConfigsFromTaskSet(tenantId, location);
+            }
+        }
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
@@ -96,10 +96,9 @@ public class MonitoringSystemService {
             var monitoringSystem = optionalMS.get();
             var location = monitoringSystem.getMonitoringLocation().getLocation();
             var tenantId = monitoringSystem.getTenantId();
-
-            var retrieved = systemRepository.findByMonitoringLocationIdAndTenantId(optionalMS.get().getMonitoringLocationId(), tenantId);
             systemRepository.deleteById(id);
-            if (retrieved.size() == 1 && retrieved.get(0).getSystemId().equals(monitoringSystem.getSystemId())) {
+            var retrieved = systemRepository.findByMonitoringLocationIdAndTenantId(optionalMS.get().getMonitoringLocationId(), tenantId);
+            if (retrieved.size() == 0) {
                 locationRepository.delete(monitoringSystem.getMonitoringLocation());
                 configUpdateService.removeConfigsFromTaskSet(tenantId, location);
             }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class TrapConfigService {
     private static final Logger LOG = LoggerFactory.getLogger(TrapConfigService.class);
+    public final static String TRAPS_CONFIG  = "traps-config";
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final MonitoringLocationService monitoringLocationService;
     private final TaskSetPublisher taskSetPublisher;
@@ -104,7 +105,7 @@ public class TrapConfigService {
 
     private void publishTrapConfig(String tenantId, String location, TrapConfig trapConfig) {
         TaskDefinition taskDefinition = TaskDefinition.newBuilder()
-            .setId(TaskUtils.identityForConfig("traps-config", location))
+            .setId(TaskUtils.identityForConfig(TRAPS_CONFIG, location))
             .setPluginName("trapd.listener.config")
             .setType(TaskType.LISTENER)
             .setConfiguration(Any.pack(trapConfig))

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/GrpcTestBase.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/GrpcTestBase.java
@@ -28,27 +28,26 @@
 
 package org.opennms.horizon.inventory.grpc;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
-import org.keycloak.common.VerificationException;
-import org.opennms.horizon.shared.constants.GrpcConstants;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-
 import io.grpc.BindableService;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessServerBuilder;
+import org.keycloak.common.VerificationException;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public abstract class GrpcTestBase {
     @DynamicPropertySource
@@ -96,6 +95,12 @@ public abstract class GrpcTestBase {
                 builder.addService(service);
             }
         }
-        return builder.build().start();
+        server = builder.build().start();
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            
+        }
+        return server;
     }
 }


### PR DESCRIPTION
Also remove tasksets from Gateway

## Description
When there is no single monitoring system for a given location, location should also be deleted.
(This will prevent any new devices going to non-existing locations)

## Jira link(s)
- https://issues.opennms.org/browse/HS-993

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
