### PR TITLE
HS-962 Bump keycloak version

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -91,7 +91,7 @@
         <jsr305.version>3.0.2</jsr305.version>
         <karaf.version>4.4.2</karaf.version>
         <karaf.maven-plugin.version>${karaf.version}</karaf.maven-plugin.version> <!-- use separate property in case a need to separate from the base Karaf version arises -->
-        <keycloak.version>18.0.0</keycloak.version>
+        <keycloak.version>20.0.3</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
         <log4j2.version>2.17.1</log4j2.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>


### PR DESCRIPTION
## Description
A flaw was found in Keycloak. This flaw allows impersonation and lockout due to the email trust not being handled correctly in Keycloak. An attacker can shadow other users with the same email and lockout or impersonate them.

CVE: CVE-2023-0105

## Jira link(s)
- https://issues.opennms.org/browse/HS-962

## Flagged for review
None

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
