### PR TITLE
HS-940 Update notifications topic and use tenant id header

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumer.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumer.java
@@ -1,13 +1,22 @@
 package org.opennms.horizon.notifications.kafka;
 
+import io.grpc.Context;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.service.NotificationService;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class AlarmKafkaConsumer {
@@ -20,11 +29,36 @@ public class AlarmKafkaConsumer {
         topics = "${horizon.kafka.alarms.topic}",
         concurrency = "${horizon.kafka.alarms.concurrency}"
     )
-    public void consume(AlarmDTO alarm) {
+   public void consume(@Payload AlarmDTO alarm, @Headers Map<String, Object> headers) {
+
+        LOG.info("Received alarm from kafka {}", alarm);
+        Optional<String> tenantOptional = getTenantId(headers);
+        if (tenantOptional.isEmpty()) {
+           LOG.warn("TenantId is empty, dropping alarm {}", alarm);
+           return;
+        }
+        String tenantId = tenantOptional.get();
+        LOG.info("Received tenantIda {}", tenantId);
+
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            consumeAlarm((alarm));
+        });
+    }
+
+    private void consumeAlarm(AlarmDTO alarm) {
         try {
             notificationService.postNotification(alarm);
         } catch (NotificationException e) {
             LOG.error("Exception sending alarm to PagerDuty.", e);
         }
+    }
+
+    private Optional<String> getTenantId(Map<String, Object> headers) {
+        Object tenantId = headers.get(GrpcConstants.TENANT_ID_KEY);
+        if (tenantId instanceof byte[]) {
+            return Optional.of(new String((byte[]) tenantId));
+        }
+        return Optional.empty();
     }
 }

--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumer.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumer.java
@@ -13,8 +13,6 @@ import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,11 +40,11 @@ public class AlarmKafkaConsumer {
 
         Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
         {
-            consumeAlarm((alarm));
+            consumeAlarm(alarm);
         });
     }
 
-    private void consumeAlarm(AlarmDTO alarm) {
+    public void consumeAlarm(AlarmDTO alarm){
         try {
             notificationService.postNotification(alarm);
         } catch (NotificationException e) {

--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumer.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumer.java
@@ -27,7 +27,7 @@ public class AlarmKafkaConsumer {
         topics = "${horizon.kafka.alarms.topic}",
         concurrency = "${horizon.kafka.alarms.concurrency}"
     )
-   public void consume(@Payload AlarmDTO alarm, @Headers Map<String, Object> headers) {
+    public void consume(@Payload AlarmDTO alarm, @Headers Map<String, Object> headers) {
 
         LOG.info("Received alarm from kafka {}", alarm);
         Optional<String> tenantOptional = getTenantId(headers);

--- a/notifications/src/main/resources/application.yml
+++ b/notifications/src/main/resources/application.yml
@@ -29,7 +29,7 @@ grpc:
 horizon:
   kafka:
     alarms:
-      topic: org.opennms.horizon.notifications.alarms
+      topic: alarms
       concurrency: 1
 
   pagerduty:

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
@@ -74,9 +74,6 @@ class AlarmKafkaConsumerIntegrationTest {
     @Captor
     ArgumentCaptor<AlarmDTO> alarmCaptor;
 
-    @Captor
-    ArgumentCaptor<Map<String, Object>> headerCaptor;
-
     @MockBean
     private RestTemplate restTemplate;
 
@@ -108,7 +105,7 @@ class AlarmKafkaConsumerIntegrationTest {
         stringProducer.flush();
 
         verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
-            .consume(alarmCaptor.capture(), headerCaptor.capture());
+            .consume(alarmCaptor.capture(), any());
 
         AlarmDTO capturedAlarm = alarmCaptor.getValue();
         assertEquals(id, capturedAlarm.getId());

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
@@ -2,6 +2,7 @@ package org.opennms.horizon.notifications.kafka;
 
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,6 +15,7 @@ import org.mockito.Captor;
 import org.opennms.horizon.notifications.NotificationsApplication;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.service.NotificationService;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 import org.opennms.horizon.notifications.dto.PagerDutyConfigDTO;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +35,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -94,11 +97,14 @@ class AlarmKafkaConsumerIntegrationTest {
         setupConfig();
 
         int id = 1234;
-        stringProducer.send(new ProducerRecord<>(alarmsTopic, String.format("{\"id\": %d, \"severity\":\"indeterminate\", \"logMessage\":\"hello\"}", id)));
+        String tenantId = "opennms-prime";
+        ProducerRecord producerRecord = new ProducerRecord<>(alarmsTopic, String.format("{\"id\": %d, \"severity\":\"indeterminate\", \"logMessage\":\"hello\"}", id));
+        producerRecord.headers().add(new RecordHeader(GrpcConstants.TENANT_ID_KEY, tenantId.getBytes(StandardCharsets.UTF_8)));
+        stringProducer.send(producerRecord);
         stringProducer.flush();
 
-        verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
-            .consume(alarmCaptor.capture());
+        //verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
+        //    .consume(alarmCaptor.capture());
 
         AlarmDTO capturedAlarm = alarmCaptor.getValue();
         assertEquals(id, capturedAlarm.getId());

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
@@ -112,10 +112,10 @@ class AlarmKafkaConsumerIntegrationTest {
 
         // This is the call to the PagerDuty API, it will fail due to an invalid token, but we just need to
         // verify that the call has been attempted.
-        verify(restTemplate, timeout(HTTP_TIMEOUT).times(1)).exchange(any(URI.class),
+        verify(restTemplate, timeout(HTTP_TIMEOUT).times(1)).exchange(ArgumentMatchers.any(URI.class),
             ArgumentMatchers.eq(HttpMethod.POST),
-            any(HttpEntity.class),
-            any(Class.class));
+            ArgumentMatchers.any(HttpEntity.class),
+            ArgumentMatchers.any(Class.class));
     }
 
     @AfterAll

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -73,6 +74,9 @@ class AlarmKafkaConsumerIntegrationTest {
     @Captor
     ArgumentCaptor<AlarmDTO> alarmCaptor;
 
+    @Captor
+    ArgumentCaptor<Map<String, Object>> headerCaptor;
+
     @MockBean
     private RestTemplate restTemplate;
 
@@ -103,18 +107,18 @@ class AlarmKafkaConsumerIntegrationTest {
         stringProducer.send(producerRecord);
         stringProducer.flush();
 
-        //verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
-        //    .consume(alarmCaptor.capture());
+        verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
+            .consume(alarmCaptor.capture(), headerCaptor.capture());
 
         AlarmDTO capturedAlarm = alarmCaptor.getValue();
         assertEquals(id, capturedAlarm.getId());
 
         // This is the call to the PagerDuty API, it will fail due to an invalid token, but we just need to
         // verify that the call has been attempted.
-        verify(restTemplate, timeout(HTTP_TIMEOUT).times(1)).exchange(ArgumentMatchers.any(URI.class),
+        verify(restTemplate, timeout(HTTP_TIMEOUT).times(1)).exchange(any(URI.class),
             ArgumentMatchers.eq(HttpMethod.POST),
-            ArgumentMatchers.any(HttpEntity.class),
-            ArgumentMatchers.any(Class.class));
+            any(HttpEntity.class),
+            any(Class.class));
     }
 
     @AfterAll

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
@@ -29,7 +29,6 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
@@ -69,9 +70,6 @@ class AlarmKafkaConsumerIntegrationTestNoConfig {
 
     @Captor
     ArgumentCaptor<AlarmDTO> alarmCaptor;
-
-    @Captor
-    ArgumentCaptor<Map<String, Object>> headerCaptor;
 
     @Autowired
     private TestRestTemplate testRestTemplate;
@@ -105,17 +103,17 @@ class AlarmKafkaConsumerIntegrationTestNoConfig {
         stringProducer.flush();
 
         verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
-            .consume(alarmCaptor.capture(),headerCaptor.capture());
+            .consume(alarmCaptor.capture(),any());
 
         AlarmDTO capturedAlarm = alarmCaptor.getValue();
         assertEquals(id, capturedAlarm.getId());
 
         // This is the call to the PagerDuty API, we won't get this far, as we will get an exception when we try
         // to get the token, as the config table hasn't been setup.
-        verify(restTemplate, timeout(HTTP_TIMEOUT).times(0)).exchange(ArgumentMatchers.any(URI.class),
+        verify(restTemplate, timeout(HTTP_TIMEOUT).times(0)).exchange(any(URI.class),
             ArgumentMatchers.eq(HttpMethod.POST),
-            ArgumentMatchers.any(HttpEntity.class),
-            ArgumentMatchers.any(Class.class));
+            any(HttpEntity.class),
+            any(Class.class));
     }
 
     @AfterAll

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
@@ -71,6 +71,9 @@ class AlarmKafkaConsumerIntegrationTestNoConfig {
     @Captor
     ArgumentCaptor<AlarmDTO> alarmCaptor;
 
+    @Captor
+    ArgumentCaptor<Map<String, Object>> headerCaptor;
+
     @Autowired
     private TestRestTemplate testRestTemplate;
 
@@ -102,8 +105,8 @@ class AlarmKafkaConsumerIntegrationTestNoConfig {
         stringProducer.send(producerRecord);
         stringProducer.flush();
 
-        //verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
-        //    .consume(alarmCaptor.capture());
+        verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
+            .consume(alarmCaptor.capture(),headerCaptor.capture());
 
         AlarmDTO capturedAlarm = alarmCaptor.getValue();
         assertEquals(id, capturedAlarm.getId());

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
@@ -2,6 +2,7 @@ package org.opennms.horizon.notifications.kafka;
 
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,6 +14,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.opennms.horizon.notifications.NotificationsApplication;
 import org.opennms.horizon.notifications.api.PagerDutyAPIImpl;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,12 +29,14 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -91,11 +95,15 @@ class AlarmKafkaConsumerIntegrationTestNoConfig {
     @Test
     void testProducingAlarmWithNoConfigSetup() {
         int id = 1234;
-        stringProducer.send(new ProducerRecord<>(alarmsTopic, String.format("{\"id\": %d, \"severity\":\"indeterminate\", \"logMessage\":\"hello\"}", id)));
+        String tenantId = "opennms-prime";
+        ProducerRecord producerRecord = new ProducerRecord<>(alarmsTopic, String.format("{\"id\": %d, \"severity\":\"indeterminate\", \"logMessage\":\"hello\"}", id));
+        producerRecord.headers().add(new RecordHeader(GrpcConstants.TENANT_ID_KEY, tenantId.getBytes(StandardCharsets.UTF_8)));
+
+        stringProducer.send(producerRecord);
         stringProducer.flush();
 
-        verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
-            .consume(alarmCaptor.capture());
+        //verify(alarmKafkaConsumer, timeout(KAFKA_TIMEOUT).times(1))
+        //    .consume(alarmCaptor.capture());
 
         AlarmDTO capturedAlarm = alarmCaptor.getValue();
         assertEquals(id, capturedAlarm.getId());

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerUnitTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerUnitTest.java
@@ -28,7 +28,6 @@
 
 package org.opennms.horizon.notifications.kafka;
 
-import org.apache.kafka.common.header.internals.RecordHeader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerUnitTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerUnitTest.java
@@ -37,10 +37,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.exceptions.NotificationInternalException;
 import org.opennms.horizon.notifications.service.NotificationService;
-import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,7 +66,6 @@ public class AlarmKafkaConsumerUnitTest {
             .when(notificationService).postNotification(any());
 
         AlarmDTO alarmDTO = new AlarmDTO();
-        Map<String, Object> headers = new HashMap<>();
-        alarmKafkaConsumer.consume(alarmDTO,headers);
+        alarmKafkaConsumer.consumeAlarm(alarmDTO);
     }
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerUnitTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerUnitTest.java
@@ -28,6 +28,7 @@
 
 package org.opennms.horizon.notifications.kafka;
 
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -36,7 +37,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.exceptions.NotificationInternalException;
 import org.opennms.horizon.notifications.service.NotificationService;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -52,7 +58,8 @@ public class AlarmKafkaConsumerUnitTest {
     @Test
     public void testConsume() {
         AlarmDTO alarmDTO = new AlarmDTO();
-        alarmKafkaConsumer.consume(alarmDTO);
+        Map<String, Object> headers = new HashMap<>();
+        alarmKafkaConsumer.consume(alarmDTO,headers);
     }
 
     @Test
@@ -61,6 +68,7 @@ public class AlarmKafkaConsumerUnitTest {
             .when(notificationService).postNotification(any());
 
         AlarmDTO alarmDTO = new AlarmDTO();
-        alarmKafkaConsumer.consume(alarmDTO);
+        Map<String, Object> headers = new HashMap<>();
+        alarmKafkaConsumer.consume(alarmDTO,headers);
     }
 }

--- a/notifications/src/test/resources/application.yml
+++ b/notifications/src/test/resources/application.yml
@@ -25,7 +25,7 @@ spring:
 horizon:
   kafka:
     alarms:
-      topic: org.opennms.horizon.notifications.alarms
+      topic: alarms
       concurrency: 1
 
   pagerduty:


### PR DESCRIPTION
## Description
New alarms module does not send created alarms to notifications topic. TenantId has been added to headers and must be used

## Jira link(s)
- https://issues.opennms.org/browse/HS-940

## Flagged for review
Not sure if I have covered the acceptance requirements correctly

## Checklist
* [X] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [X] Appropriate reviewer(s) have been selected.
* [X] Jira issue(s) have been updated to "In Review".
* [X] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
