### PR TITLE
HS-964 Bump log4j version

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -1032,4 +1032,3 @@
         </repository>
     </repositories>
 </project>
-

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -93,8 +93,7 @@
         <karaf.maven-plugin.version>${karaf.version}</karaf.maven-plugin.version> <!-- use separate property in case a need to separate from the base Karaf version arises -->
         <keycloak.version>18.0.0</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
-        <log4j2.version>2.17.1</log4j2.version>
-        <!-- <log4j2.version>2.19.0</log4j2.version> -->
+        <log4j2.version>2.19.0</log4j2.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <maven-resources.version>3.3.0</maven-resources.version>
         <mina.version>2.1.5</mina.version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -93,7 +93,8 @@
         <karaf.maven-plugin.version>${karaf.version}</karaf.maven-plugin.version> <!-- use separate property in case a need to separate from the base Karaf version arises -->
         <keycloak.version>18.0.0</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
-        <log4j2.version>2.19.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
+        <!-- <log4j2.version>2.19.0</log4j2.version> -->
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <maven-resources.version>3.3.0</maven-resources.version>
         <mina.version>2.1.5</mina.version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -93,7 +93,7 @@
         <karaf.maven-plugin.version>${karaf.version}</karaf.maven-plugin.version> <!-- use separate property in case a need to separate from the base Karaf version arises -->
         <keycloak.version>18.0.0</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.19.0</log4j2.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <maven-resources.version>3.3.0</maven-resources.version>
         <mina.version>2.1.5</mina.version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -1032,3 +1032,4 @@
         </repository>
     </repositories>
 </project>
+


### PR DESCRIPTION
## Description
Deserialization of Untrusted Data in Log4j

HS-964: CVE: CVE-2019-17571
HS-967: CVE-2022-23302


## Jira link(s)
- https://issues.opennms.org/browse/HS-964

## Flagged for review
No

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
