### PR TITLE
HS-959: Remove HSQL in memory database in tests in favour of postgres

### DIFF
--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -263,12 +263,6 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
-            <version>2.7.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 	<build>

--- a/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.verify;
 @CucumberContextConfiguration
 @SpringBootTest
 @EnableAutoConfiguration
+@ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 public class NotificationCucumberTestSteps extends GrpcTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationCucumberTestSteps.class);
 

--- a/notifications/src/test/java/org/opennms/horizon/notifications/NotificationsApplicationTests.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/NotificationsApplicationTests.java
@@ -8,12 +8,14 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = NotificationsApplication.class)
 @TestPropertySource(locations = "classpath:application.yml")
+@ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 class NotificationsApplicationTests {
 
     @Autowired

--- a/notifications/src/test/java/org/opennms/horizon/notifications/SpringContextTestInitializer.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/SpringContextTestInitializer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class SpringContextTestInitializer implements ApplicationContextInitializer<GenericApplicationContext> {
+
+    private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:14.5-alpine")
+        .withDatabaseName("notifications").withUsername("notifications")
+        .withPassword("passw0rd").withExposedPorts(5432);
+
+
+    static {
+        postgres.start();
+    }
+
+    @Override
+    public void initialize(@NotNull GenericApplicationContext context) {
+        initDatasourceParams(context);
+    }
+
+    private void initDatasourceParams(GenericApplicationContext context) {
+        TestPropertyValues.of(
+            "spring.datasource.url=" + postgres.getJdbcUrl(),
+            "spring.datasource.username=" + postgres.getUsername(),
+            "spring.datasource.password=" + postgres.getPassword()
+        ).applyTo(context.getEnvironment());
+    }
+}

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.opennms.horizon.notifications.NotificationsApplication;
+import org.opennms.horizon.notifications.SpringContextTestInitializer;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.service.NotificationService;
 import org.opennms.horizon.shared.constants.GrpcConstants;
@@ -30,6 +31,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
@@ -52,6 +54,7 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = NotificationsApplication.class)
 @TestPropertySource(properties = "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}", locations = "classpath:application.yml")
+@ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 @ActiveProfiles("test")
 class AlarmKafkaConsumerIntegrationTest {
     private static final int KAFKA_TIMEOUT = 5000;

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTestNoConfig.java
@@ -13,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.opennms.horizon.notifications.NotificationsApplication;
+import org.opennms.horizon.notifications.SpringContextTestInitializer;
 import org.opennms.horizon.notifications.api.PagerDutyAPIImpl;
 import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
@@ -30,6 +31,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
@@ -52,6 +54,7 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     classes = NotificationsApplication.class)
 @TestPropertySource(properties = "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}", locations = "classpath:application.yml")
+@ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 @ActiveProfiles("test")
 class AlarmKafkaConsumerIntegrationTestNoConfig {
     private static final int KAFKA_TIMEOUT = 30000;

--- a/notifications/src/test/resources/application.yml
+++ b/notifications/src/test/resources/application.yml
@@ -2,12 +2,6 @@ spring:
   application:
     name: integration-test
 
-  datasource:
-    driver-class-name: org.hsqldb.jdbc.JDBCDriver
-    url: jdbc:hsqldb:mem:db
-    username: sa
-    password: sa
-
   liquibase:
     change-log: db/changelog/changelog.xml
     enabled: true

--- a/notifications/src/test/resources/logback.xml
+++ b/notifications/src/test/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+	<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </layout>
+  </appender>
+
+  <logger name="com.github.dockerjava" level="WARN"></logger>
+  <logger name="org.testcontainers" level="INFO"></logger>
+    <logger name="org.hibernate.SQL" level="ERROR"> <!-- DEBUG -->
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    <logger name="org.hibernate.type.descriptor.sql" level="ERROR"> <!-- TRACE -->
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+    <logger name="org.hibernate" level="ERROR"> <!-- DEBUG -->
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+  <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+  </root>
+
+</configuration>
+


### PR DESCRIPTION
## Description
Better to use postgres in tests as that's what is used in production

## Jira link(s)
- https://issues.opennms.org/browse/HS-959

## Flagged for review
n/a

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
