### PR TITLE
HS-1015: Inventory - Partial Search on Tags

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/grpc/TagGrpcService.java
@@ -38,9 +38,12 @@ import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.opennms.horizon.inventory.dto.ListAllTagsParamsDTO;
+import org.opennms.horizon.inventory.dto.ListTagsByNodeIdParamsDTO;
 import org.opennms.horizon.inventory.dto.TagCreateListDTO;
 import org.opennms.horizon.inventory.dto.TagDTO;
 import org.opennms.horizon.inventory.dto.TagListDTO;
+import org.opennms.horizon.inventory.dto.TagListParamsDTO;
 import org.opennms.horizon.inventory.dto.TagRemoveListDTO;
 import org.opennms.horizon.inventory.dto.TagServiceGrpc;
 import org.opennms.horizon.inventory.service.TagService;
@@ -113,13 +116,12 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
     }
 
     @Override
-    public void getTagsByNodeId(Int64Value request, StreamObserver<TagListDTO> responseObserver) {
+    public void getTagsByNodeId(ListTagsByNodeIdParamsDTO request, StreamObserver<TagListDTO> responseObserver) {
         Optional<String> tenantIdOptional = tenantLookup.lookupTenantId(Context.current());
 
         tenantIdOptional.ifPresentOrElse(tenantId -> {
             try {
-                List<TagDTO> tags = service.getTagsByNodeId(tenantId, request.getValue());
-
+                List<TagDTO> tags = service.getTagsByNodeId(tenantId, request);
                 responseObserver.onNext(TagListDTO.newBuilder().addAllTags(tags).build());
                 responseObserver.onCompleted();
             } catch (Exception e) {
@@ -141,13 +143,12 @@ public class TagGrpcService extends TagServiceGrpc.TagServiceImplBase {
     }
 
     @Override
-    public void getTags(Empty request, StreamObserver<TagListDTO> responseObserver) {
+    public void getTags(ListAllTagsParamsDTO request, StreamObserver<TagListDTO> responseObserver) {
         Optional<String> tenantIdOptional = tenantLookup.lookupTenantId(Context.current());
 
         tenantIdOptional.ifPresentOrElse(tenantId -> {
             try {
-                List<TagDTO> tags = service.getTags(tenantId);
-
+                List<TagDTO> tags = service.getTags(tenantId, request);
                 responseObserver.onNext(TagListDTO.newBuilder().addAllTags(tags).build());
                 responseObserver.onCompleted();
             } catch (Exception e) {

--- a/inventory/src/main/java/org/opennms/horizon/inventory/repository/TagRepository.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/repository/TagRepository.java
@@ -64,8 +64,8 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
         "FROM Tag tag " +
         "WHERE tag.tenantId = :tenantId " +
         "AND LOWER(tag.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))")
-    List<Tag> findByTenantIdAndSearchTerm(@Param("tenantId") String tenantId,
-                                          @Param("searchTerm") String searchTerm);
+    List<Tag> findByTenantIdAndNameLike(@Param("tenantId") String tenantId,
+                                        @Param("searchTerm") String searchTerm);
 
     @Query("SELECT tag " +
         "FROM Tag tag " +
@@ -73,9 +73,9 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
         "WHERE tag.tenantId = :tenantId " +
         "AND node.id = :nodeId " +
         "AND LOWER(tag.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))")
-    List<Tag> findByTenantIdAndNodeIdAndSearchTerm(@Param("tenantId") String tenantId,
-                                                   @Param("nodeId") long nodeId,
-                                                   @Param("searchTerm") String searchTerm);
+    List<Tag> findByTenantIdAndNodeIdAndNameLike(@Param("tenantId") String tenantId,
+                                                 @Param("nodeId") long nodeId,
+                                                 @Param("searchTerm") String searchTerm);
 
     List<Tag> findByTenantId(String tenantId);
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/repository/TagRepository.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/repository/TagRepository.java
@@ -60,5 +60,22 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByTenantIdAndNodeId(@Param("tenantId") String tenantId,
                                       @Param("nodeId") long nodeId);
 
+    @Query("SELECT tag " +
+        "FROM Tag tag " +
+        "WHERE tag.tenantId = :tenantId " +
+        "AND LOWER(tag.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))")
+    List<Tag> findByTenantIdAndSearchTerm(@Param("tenantId") String tenantId,
+                                          @Param("searchTerm") String searchTerm);
+
+    @Query("SELECT tag " +
+        "FROM Tag tag " +
+        "JOIN tag.nodes node " +
+        "WHERE tag.tenantId = :tenantId " +
+        "AND node.id = :nodeId " +
+        "AND LOWER(tag.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))")
+    List<Tag> findByTenantIdAndNodeIdAndSearchTerm(@Param("tenantId") String tenantId,
+                                                   @Param("nodeId") long nodeId,
+                                                   @Param("searchTerm") String searchTerm);
+
     List<Tag> findByTenantId(String tenantId);
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TagService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TagService.java
@@ -30,9 +30,13 @@ package org.opennms.horizon.inventory.service;
 
 import com.google.protobuf.Int64Value;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.opennms.horizon.inventory.dto.ListAllTagsParamsDTO;
+import org.opennms.horizon.inventory.dto.ListTagsByNodeIdParamsDTO;
 import org.opennms.horizon.inventory.dto.TagCreateDTO;
 import org.opennms.horizon.inventory.dto.TagCreateListDTO;
 import org.opennms.horizon.inventory.dto.TagDTO;
+import org.opennms.horizon.inventory.dto.TagListParamsDTO;
 import org.opennms.horizon.inventory.dto.TagRemoveListDTO;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.mapper.TagMapper;
@@ -131,12 +135,31 @@ public class TagService {
         return tagOpt.get();
     }
 
-    public List<TagDTO> getTagsByNodeId(String tenantId, long nodeId) {
+    public List<TagDTO> getTagsByNodeId(String tenantId, ListTagsByNodeIdParamsDTO listParams) {
+        long nodeId = listParams.getNodeId();
+        if (listParams.hasParams()) {
+            TagListParamsDTO params = listParams.getParams();
+            String searchTerm = params.getSearchTerm();
+
+            if (StringUtils.isNotEmpty(searchTerm)) {
+                return repository.findByTenantIdAndNodeIdAndSearchTerm(tenantId, nodeId, searchTerm)
+                    .stream().map(mapper::modelToDTO).toList();
+            }
+        }
         return repository.findByTenantIdAndNodeId(tenantId, nodeId)
             .stream().map(mapper::modelToDTO).toList();
     }
 
-    public List<TagDTO> getTags(String tenantId) {
+    public List<TagDTO> getTags(String tenantId, ListAllTagsParamsDTO listParams) {
+        if (listParams.hasParams()) {
+            TagListParamsDTO params = listParams.getParams();
+            String searchTerm = params.getSearchTerm();
+
+            if (StringUtils.isNotEmpty(searchTerm)) {
+                return repository.findByTenantIdAndSearchTerm(tenantId, searchTerm)
+                    .stream().map(mapper::modelToDTO).toList();
+            }
+        }
         return repository.findByTenantId(tenantId)
             .stream().map(mapper::modelToDTO).toList();
     }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TagService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TagService.java
@@ -142,7 +142,7 @@ public class TagService {
             String searchTerm = params.getSearchTerm();
 
             if (StringUtils.isNotEmpty(searchTerm)) {
-                return repository.findByTenantIdAndNodeIdAndSearchTerm(tenantId, nodeId, searchTerm)
+                return repository.findByTenantIdAndNodeIdAndNameLike(tenantId, nodeId, searchTerm)
                     .stream().map(mapper::modelToDTO).toList();
             }
         }
@@ -156,7 +156,7 @@ public class TagService {
             String searchTerm = params.getSearchTerm();
 
             if (StringUtils.isNotEmpty(searchTerm)) {
-                return repository.findByTenantIdAndSearchTerm(tenantId, searchTerm)
+                return repository.findByTenantIdAndNameLike(tenantId, searchTerm)
                     .stream().map(mapper::modelToDTO).toList();
             }
         }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/cucumber/steps/NodeTaggingStepDefinitions.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/cucumber/steps/NodeTaggingStepDefinitions.java
@@ -35,12 +35,15 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.opennms.horizon.inventory.cucumber.InventoryBackgroundHelper;
+import org.opennms.horizon.inventory.dto.ListAllTagsParamsDTO;
+import org.opennms.horizon.inventory.dto.ListTagsByNodeIdParamsDTO;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
 import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.inventory.dto.TagCreateDTO;
 import org.opennms.horizon.inventory.dto.TagCreateListDTO;
 import org.opennms.horizon.inventory.dto.TagDTO;
 import org.opennms.horizon.inventory.dto.TagListDTO;
+import org.opennms.horizon.inventory.dto.TagListParamsDTO;
 import org.opennms.horizon.inventory.dto.TagRemoveListDTO;
 
 import java.util.ArrayList;
@@ -162,8 +165,9 @@ public class NodeTaggingStepDefinitions {
     @When("A GRPC request to fetch tags for node")
     public void aGrpcRequestToFetchTagsForNode() {
         var tagServiceBlockingStub = backgroundHelper.getTagServiceBlockingStub();
-        fetchedTagList = tagServiceBlockingStub.getTagsByNodeId(Int64Value.newBuilder()
-            .setValue(node.getId()).build());
+        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder()
+            .setNodeId(node.getId()).setParams(TagListParamsDTO.newBuilder().build()).build();
+        fetchedTagList = tagServiceBlockingStub.getTagsByNodeId(params);
     }
 
     @When("A GRPC request to remove tag {string} for node")
@@ -177,14 +181,34 @@ public class NodeTaggingStepDefinitions {
                 break;
             }
         }
-        fetchedTagList = tagServiceBlockingStub.getTagsByNodeId(Int64Value.newBuilder()
-            .setValue(node.getId()).build());
+        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder()
+            .setNodeId(node.getId()).setParams(TagListParamsDTO.newBuilder().build()).build();
+        fetchedTagList = tagServiceBlockingStub.getTagsByNodeId(params);
     }
 
     @When("A GRPC request to fetch all tags")
     public void aGRPCRequestToFetchAllTags() {
         var tagServiceBlockingStub = backgroundHelper.getTagServiceBlockingStub();
-        fetchedTagList = tagServiceBlockingStub.getTags(Empty.getDefaultInstance());
+        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder()
+            .setParams(TagListParamsDTO.newBuilder().build()).build();
+        fetchedTagList = tagServiceBlockingStub.getTags(params);
+    }
+
+    @When("A GRPC request to fetch all tags for node with searchTerm {string}")
+    public void aGRPCRequestToFetchAllTagsForNodeWithSearchTerm(String searchTerm) {
+        var tagServiceBlockingStub = backgroundHelper.getTagServiceBlockingStub();
+        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder()
+            .setNodeId(node.getId())
+            .setParams(TagListParamsDTO.newBuilder().setSearchTerm(searchTerm).build()).build();
+        fetchedTagList = tagServiceBlockingStub.getTagsByNodeId(params);
+    }
+
+    @When("A GRPC request to fetch all tags with searchTerm {string}")
+    public void aGRPCRequestToFetchAllTagsWithSearchTerm(String searchTerm) {
+        var tagServiceBlockingStub = backgroundHelper.getTagServiceBlockingStub();
+        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder()
+            .setParams(TagListParamsDTO.newBuilder().setSearchTerm(searchTerm).build()).build();
+        fetchedTagList = tagServiceBlockingStub.getTags(params);
     }
 
     /*

--- a/inventory/src/test/java/org/opennms/horizon/inventory/cucumber/steps/NodeTaggingStepDefinitions.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/cucumber/steps/NodeTaggingStepDefinitions.java
@@ -194,8 +194,8 @@ public class NodeTaggingStepDefinitions {
         fetchedTagList = tagServiceBlockingStub.getTags(params);
     }
 
-    @When("A GRPC request to fetch all tags for node with searchTerm {string}")
-    public void aGRPCRequestToFetchAllTagsForNodeWithSearchTerm(String searchTerm) {
+    @When("A GRPC request to fetch all tags for node with name like {string}")
+    public void aGRPCRequestToFetchAllTagsForNodeWithNameLike(String searchTerm) {
         var tagServiceBlockingStub = backgroundHelper.getTagServiceBlockingStub();
         ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder()
             .setNodeId(node.getId())
@@ -203,8 +203,8 @@ public class NodeTaggingStepDefinitions {
         fetchedTagList = tagServiceBlockingStub.getTagsByNodeId(params);
     }
 
-    @When("A GRPC request to fetch all tags with searchTerm {string}")
-    public void aGRPCRequestToFetchAllTagsWithSearchTerm(String searchTerm) {
+    @When("A GRPC request to fetch all tags with name like {string}")
+    public void aGRPCRequestToFetchAllTagsWithNameLike(String searchTerm) {
         var tagServiceBlockingStub = backgroundHelper.getTagServiceBlockingStub();
         ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder()
             .setParams(TagListParamsDTO.newBuilder().setSearchTerm(searchTerm).build()).build();

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
@@ -39,10 +39,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.VerificationException;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
+import org.opennms.horizon.inventory.dto.ListAllTagsParamsDTO;
+import org.opennms.horizon.inventory.dto.ListTagsByNodeIdParamsDTO;
 import org.opennms.horizon.inventory.dto.TagCreateDTO;
 import org.opennms.horizon.inventory.dto.TagCreateListDTO;
 import org.opennms.horizon.inventory.dto.TagDTO;
 import org.opennms.horizon.inventory.dto.TagListDTO;
+import org.opennms.horizon.inventory.dto.TagListParamsDTO;
 import org.opennms.horizon.inventory.dto.TagRemoveListDTO;
 import org.opennms.horizon.inventory.dto.TagServiceGrpc;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
@@ -403,13 +406,83 @@ class TagGrpcItTest extends GrpcTestBase {
         List<Tag> allTags = tagRepository.findAll();
         assertEquals(2, allTags.size());
 
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(Int64Value.newBuilder().setValue(nodeId).build());
+        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().build()).build();
+        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
         List<TagDTO> tagsList = tagsByNodeId.getTagsList();
         assertEquals(2, tagsList.size());
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
 
+    @Test
+    void testGetTagListForNodeWithSearchTerm() throws Exception {
+        long nodeId = setupDatabase();
+
+        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_1)
+            .build();
+
+        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+
+        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_2)
+            .build();
+
+        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+
+        List<Tag> allTags = tagRepository.findAll();
+        assertEquals(2, allTags.size());
+
+
+        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name").build()).build();
+        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
+        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+        assertEquals(2, tagsList.size());
+
+        verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
+
+    @Test
+    void testGetTagListForNodeWithSearchTermNoResults() throws Exception {
+        long nodeId = setupDatabase();
+
+        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_1)
+            .build();
+
+        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+
+        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_2)
+            .build();
+
+        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+
+        List<Tag> allTags = tagRepository.findAll();
+        assertEquals(2, allTags.size());
+
+
+        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name-INVALID").build()).build();
+        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
+        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+        assertEquals(0, tagsList.size());
+
+        verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
 
     @Test
@@ -437,13 +510,81 @@ class TagGrpcItTest extends GrpcTestBase {
         List<Tag> allTags = tagRepository.findAll();
         assertEquals(2, allTags.size());
 
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(Empty.getDefaultInstance());
+        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().build()).build();
+        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
         List<TagDTO> tagsList = tagsByNodeId.getTagsList();
         assertEquals(2, tagsList.size());
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
 
+    @Test
+    void testGetTagListWithSearchTerm() throws Exception {
+        long nodeId = setupDatabase();
+
+        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_1)
+            .build();
+
+        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+
+        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_2)
+            .build();
+
+        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+
+        List<Tag> allTags = tagRepository.findAll();
+        assertEquals(2, allTags.size());
+
+        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name").build()).build();
+        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
+        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+        assertEquals(2, tagsList.size());
+
+        verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
+
+    @Test
+    void testGetTagListWithSearchTermNoResults() throws Exception {
+        long nodeId = setupDatabase();
+
+        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_1)
+            .build();
+
+        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+
+        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+            .setName(TEST_TAG_NAME_2)
+            .build();
+
+        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+
+        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+
+        List<Tag> allTags = tagRepository.findAll();
+        assertEquals(2, allTags.size());
+
+        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name-INVALID").build()).build();
+        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
+        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+        assertEquals(0, tagsList.size());
+
+        verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
 
     private long setupDatabase() {

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
@@ -28,7 +28,6 @@
 
 package org.opennms.horizon.inventory.grpc;
 
-import com.google.protobuf.Empty;
 import com.google.protobuf.Int64Value;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -416,7 +415,7 @@ class TagGrpcItTest extends GrpcTestBase {
     }
 
     @Test
-    void testGetTagListForNodeWithSearchTerm() throws Exception {
+    void testGetTagListForNodeWithNameLike() throws Exception {
         long nodeId = setupDatabase();
 
         TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
@@ -451,7 +450,7 @@ class TagGrpcItTest extends GrpcTestBase {
     }
 
     @Test
-    void testGetTagListForNodeWithSearchTermNoResults() throws Exception {
+    void testGetTagListForNodeWithNameLikeNoResults() throws Exception {
         long nodeId = setupDatabase();
 
         TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
@@ -520,7 +519,7 @@ class TagGrpcItTest extends GrpcTestBase {
     }
 
     @Test
-    void testGetTagListWithSearchTerm() throws Exception {
+    void testGetTagListWithNameLike() throws Exception {
         long nodeId = setupDatabase();
 
         TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
@@ -554,7 +553,7 @@ class TagGrpcItTest extends GrpcTestBase {
     }
 
     @Test
-    void testGetTagListWithSearchTermNoResults() throws Exception {
+    void testGetTagListWithNameLikeNoResults() throws Exception {
         long nodeId = setupDatabase();
 
         TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()

--- a/inventory/src/test/resources/org/opennms/horizon/inventory/node-tagging.feature
+++ b/inventory/src/test/resources/org/opennms/horizon/inventory/node-tagging.feature
@@ -21,6 +21,16 @@ Feature: Node Tagging
     When A GRPC request to fetch tags for node
     Then The response should contain an empty list of tags
 
+  Scenario: Get a list of tags for node and search term
+    Given A new node with tags "abc,bcd"
+    When A GRPC request to fetch all tags for node with searchTerm "cd"
+    Then The response should contain only tags "bcd"
+
+  Scenario: Get an empty list of tags for node and search term
+    Given A new node with tags "abc,bcd"
+    When A GRPC request to fetch all tags for node with searchTerm "xyz"
+    Then The response should contain an empty list of tags
+
   Scenario: Remove tags from node
     Given A new node with tags "tag1,tag2"
     When A GRPC request to remove tag "tag1" for node
@@ -32,7 +42,14 @@ Feature: Node Tagging
     When A GRPC request to fetch all tags
     Then The response should contain only tags "tag1,tag2,tag3"
 
-  Scenario: Get an empty list of tags
-    Given A new node with no tags
-    When A GRPC request to fetch all tags
+  Scenario: Get a list of tags for search term
+    Given A new node with tags "abc,bcd"
+    Given Another node with tags "cde,defg"
+    When A GRPC request to fetch all tags with searchTerm "cd"
+    Then The response should contain only tags "bcd,cde"
+
+  Scenario: Get an empty list of tags for search term
+    Given A new node with tags "abc,bcd"
+    Given Another node with tags "cde,defg"
+    When A GRPC request to fetch all tags with searchTerm "xyz"
     Then The response should contain an empty list of tags

--- a/inventory/src/test/resources/org/opennms/horizon/inventory/node-tagging.feature
+++ b/inventory/src/test/resources/org/opennms/horizon/inventory/node-tagging.feature
@@ -21,14 +21,14 @@ Feature: Node Tagging
     When A GRPC request to fetch tags for node
     Then The response should contain an empty list of tags
 
-  Scenario: Get a list of tags for node and search term
+  Scenario: Get a list of tags for node and name like provided search term
     Given A new node with tags "abc,bcd"
-    When A GRPC request to fetch all tags for node with searchTerm "cd"
+    When A GRPC request to fetch all tags for node with name like "cd"
     Then The response should contain only tags "bcd"
 
-  Scenario: Get an empty list of tags for node and search term
+  Scenario: Get an empty list of tags for node and name like provided search term
     Given A new node with tags "abc,bcd"
-    When A GRPC request to fetch all tags for node with searchTerm "xyz"
+    When A GRPC request to fetch all tags for node with name like "xyz"
     Then The response should contain an empty list of tags
 
   Scenario: Remove tags from node
@@ -42,14 +42,14 @@ Feature: Node Tagging
     When A GRPC request to fetch all tags
     Then The response should contain only tags "tag1,tag2,tag3"
 
-  Scenario: Get a list of tags for search term
+  Scenario: Get a list of tags with name like provided search term
     Given A new node with tags "abc,bcd"
     Given Another node with tags "cde,defg"
-    When A GRPC request to fetch all tags with searchTerm "cd"
+    When A GRPC request to fetch all tags with name like "cd"
     Then The response should contain only tags "bcd,cde"
 
-  Scenario: Get an empty list of tags for search term
+  Scenario: Get an empty list of tags with name like provided search term
     Given A new node with tags "abc,bcd"
     Given Another node with tags "cde,defg"
-    When A GRPC request to fetch all tags with searchTerm "xyz"
+    When A GRPC request to fetch all tags with name like "xyz"
     Then The response should contain an empty list of tags

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcTagService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcTagService.java
@@ -76,14 +76,17 @@ public class GrpcTagService {
     }
 
     @GraphQLQuery
-    public Mono<List<Tag>> getTagsByNodeId(@GraphQLArgument(name = "nodeId") Long nodeId, @GraphQLEnvironment ResolutionEnvironment env) {
-        List<TagDTO> tagsList = client.getTagsByNodeId(nodeId, headerUtil.getAuthHeader(env)).getTagsList();
+    public Mono<List<Tag>> getTagsByNodeId(@GraphQLArgument(name = "nodeId") Long nodeId,
+                                           @GraphQLArgument(name = "searchTerm") String searchTerm,
+                                           @GraphQLEnvironment ResolutionEnvironment env) {
+        List<TagDTO> tagsList = client.getTagsByNodeId(nodeId, searchTerm, headerUtil.getAuthHeader(env)).getTagsList();
         return Mono.just(tagsList.stream().map(mapper::protoToTag).toList());
     }
 
     @GraphQLQuery
-    public Mono<List<Tag>> getTags(@GraphQLEnvironment ResolutionEnvironment env) {
-        List<TagDTO> tagsList = client.getTags(headerUtil.getAuthHeader(env)).getTagsList();
+    public Mono<List<Tag>> getTags(@GraphQLArgument(name = "searchTerm") String searchTerm,
+                                   @GraphQLEnvironment ResolutionEnvironment env) {
+        List<TagDTO> tagsList = client.getTags(searchTerm, headerUtil.getAuthHeader(env)).getTagsList();
         return Mono.just(tagsList.stream().map(mapper::protoToTag).toList());
     }
 }

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/GraphQLTagServiceTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/GraphQLTagServiceTest.java
@@ -128,7 +128,7 @@ class GraphQLTagServiceTest {
         TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
         TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
         TagListDTO tagListDTO = TagListDTO.newBuilder().addTags(tagDTO1).addTags(tagDTO2).build();
-        when(mockClient.getTagsByNodeId(anyLong(), anyString())).thenReturn(tagListDTO);
+        when(mockClient.getTagsByNodeId(anyLong(), any(), anyString())).thenReturn(tagListDTO);
 
         String getRequest = "query { " +
             "    tagsByNodeId (nodeId: 1) { " +
@@ -152,7 +152,41 @@ class GraphQLTagServiceTest {
             .jsonPath("$.data.tagsByNodeId[1].tenantId").isNotEmpty()
             .jsonPath("$.data.tagsByNodeId[1].name").isEqualTo(TEST_TAG_NAME_2);
 
-        verify(mockClient, times(1)).getTagsByNodeId(1L, accessToken);
+        verify(mockClient, times(1)).getTagsByNodeId(1L, null, accessToken);
+        verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
+    }
+
+    @Test
+    void testGetTagsFromNodeWithSearchTerm() throws JSONException {
+
+        TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
+        TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
+        TagListDTO tagListDTO = TagListDTO.newBuilder().addTags(tagDTO1).addTags(tagDTO2).build();
+        when(mockClient.getTagsByNodeId(anyLong(), anyString(), anyString())).thenReturn(tagListDTO);
+
+        String getRequest = "query { " +
+            "    tagsByNodeId (nodeId: 1, searchTerm: \"abc\") { " +
+            "        id, " +
+            "        tenantId, " +
+            "        name " +
+            "    }" +
+            "}";
+        webClient.post()
+            .uri(GRAPHQL_PATH)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(createPayload(getRequest))
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody()
+            .jsonPath("$.data.tagsByNodeId[0].id").isEqualTo(1)
+            .jsonPath("$.data.tagsByNodeId[0].tenantId").isNotEmpty()
+            .jsonPath("$.data.tagsByNodeId[0].name").isEqualTo(TEST_TAG_NAME_1)
+            .jsonPath("$.data.tagsByNodeId[1].id").isEqualTo(2)
+            .jsonPath("$.data.tagsByNodeId[1].tenantId").isNotEmpty()
+            .jsonPath("$.data.tagsByNodeId[1].name").isEqualTo(TEST_TAG_NAME_2);
+
+        verify(mockClient, times(1)).getTagsByNodeId(1L, "abc", accessToken);
         verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
     }
 
@@ -162,7 +196,7 @@ class GraphQLTagServiceTest {
         TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
         TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
         TagListDTO tagListDTO = TagListDTO.newBuilder().addTags(tagDTO1).addTags(tagDTO2).build();
-        when(mockClient.getTags(anyString())).thenReturn(tagListDTO);
+        when(mockClient.getTags(any(), anyString())).thenReturn(tagListDTO);
 
         String getRequest = "query { " +
             "    tags { " +
@@ -186,7 +220,41 @@ class GraphQLTagServiceTest {
             .jsonPath("$.data.tags[1].tenantId").isNotEmpty()
             .jsonPath("$.data.tags[1].name").isEqualTo(TEST_TAG_NAME_2);
 
-        verify(mockClient, times(1)).getTags(accessToken);
+        verify(mockClient, times(1)).getTags(null, accessToken);
+        verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
+    }
+
+    @Test
+    void testGetTagsWithSearchTerm() throws JSONException {
+
+        TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
+        TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
+        TagListDTO tagListDTO = TagListDTO.newBuilder().addTags(tagDTO1).addTags(tagDTO2).build();
+        when(mockClient.getTags(anyString(), anyString())).thenReturn(tagListDTO);
+
+        String getRequest = "query { " +
+            "    tags (searchTerm: \"abc\") { " +
+            "        id, " +
+            "        tenantId, " +
+            "        name " +
+            "    }" +
+            "}";
+        webClient.post()
+            .uri(GRAPHQL_PATH)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(createPayload(getRequest))
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody()
+            .jsonPath("$.data.tags[0].id").isEqualTo(1)
+            .jsonPath("$.data.tags[0].tenantId").isNotEmpty()
+            .jsonPath("$.data.tags[0].name").isEqualTo(TEST_TAG_NAME_1)
+            .jsonPath("$.data.tags[1].id").isEqualTo(2)
+            .jsonPath("$.data.tags[1].tenantId").isNotEmpty()
+            .jsonPath("$.data.tags[1].name").isEqualTo(TEST_TAG_NAME_2);
+
+        verify(mockClient, times(1)).getTags("abc", accessToken);
         verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
     }
 

--- a/shared-lib/inventory/src/main/proto/tagService.proto
+++ b/shared-lib/inventory/src/main/proto/tagService.proto
@@ -58,9 +58,23 @@ message TagRemoveListDTO {
   repeated google.protobuf.Int64Value tag_ids = 2;
 }
 
+message ListTagsByNodeIdParamsDTO {
+  int64 node_id = 1;
+  optional TagListParamsDTO params = 2;
+}
+
+message ListAllTagsParamsDTO {
+  optional TagListParamsDTO params = 1;
+}
+
+message TagListParamsDTO {
+  optional string searchTerm = 1;
+  // may require pagination fields or other common list params
+}
+
 service TagService {
   rpc addTags(TagCreateListDTO) returns (TagListDTO) {};
   rpc removeTags(TagRemoveListDTO) returns (google.protobuf.BoolValue) {};
-  rpc getTagsByNodeId(google.protobuf.Int64Value) returns (TagListDTO) {};
-  rpc getTags(google.protobuf.Empty) returns (TagListDTO) {};
+  rpc getTagsByNodeId(ListTagsByNodeIdParamsDTO) returns (TagListDTO) {};
+  rpc getTags(ListAllTagsParamsDTO) returns (TagListDTO) {};
 }


### PR DESCRIPTION
## Description
HS-1015: Inventory - Partial Search on Tags

the ui needs to search for the tags for the auto populate box, this is adding that functionality to the list endpoints as an optional search term string

```
query {
    tags (searchTerm: "abc") {
        id,
        tenantId,
        name
    }
}
```
```
query {
    tagsByNodeId (nodeId: 1, searchTerm: "abc") {
        id,
        tenantId,
        name
    }
}
```

## Jira link(s)
- https://issues.opennms.org/browse/HS-1015

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
