### PR TITLE
HS-964: Deserialization of Untrusted Data in Log4j

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -74,7 +74,7 @@
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jaxrs.version>2.1</jaxrs.version>
-        <jboss-logging.version>3.5.0.Final</jboss-logging.version>
+        <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <jcifs.version>2.1.6</jcifs.version>
         <jexl.version>2.1.1</jexl.version>
         <jicmp.version>3.0.0</jicmp.version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -74,7 +74,7 @@
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jaxrs.version>2.1</jaxrs.version>
-        <jboss-logging.version>3.4.1.Final</jboss-logging.version>
+        <jboss-logging.version>3.5.0.Final</jboss-logging.version>
         <jcifs.version>2.1.6</jcifs.version>
         <jexl.version>2.1.1</jexl.version>
         <jicmp.version>3.0.0</jicmp.version>
@@ -93,7 +93,7 @@
         <karaf.maven-plugin.version>${karaf.version}</karaf.maven-plugin.version> <!-- use separate property in case a need to separate from the base Karaf version arises -->
         <keycloak.version>20.0.3</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
-        <log4j2.version>2.17.1</log4j2.version>
+        <log4j2.version>2.19.0</log4j2.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <maven-resources.version>3.3.0</maven-resources.version>
         <mina.version>2.1.5</mina.version>


### PR DESCRIPTION
## Description
Upgrade log4j2 to fix deserialization of Untrusted Data in Log4j. CVE: CVE-2019-17571
Upgrade log4j2 to fix JMSAppender in Log4j 1.2 is vulnerable to deserialization of untrusted data CVE: CVE-2022-23302

## Jira link(s)
- https://issues.opennms.org/browse/HS-964

## Flagged for review
None

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
