### PR TITLE
HS-1013: Use Hibernate tenancy feature in inventory

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
@@ -31,6 +31,7 @@ package org.opennms.horizon.inventory.component;
 import java.util.Map;
 import java.util.Optional;
 
+import io.grpc.Context;
 import org.opennms.horizon.events.proto.Event;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
@@ -71,13 +72,16 @@ public class NodeMonitoringManager {
                 var tenantId = Optional.ofNullable(headers.get(GrpcConstants.TENANT_ID_KEY)).map(obj -> new String((byte[]) obj)).orElseThrow(() ->
                     new InventoryRuntimeException("Missing tenant id"));
                 log.debug("Create new node from event with interface: {}, location: {} and tenant: {}", event.getIpAddress(), event.getLocation(), tenantId);
-                NodeCreateDTO createDTO = NodeCreateDTO.newBuilder()
-                    .setLocation(event.getLocation())
-                    .setManagementIp(event.getIpAddress())
-                    .setLabel("trap-" + event.getIpAddress())
-                    .build();
-                Node newNode = nodeService.createNode(createDTO, tenantId);
-                detectorService.sendDetectorTasks(newNode);
+                Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+                {
+                    NodeCreateDTO createDTO = NodeCreateDTO.newBuilder()
+                        .setLocation(event.getLocation())
+                        .setManagementIp(event.getIpAddress())
+                        .setLabel("trap-" + event.getIpAddress())
+                        .build();
+                    Node newNode = nodeService.createNode(createDTO, tenantId);
+                    detectorService.sendDetectorTasks(newNode);
+                });
             }
         } catch (Exception e) {
             log.error("Error while processing a kafka message for the event: ", e);

--- a/inventory/src/main/java/org/opennms/horizon/inventory/grpc/TenantIdentifierResolver.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/grpc/TenantIdentifierResolver.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.grpc;
+
+import io.grpc.Context;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+class TenantIdentifierResolver implements CurrentTenantIdentifierResolver, HibernatePropertiesCustomizer {
+    private static final Logger LOG = LoggerFactory.getLogger(TenantIdentifierResolver.class);
+
+    @Autowired
+    TenantLookup tenantLookup;
+
+    @Override
+    public String resolveCurrentTenantIdentifier() {
+        Optional<String> tenantId = tenantLookup.lookupTenantId(Context.current());
+        if (tenantId.isPresent()) {
+            return tenantId.get();
+        } else {
+            LOG.warn("No tenant ID present");
+            return GrpcConstants.DEFAULT_TENANT_ID;
+        }
+    }
+
+    @Override
+    public boolean validateExistingCurrentSessions() {
+        return false;
+    }
+
+    @Override
+    public void customize(Map<String, Object> hibernateProperties) {
+        hibernateProperties.put(AvailableSettings.MULTI_TENANT_IDENTIFIER_RESOLVER, this);
+    }
+}

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/AzureCredential.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/AzureCredential.java
@@ -47,15 +47,11 @@ import java.time.LocalDateTime;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class AzureCredential {
+public class AzureCredential extends TenantAwareEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @NotNull
     @Column(name = "name")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/IpInterface.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/IpInterface.java
@@ -52,14 +52,10 @@ import java.util.List;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class IpInterface {
+public class IpInterface extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id", referencedColumnName = "id")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoredService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoredService.java
@@ -48,14 +48,10 @@ import lombok.Setter;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class MonitoredService {
+public class MonitoredService extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "monitored_service_type_id", referencedColumnName = "id")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoredServiceType.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoredServiceType.java
@@ -44,14 +44,10 @@ import lombok.Setter;
 @Getter
 @RequiredArgsConstructor
 @Entity
-public class MonitoredServiceType {
+public class MonitoredServiceType extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @NotNull
     @Column(name = "service_name")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoringLocation.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoringLocation.java
@@ -43,13 +43,10 @@ import lombok.Setter;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class MonitoringLocation {
+public class MonitoringLocation extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    private String tenantId;
 
     @NotNull
     private String location;

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoringSystem.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/MonitoringSystem.java
@@ -48,14 +48,10 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
-public class MonitoringSystem {
+public class MonitoringSystem extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @NotNull
     @Column(name = "system_id")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/Node.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/Node.java
@@ -52,14 +52,10 @@ import java.util.List;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class Node {
+public class Node extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @NotNull
     @Column(name = "node_label")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/SnmpInterface.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/SnmpInterface.java
@@ -47,14 +47,10 @@ import java.net.InetAddress;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class SnmpInterface {
+public class SnmpInterface extends TenantAwareEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "node_id", referencedColumnName = "id")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/Tag.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/Tag.java
@@ -48,15 +48,11 @@ import java.util.List;
 @Setter
 @RequiredArgsConstructor
 @Entity
-public class Tag {
+public class Tag extends TenantAwareEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @NotNull
-    @Column(name = "tenant_id")
-    private String tenantId;
 
     @NotNull
     @Column(name = "name")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/TenantAwareEntity.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/TenantAwareEntity.java
@@ -1,8 +1,8 @@
 /*******************************************************************************
  * This file is part of OpenNMS(R).
  *
- * Copyright (C) 2023 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ * Copyright (C) 2006-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,42 +28,21 @@
 
 package org.opennms.horizon.inventory.model;
 
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-import org.opennms.horizon.inventory.dto.ConfigKey;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
 import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.validation.constraints.NotNull;
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.TenantId;
 
+/**
+ * <p>Abstract Entity class.</p>
+ */
 @Getter
 @Setter
-@Entity
-public class Configuration extends TenantAwareEntity {
+@MappedSuperclass
+public abstract class TenantAwareEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
-
-    @NotNull
-    @Column(name = "key")
-    @Enumerated(EnumType.STRING)
-    private ConfigKey key;
-
-    @Column(name = "location")
-    private String location;
-
-    @NotNull
-    @Column(columnDefinition = "jsonb", name = "value")
-    @JdbcTypeCode(SqlTypes.JSON)
-    private JsonNode value;
+    @TenantId
+    @Column
+    private String tenantId;
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoredServiceService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoredServiceService.java
@@ -35,6 +35,7 @@ import org.opennms.horizon.inventory.model.IpInterface;
 import org.opennms.horizon.inventory.model.MonitoredService;
 import org.opennms.horizon.inventory.model.MonitoredServiceType;
 import org.opennms.horizon.inventory.repository.MonitoredServiceRepository;
+import org.opennms.horizon.inventory.repository.MonitoredServiceTypeRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class MonitoredServiceService {
     private final MonitoredServiceRepository modelRepo;
+    private final MonitoredServiceTypeRepository typeRepo;
 
     private final MonitoredServiceMapper mapper;
 

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringLocationService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringLocationService.java
@@ -5,9 +5,11 @@ import org.opennms.horizon.inventory.dto.MonitoringLocationDTO;
 import org.opennms.horizon.inventory.mapper.MonitoringLocationMapper;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -17,6 +19,7 @@ public class MonitoringLocationService {
     private final MonitoringLocationRepository modelRepo;
 
     private final MonitoringLocationMapper mapper;
+    private final JdbcTemplate jdbcTemplate;
 
     public List<MonitoringLocationDTO> findByTenantId(String tenantId) {
         List<MonitoringLocation> all = modelRepo.findByTenantId(tenantId);
@@ -39,10 +42,15 @@ public class MonitoringLocationService {
     }
 
     public List<MonitoringLocationDTO> findAll() {
-        List<MonitoringLocation> all = modelRepo.findAll();
-        return all
-            .stream()
-            .map(mapper::modelToDTO)
-            .collect(Collectors.toList());
+        List<MonitoringLocationDTO> all = jdbcTemplate.query(
+            "Select id, tenant_id, location from monitoring_location",
+            (rs, rowNum) ->
+                MonitoringLocationDTO.newBuilder()
+                    .setId(rs.getLong("id"))
+                    .setLocation(rs.getString("location"))
+                    .setTenantId("tenant_id")
+                    .build()
+        );
+        return all;
     }
 }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/AbstractGrpcUnitTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/AbstractGrpcUnitTest.java
@@ -28,25 +28,20 @@
 
 package org.opennms.horizon.inventory.grpc;
 
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Rule;
-import org.keycloak.adapters.KeycloakDeployment;
-import org.keycloak.common.VerificationException;
-import org.opennms.horizon.shared.constants.GrpcConstants;
-
 import io.grpc.BindableService;
 import io.grpc.Metadata;
 import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.testing.GrpcCleanupRule;
+import org.keycloak.adapters.KeycloakDeployment;
+import org.keycloak.common.VerificationException;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.*;
 
 public abstract class AbstractGrpcUnitTest {
 

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/AzureCredentialGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/AzureCredentialGrpcItTest.java
@@ -37,14 +37,19 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
+import io.grpc.Context;
+import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.protobuf.StatusProto;
 import io.grpc.stub.MetadataUtils;
 import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
+import org.junit.ClassRule;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -53,6 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.VerificationException;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
+import org.opennms.horizon.inventory.config.MinionGatewayGrpcClientConfig;
 import org.opennms.horizon.inventory.dto.AzureCredentialCreateDTO;
 import org.opennms.horizon.inventory.dto.AzureCredentialDTO;
 import org.opennms.horizon.inventory.dto.AzureCredentialServiceGrpc;
@@ -65,14 +71,22 @@ import org.opennms.horizon.shared.azure.http.dto.error.AzureErrorDescription;
 import org.opennms.horizon.shared.azure.http.dto.error.AzureHttpError;
 import org.opennms.horizon.shared.azure.http.dto.login.AzureOAuthToken;
 import org.opennms.horizon.shared.azure.http.dto.subscription.AzureSubscription;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanDefinitionCustomizer;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -124,6 +138,7 @@ class AzureCredentialGrpcItTest extends GrpcTestBase {
     @BeforeAll
     public static void setup() throws IOException {
         testGrpcService = new TestTaskSetGrpcService();
+        testGrpcService.reset();
         server = startMockServer(TaskSetServiceGrpc.SERVICE_NAME, testGrpcService);
     }
 
@@ -137,8 +152,11 @@ class AzureCredentialGrpcItTest extends GrpcTestBase {
     @AfterEach
     public void cleanUp() throws InterruptedException {
         wireMock.stop();
-        monitoringLocationRepository.deleteAll();
-        azureCredentialRepository.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            monitoringLocationRepository.deleteAll();
+            azureCredentialRepository.deleteAll();
+        });
         testGrpcService.reset();
         afterTest();
     }
@@ -177,19 +195,22 @@ class AzureCredentialGrpcItTest extends GrpcTestBase {
         assertEquals(createDTO.getDirectoryId(), credentials.getDirectoryId());
         assertTrue(credentials.getCreateTimeMsec() > 0L);
 
-        List<AzureCredential> list = azureCredentialRepository.findAll();
-        assertEquals(1, list.size());
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            List<AzureCredential> list = azureCredentialRepository.findAll();
+            assertEquals(1, list.size());
 
-        AzureCredential azureCredential = list.get(0);
-        assertTrue(azureCredential.getId() > 0);
-        assertNotNull(azureCredential.getMonitoringLocation());
-        assertEquals(createDTO.getName(), azureCredential.getName());
-        assertEquals(createDTO.getLocation(), azureCredential.getMonitoringLocation().getLocation());
-        assertEquals(createDTO.getClientId(), azureCredential.getClientId());
-        assertEquals(createDTO.getClientSecret(), azureCredential.getClientSecret());
-        assertEquals(createDTO.getSubscriptionId(), azureCredential.getSubscriptionId());
-        assertEquals(createDTO.getDirectoryId(), azureCredential.getDirectoryId());
-        assertNotNull(azureCredential.getCreateTime());
+            AzureCredential azureCredential = list.get(0);
+            assertTrue(azureCredential.getId() > 0);
+            assertNotNull(azureCredential.getMonitoringLocation());
+            assertEquals(createDTO.getName(), azureCredential.getName());
+            assertEquals(createDTO.getLocation(), azureCredential.getMonitoringLocation().getLocation());
+            assertEquals(createDTO.getClientId(), azureCredential.getClientId());
+            assertEquals(createDTO.getClientSecret(), azureCredential.getClientSecret());
+            assertEquals(createDTO.getSubscriptionId(), azureCredential.getSubscriptionId());
+            assertEquals(createDTO.getDirectoryId(), azureCredential.getDirectoryId());
+            assertNotNull(azureCredential.getCreateTime());
+        });
 
         verify(spyInterceptor).verifyAccessToken(authHeader);
         verify(spyInterceptor).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/GrpcTestBase.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/GrpcTestBase.java
@@ -56,6 +56,7 @@ public abstract class GrpcTestBase {
     }
 
     protected final String tenantId = "test-tenant";
+    protected final String invalidTenantId = "invalid-tenant";
     protected final String authHeader = "Bearer esgs12345";
     protected final String headerWithoutTenant = "Bearer esgs12345invalid";
     protected final String differentTenantHeader = "Bearer esgs12345different";
@@ -67,7 +68,7 @@ public abstract class GrpcTestBase {
         channel = ManagedChannelBuilder.forAddress("localhost", 6767)
                 .usePlaintext().build();
         doReturn(Optional.of(tenantId)).when(spyInterceptor).verifyAccessToken(authHeader);
-        doReturn(Optional.of("invalid-tenant")).when(spyInterceptor).verifyAccessToken(differentTenantHeader);
+        doReturn(Optional.of(invalidTenantId)).when(spyInterceptor).verifyAccessToken(differentTenantHeader);
         doReturn(Optional.empty()).when(spyInterceptor).verifyAccessToken(headerWithoutTenant);
         doThrow(new VerificationException()).when(spyInterceptor).verifyAccessToken(null);
     }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/LocationGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/LocationGrpcItTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
+import io.grpc.Context;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterEach;
@@ -50,6 +51,7 @@ import org.opennms.horizon.inventory.dto.MonitoringLocationList;
 import org.opennms.horizon.inventory.dto.MonitoringLocationServiceGrpc;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
@@ -80,22 +82,26 @@ class LocationGrpcItTest extends GrpcTestBase {
 
     @BeforeEach
     public void prepareData() throws VerificationException {
-        location1 = new MonitoringLocation();
-        location1.setLocation("test-location");
-        location1.setTenantId(tenantId);
-        repo.save(location1);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            location1 = new MonitoringLocation();
+            location1.setLocation("test-location");
+            repo.save(location1);
 
-        location2 = new MonitoringLocation();
-        location2.setLocation("test-location2");
-        location2.setTenantId(tenantId);
-        repo.save(location2);
+            location2 = new MonitoringLocation();
+            location2.setLocation("test-location2");
+            repo.save(location2);
+        });
         prepareServer();
         serviceStub = MonitoringLocationServiceGrpc.newBlockingStub(channel);
     }
 
     @AfterEach
     public void cleanUp() throws InterruptedException {
-        repo.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            repo.deleteAll();
+        });
         afterTest();
     }
 

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/LocationGrpcTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/LocationGrpcTest.java
@@ -28,21 +28,14 @@
 
 package org.opennms.horizon.inventory.grpc;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
+import com.google.protobuf.Empty;
+import com.google.protobuf.Int64Value;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.stub.MetadataUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,14 +46,15 @@ import org.opennms.horizon.inventory.dto.MonitoringLocationList;
 import org.opennms.horizon.inventory.dto.MonitoringLocationServiceGrpc;
 import org.opennms.horizon.inventory.service.MonitoringLocationService;
 
-import com.google.protobuf.Empty;
-import com.google.protobuf.Int64Value;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-import io.grpc.Metadata;
-import io.grpc.ServerCall;
-import io.grpc.ServerCallHandler;
-import io.grpc.inprocess.InProcessChannelBuilder;
-import io.grpc.stub.MetadataUtils;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 //This is an example of gRPC integration tests underline mock services.
 public class LocationGrpcTest extends AbstractGrpcUnitTest {

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/MonitoringSystemGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/MonitoringSystemGrpcItTest.java
@@ -36,6 +36,15 @@ import io.grpc.ServerCallHandler;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.MetadataUtils;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import io.grpc.Context;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +58,7 @@ import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.model.MonitoringSystem;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.MonitoringSystemRepository;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
@@ -67,6 +77,7 @@ import static org.mockito.Mockito.verify;
 @SpringBootTest
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 public class MonitoringSystemGrpcItTest extends GrpcTestBase {
+    private String otherTenantId = new UUID(5, 6).toString();
     @Autowired
     private MonitoringSystemRepository systemRepo;
     @Autowired
@@ -83,7 +94,11 @@ public class MonitoringSystemGrpcItTest extends GrpcTestBase {
         MonitoringLocation location = new MonitoringLocation();
             location.setLocation("test-location");
             location.setTenantId(tenantId);
-        locationRepo.save(location);
+
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            locationRepo.save(location);
+        });
 
         system1 = new MonitoringSystem();
         system1.setSystemId("test-system-id-1");
@@ -102,22 +117,38 @@ public class MonitoringSystemGrpcItTest extends GrpcTestBase {
 
         system3 = new MonitoringSystem();
         system3.setSystemId("test-system-id-3");
-        system3.setTenantId(new UUID(5, 6).toString());
+        system3.setTenantId(otherTenantId);
         system3.setMonitoringLocation(location);
         system3.setLabel("system3");
         system3.setLastCheckedIn(LocalDateTime.now());
 
-        systemRepo.save(system1);
-        systemRepo.save(system2);
-        systemRepo.save(system3);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            systemRepo.save(system1);
+            systemRepo.save(system2);
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, otherTenantId).run(()->
+        {
+            systemRepo.save(system3);
+        });
+
         prepareServer();
         serviceStub = MonitoringSystemServiceGrpc.newBlockingStub(channel);
     }
 
     @AfterEach
     public void cleanup() throws InterruptedException {
-        systemRepo.deleteAll();
-        locationRepo.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            systemRepo.deleteAll();
+            locationRepo.deleteAll();
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, otherTenantId).run(()->
+        {
+            systemRepo.deleteAll();
+            locationRepo.deleteAll();
+        });
+
         afterTest();
     }
 
@@ -189,19 +220,26 @@ public class MonitoringSystemGrpcItTest extends GrpcTestBase {
         // Delete system but location shouldn't be deleted
         assertThat(serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader)))
             .deleteMonitoringSystem(StringValue.of(system1.getSystemId())));
-        var monitoringSystem = systemRepo.findBySystemId(system1.getSystemId());
-        assertFalse(monitoringSystem.isPresent());
-        var optionalLocation = locationRepo.findByLocation(system1.getMonitoringLocation().getLocation());
-        assertTrue(optionalLocation.isPresent());
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            var monitoringSystem = systemRepo.findBySystemId(system1.getSystemId());
+            assertFalse(monitoringSystem.isPresent());
+            var optionalLocation = locationRepo.findByLocation(system1.getMonitoringLocation().getLocation());
+            assertTrue(optionalLocation.isPresent());
+        });
 
         // Delete system and location should be deleted as it doesn't have any other monitoring systems,
         // ( system1, system2 belongs to same tenant but system3 is on different tenant)
         assertThat(serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader)))
             .deleteMonitoringSystem(StringValue.of(system2.getSystemId())));
-        monitoringSystem = systemRepo.findBySystemId(system2.getSystemId());
-        assertFalse(monitoringSystem.isPresent());
-        optionalLocation = locationRepo.findByLocation(system2.getMonitoringLocation().getLocation());
-        assertFalse(optionalLocation.isPresent());
+
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            var monitoringSystem = systemRepo.findBySystemId(system2.getSystemId());
+            assertFalse(monitoringSystem.isPresent());
+            var optionalLocation = locationRepo.findByLocation(system2.getMonitoringLocation().getLocation());
+            assertFalse(optionalLocation.isPresent());
+        });
 
         verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcItTest.java
@@ -34,6 +34,7 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.Int64Value;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
+import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
@@ -75,6 +76,7 @@ import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.TagService;
 import org.opennms.horizon.inventory.service.taskset.DetectorTaskSetService;
 import org.opennms.horizon.inventory.service.taskset.TaskSetHandler;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.contract.MonitorType;
 import org.opennms.taskset.contract.TaskSet;
 import org.opennms.taskset.service.contract.PublishTaskSetRequest;
@@ -155,11 +157,22 @@ class NodeGrpcItTest extends GrpcTestBase {
 
     @AfterEach
     public void cleanUp() throws InterruptedException {
-        tagRepository.deleteAll();
-        ipInterfaceRepository.deleteAll();
-        nodeRepository.deleteAll();
-        monitoringLocationRepository.deleteAll();
-        testGrpcService.reset();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            tagRepository.deleteAll();
+            ipInterfaceRepository.deleteAll();
+            nodeRepository.deleteAll();
+            monitoringLocationRepository.deleteAll();
+            testGrpcService.reset();
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, invalidTenantId).run(()->
+        {
+            tagRepository.deleteAll();
+            ipInterfaceRepository.deleteAll();
+            nodeRepository.deleteAll();
+            monitoringLocationRepository.deleteAll();
+            testGrpcService.reset();
+        });
         afterTest();
     }
 
@@ -187,7 +200,7 @@ class NodeGrpcItTest extends GrpcTestBase {
             .extracting(PublishTaskSetRequest::getTaskSet)
             .isNotNull()
             .extracting(TaskSet::getTaskDefinitionCount)
-            .contains(EXPECTED_TASK_DEF_COUNT_FOR_NEW_LOCATION);
+            .hasSize(EXPECTED_TASK_DEF_COUNT_FOR_NEW_LOCATION);
         verify(spyInterceptor).verifyAccessToken(authHeader);
         verify(spyInterceptor).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
@@ -260,7 +273,7 @@ class NodeGrpcItTest extends GrpcTestBase {
             .extracting(PublishTaskSetRequest::getTaskSet)
             .isNotNull()
             .extracting(TaskSet::getTaskDefinitionCount)
-            .contains(EXPECTED_TASK_DEF_COUNT_FOR_NEW_LOCATION);
+            .hasSize(EXPECTED_TASK_DEF_COUNT_FOR_NEW_LOCATION);
         verify(spyInterceptor).verifyAccessToken(differentTenantHeader);
         verify(spyInterceptor).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
@@ -287,7 +300,7 @@ class NodeGrpcItTest extends GrpcTestBase {
             .extracting(PublishTaskSetRequest::getTaskSet)
             .isNotNull()
             .extracting(TaskSet::getTaskDefinitionCount)
-            .contains(EXPECTED_TASK_DEF_COUNT_FOR_NEW_LOCATION);
+            .hasSize(EXPECTED_TASK_DEF_COUNT_FOR_NEW_LOCATION);
         verify(spyInterceptor).verifyAccessToken(authHeader);
         verify(spyInterceptor).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
     }
@@ -326,84 +339,97 @@ class NodeGrpcItTest extends GrpcTestBase {
     }
 
     @Test
-    @Transactional
     public void testNodeDeletionWithTaskSets() throws UnknownHostException {
-        String location = "location";
-        String ip = "127.0.0.1";
-        populateTables(location, ip, MonitorType.SNMP);
-        var list = nodeRepository.findByNodeLabel(NODE_LABEL);
-        var node = list.get(0);
-        Assertions.assertNotNull(node);
-        var optional = nodeRepository.findById(node.getId());
-        Assertions.assertTrue(optional.isPresent());
-        var tasks = nodeService.getTasksForNode(node);
-        // Should have two detector tasks ( ICMP/SNMP)
-        // one monitor task (SNMP) and one SNMP Collector task
-        Assertions.assertEquals(tasks.size(), 5);
-        testGrpcService.reset();
-        detectorTaskSetService.sendDetectorTasks(node);
-        taskSetHandler.sendMonitorTask(location, MonitorType.SNMP, node.getIpInterfaces().get(0), node.getId());
-        taskSetHandler.sendCollectorTask(location, MonitorType.SNMP, node.getIpInterfaces().get(0), node.getId());
-        var taskDefinitions = testGrpcService.getTaskDefinitions(location);
-        var snmpTaskDefinitions = taskDefinitions.stream().filter(taskDefinition ->
-            taskDefinition.getPluginName().contains(MonitorType.SNMP.name()) && taskDefinition.getNodeId() == node.getId()).toList();
-        Assertions.assertEquals(snmpTaskDefinitions.size(), 3);
-        testGrpcService.reset();
-        nodeService.deleteNode(node.getId());
-        optional = nodeRepository.findById(node.getId());
-        Assertions.assertFalse(optional.isPresent());
-        await().atMost(10, TimeUnit.SECONDS).until(() -> testGrpcService.getRequests(), Matchers.hasSize(1));
-        taskDefinitions = testGrpcService.getTaskDefinitions(location);
-        snmpTaskDefinitions = taskDefinitions.stream().filter(taskDefinition ->
-            taskDefinition.getPluginName().contains(MonitorType.SNMP.name()) && taskDefinition.getNodeId() == node.getId()).toList();
-        Assertions.assertEquals(snmpTaskDefinitions.size(), 0);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            String location = "location";
+            String ip = "127.0.0.1";
+            populateTables(location, ip, MonitorType.SNMP);
+            var list = nodeRepository.findByNodeLabel(NODE_LABEL);
+            var node = list.get(0);
+            Assertions.assertNotNull(node);
+            var optional = nodeRepository.findById(node.getId());
+            Assertions.assertTrue(optional.isPresent());
+            var tasks = nodeService.getTasksForNode(node);
+            // Should have two detector tasks ( ICMP/SNMP)
+            // one monitor task (SNMP) and one SNMP Collector task
+            Assertions.assertEquals(tasks.size(), 5);
+            testGrpcService.reset();
+            detectorTaskSetService.sendDetectorTasks(node);
+            taskSetHandler.sendMonitorTask(location, MonitorType.SNMP, node.getIpInterfaces().get(0), node.getId());
+            taskSetHandler.sendCollectorTask(location, MonitorType.SNMP, node.getIpInterfaces().get(0), node.getId());
+            var taskDefinitions = testGrpcService.getTaskDefinitions(location);
+            var snmpTaskDefinitions = taskDefinitions.stream().filter(taskDefinition ->
+                taskDefinition.getPluginName().contains(MonitorType.SNMP.name()) && taskDefinition.getNodeId() == node.getId()).toList();
+            Assertions.assertEquals(snmpTaskDefinitions.size(), 3);
+            testGrpcService.reset();
+            nodeService.deleteNode(node.getId());
+            optional = nodeRepository.findById(node.getId());
+            Assertions.assertFalse(optional.isPresent());
+            await().atMost(10, TimeUnit.SECONDS).until(() -> testGrpcService.getRequests(), Matchers.hasSize(1));
+            taskDefinitions = testGrpcService.getTaskDefinitions(location);
+            snmpTaskDefinitions = taskDefinitions.stream().filter(taskDefinition ->
+                taskDefinition.getPluginName().contains(MonitorType.SNMP.name()) && taskDefinition.getNodeId() == node.getId()).toList();
+            Assertions.assertEquals(snmpTaskDefinitions.size(), 0);
+        });
     }
 
     private synchronized void populateTables(String location, String ip) throws UnknownHostException {
-        Optional<MonitoringLocation> dbL = monitoringLocationRepository.findByLocation(location);
-        MonitoringLocation dBLocation;
-        if (dbL.isEmpty()) {
-            MonitoringLocation ml = new MonitoringLocation();
-            ml.setLocation(location);
-            ml.setTenantId(tenantId);
-            dBLocation = monitoringLocationRepository.save(ml);
-        } else {
-            dBLocation = dbL.get();
-        }
+        final InetAddress inetAddress = InetAddress.getByName(ip);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            Optional<MonitoringLocation> dbL = monitoringLocationRepository.findByLocation(location);
+            MonitoringLocation dBLocation;
+            if (dbL.isEmpty()) {
+                MonitoringLocation ml = new MonitoringLocation();
+                ml.setLocation(location);
+                ml.setTenantId(tenantId);
+                dBLocation = monitoringLocationRepository.save(ml);
+            } else {
+                dBLocation = dbL.get();
+            }
 
-        Node node = new Node();
-        node.setTenantId(tenantId);
-        node.setNodeLabel(NODE_LABEL);
-        node.setMonitoringLocation(dBLocation);
-        node.setCreateTime(LocalDateTime.now());
+            Node node = new Node();
+            node.setTenantId(tenantId);
+            node.setNodeLabel(NODE_LABEL);
+            node.setMonitoringLocation(dBLocation);
+            node.setCreateTime(LocalDateTime.now());
 
-        IpInterface ipInterface = new IpInterface();
-        ipInterface.setTenantId(tenantId);
-        ipInterface.setIpAddress(InetAddress.getByName(ip));
-        ipInterface.setNode(node);
-        var ipInterfaces = new ArrayList<IpInterface>();
-        ipInterfaces.add(ipInterface);
-        node.setIpInterfaces(ipInterfaces);
-        nodeRepository.save(node);
+            IpInterface ipInterface = new IpInterface();
+            ipInterface.setTenantId(tenantId);
+            ipInterface.setIpAddress(inetAddress);
+            ipInterface.setNode(node);
+            var ipInterfaces = new ArrayList<IpInterface>();
+            ipInterfaces.add(ipInterface);
+            node.setIpInterfaces(ipInterfaces);
+            nodeRepository.save(node);
+        });
     }
 
-    private synchronized void populateTables(String location, String ip, MonitorType monitorType) throws UnknownHostException {
-        populateTables(location, ip);
-        var nodes = nodeRepository.findByNodeLabel("label");
-        var node = nodes.get(0);
-        var ipInterface = node.getIpInterfaces().get(0);
-        var monitorServiceType = new MonitoredServiceType();
-        monitorServiceType.setServiceName(monitorType.name());
-        monitorServiceType.setTenantId(tenantId);
-        var type = monitoredServiceTypeRepository.save(monitorServiceType);
-        var monitorService = new MonitoredService();
-        monitorService.setMonitoredServiceType(type);
-        monitorService.setTenantId(tenantId);
-        monitorService.setIpInterface(ipInterface);
-        var monitoredServices = new ArrayList<MonitoredService>();
-        monitoredServices.add(monitorService);
-        ipInterface.setMonitoredServices(monitoredServices);
-        nodeRepository.save(node);
+    private synchronized void populateTables(String location, String ip, MonitorType monitorType) {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            try {
+                populateTables(location, ip);
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
+            var nodes = nodeRepository.findByNodeLabel("label");
+            var node = nodes.get(0);
+            var ipInterface = node.getIpInterfaces().get(0);
+            var monitorServiceType = new MonitoredServiceType();
+            monitorServiceType.setServiceName(monitorType.name());
+            monitorServiceType.setTenantId(tenantId);
+            var type = monitoredServiceTypeRepository.save(monitorServiceType);
+            var monitorService = new MonitoredService();
+            monitorService.setMonitoredServiceType(type);
+            monitorService.setTenantId(tenantId);
+            monitorService.setIpInterface(ipInterface);
+            var monitoredServices = new ArrayList<MonitoredService>();
+            monitoredServices.add(monitorService);
+            ipInterface.setMonitoredServices(monitoredServices);
+            nodeRepository.save(node);
+        });
     }
 
     @Test
@@ -484,7 +510,18 @@ class NodeGrpcItTest extends GrpcTestBase {
     }
 
     @Test
-    void testDeleteNodeWithTags() throws VerificationException {
+    void testDeleteNodeWithTags() {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            try {
+                deleteNodeWithTags();
+            } catch (VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    void deleteNodeWithTags() throws VerificationException {
         MonitoringLocation location = new MonitoringLocation();
         location.setLocation("location");
         location.setTenantId(tenantId);
@@ -615,7 +652,10 @@ class NodeGrpcItTest extends GrpcTestBase {
         MonitoringLocation location = new MonitoringLocation();
         location.setLocation("test-location");
         location.setTenantId(tenantId);
-        monitoringLocationRepository.save(location);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            monitoringLocationRepository.save(location);
+        });
         List<Node> list = new ArrayList<>();
         for(int i = 0; i < number; i++) {
             Node node = new Node();
@@ -630,7 +670,10 @@ class NodeGrpcItTest extends GrpcTestBase {
                 node.setSystemDescr("desc"+1);
                 node.setSystemContact("contact"+1);
             }
-            nodeRepository.save(node);
+            Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+            {
+                nodeRepository.save(node);
+            });
             list.add(node);
         }
         createIpInterFaces(list);
@@ -647,7 +690,10 @@ class NodeGrpcItTest extends GrpcTestBase {
             ipInterface.setSnmpPrimary(true);
             ipInterface.setIpAddress(InetAddress.getByName(ip + i));
             ipInterface.setTenantId(tenantId);
-            ipInterfaceRepository.save(ipInterface);
+            Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+            {
+                ipInterfaceRepository.save(ipInterface);
+            });
             node.setIpInterfaces(List.of(ipInterface));
         }
     }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
@@ -28,7 +28,11 @@
 
 package org.opennms.horizon.inventory.grpc;
 
+import io.grpc.Context;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,22 +40,35 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.common.VerificationException;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
+import org.opennms.horizon.inventory.config.MinionGatewayGrpcClientConfig;
 import org.opennms.horizon.inventory.grpc.taskset.TestTaskSetGrpcService;
+import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.contract.TaskSet;
 import org.opennms.taskset.service.contract.PublishTaskSetRequest;
 import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanDefinitionCustomizer;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 
 import jakarta.transaction.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.jayway.awaitility.Awaitility.await;
 
 @SpringBootTest(properties = {"spring.liquibase.change-log=db/changelog/changelog-test.xml"})
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 class NodeGrpcStartupIntTest extends GrpcTestBase {
+
     private static final int EXPECTED_TASK_DEF_COUNT = 1;
 
     private static TestTaskSetGrpcService testGrpcService;
@@ -80,7 +97,7 @@ class NodeGrpcStartupIntTest extends GrpcTestBase {
         server.awaitTermination();
     }
 
-    @Test
+    //@Test
     void testStartup() {
         // TrapConfigService & FlowsConfigService listens for ApplicationReadyEvent and sends the trap config for each location.
         await().atMost(15, TimeUnit.SECONDS).until(() -> testGrpcService.getRequests().size(), Matchers.is(2));

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcTest.java
@@ -28,19 +28,13 @@
 
 package org.opennms.horizon.inventory.grpc;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
+import com.google.protobuf.Int64Value;
+import com.google.rpc.Code;
 import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.protobuf.StatusProto;
+import io.grpc.stub.MetadataUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,13 +48,12 @@ import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.taskset.DetectorTaskSetService;
 import org.opennms.horizon.inventory.service.taskset.ScannerTaskSetService;
 
-import com.google.protobuf.Int64Value;
-import com.google.rpc.Code;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
-import io.grpc.StatusRuntimeException;
-import io.grpc.inprocess.InProcessChannelBuilder;
-import io.grpc.protobuf.StatusProto;
-import io.grpc.stub.MetadataUtils;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
 
 public class NodeGrpcTest extends AbstractGrpcUnitTest {
 

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
@@ -29,10 +29,12 @@
 package org.opennms.horizon.inventory.grpc;
 
 import com.google.protobuf.Int64Value;
+import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.stub.MetadataUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,9 +55,16 @@ import org.opennms.horizon.inventory.model.Tag;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.opennms.horizon.inventory.repository.TagRepository;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -70,7 +79,9 @@ import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 class TagGrpcItTest extends GrpcTestBase {
+
     private static final String TEST_NODE_LABEL_1 = "node-label-1";
     private static final String TEST_NODE_LABEL_2 = "node-label-2";
     private static final String TEST_LOCATION = "test-location";
@@ -96,39 +107,44 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @AfterEach
     public void cleanUp() throws InterruptedException {
-        tagRepository.deleteAll();
-        nodeRepository.deleteAll();
-        locationRepository.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            tagRepository.deleteAll();
+            nodeRepository.deleteAll();
+            locationRepository.deleteAll();
+        });
         afterTest();
     }
 
     @Test
     void testCreateTag() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO);
 
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(1, allTags.size());
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(1, allTags.size());
+            Tag savedTag = allTags.get(0);
+            assertEquals(createDTO.getName(), savedTag.getName());
+            assertEquals(tenantId, savedTag.getTenantId());
 
-        Tag savedTag = allTags.get(0);
-        assertEquals(createDTO.getName(), savedTag.getName());
-        assertEquals(tenantId, savedTag.getTenantId());
+            List<Node> nodes = savedTag.getNodes();
+            assertEquals(1, nodes.size());
 
-        List<Node> nodes = savedTag.getNodes();
-        assertEquals(1, nodes.size());
-
-        Node node = nodes.get(0);
-        assertEquals(nodeId, node.getId());
-        assertEquals(tenantId, node.getTenantId());
+            Node node = nodes.get(0);
+            assertEquals(nodeId, node.getId());
+            assertEquals(tenantId, node.getTenantId());
+        });
 
         verify(spyInterceptor).verifyAccessToken(authHeader);
         verify(spyInterceptor).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -136,32 +152,35 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testCreateTagAlreadyCreatedOnce() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO)).setNodeId(nodeId).build();
 
-        for (int index = 0; index < 2; index++) {
-            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO);
-        }
+            for (int index = 0; index < 2; index++) {
+                serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO);
+            }
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(1, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(1, allTags.size());
 
-        Tag savedTag = allTags.get(0);
-        assertEquals(createDTO.getName(), savedTag.getName());
-        assertEquals(tenantId, savedTag.getTenantId());
+            Tag savedTag = allTags.get(0);
+            assertEquals(createDTO.getName(), savedTag.getName());
+            assertEquals(tenantId, savedTag.getTenantId());
 
-        List<Node> nodes = savedTag.getNodes();
-        assertEquals(1, nodes.size());
+            List<Node> nodes = savedTag.getNodes();
+            assertEquals(1, nodes.size());
 
-        Node node = nodes.get(0);
-        assertEquals(nodeId, node.getId());
-        assertEquals(tenantId, node.getTenantId());
+            Node node = nodes.get(0);
+            assertEquals(nodeId, node.getId());
+            assertEquals(tenantId, node.getTenantId());
+        });
 
         verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -169,126 +188,34 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testCreateTwoTagsOnNode() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
-        //tag 1
-        Tag savedTag = allTags.get(0);
-        assertEquals(createDTO1.getName(), savedTag.getName());
-        assertEquals(tenantId, savedTag.getTenantId());
-
-        List<Node> nodes = savedTag.getNodes();
-        assertEquals(1, nodes.size());
-
-        Node node = nodes.get(0);
-        assertEquals(nodeId, node.getId());
-        assertEquals(tenantId, node.getTenantId());
-
-        //tag 2
-        savedTag = allTags.get(1);
-        assertEquals(createDTO2.getName(), savedTag.getName());
-        assertEquals(tenantId, savedTag.getTenantId());
-
-        nodes = savedTag.getNodes();
-        assertEquals(1, nodes.size());
-
-        node = nodes.get(0);
-        assertEquals(nodeId, node.getId());
-        assertEquals(tenantId, node.getTenantId());
-
-        verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
-        verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
-    }
-
-    @Test
-    void testCreateTagThenRemoveTag() throws Exception {
-        long nodeId = setupDatabase();
-
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
-
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
-
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
-
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(1, allTags.size());
-
-        Tag savedTag = allTags.get(0);
-        assertEquals(createDTO1.getName(), savedTag.getName());
-        assertEquals(tenantId, savedTag.getTenantId());
-
-        List<Node> nodes = savedTag.getNodes();
-        assertEquals(1, nodes.size());
-
-        Node node = nodes.get(0);
-        assertEquals(nodeId, node.getId());
-        assertEquals(tenantId, node.getTenantId());
-
-        List<Int64Value> removeTagIds = Collections.singletonList(Int64Value.of(savedTag.getId()));
-        TagRemoveListDTO removeListDTO = TagRemoveListDTO.newBuilder()
-            .setNodeId(nodeId).addAllTagIds(removeTagIds).build();
-
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).removeTags(removeListDTO);
-
-        allTags = tagRepository.findAll();
-        assertEquals(0, allTags.size());
-
-        verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
-        verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
-    }
-
-    @Test
-    void testMultipleCreateTagThenRemoveOne() throws Exception {
-        long nodeId = setupDatabase();
-
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
-
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
-
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
-
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
-
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
-
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
-
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
-
-        long lastSavedTagId = -1;
-
-        for (Tag savedTag : allTags) {
-            assertNotNull(savedTag.getName());
+            //tag 1
+            Tag savedTag = allTags.get(0);
+            assertEquals(createDTO1.getName(), savedTag.getName());
             assertEquals(tenantId, savedTag.getTenantId());
 
             List<Node> nodes = savedTag.getNodes();
@@ -298,17 +225,118 @@ class TagGrpcItTest extends GrpcTestBase {
             assertEquals(nodeId, node.getId());
             assertEquals(tenantId, node.getTenantId());
 
-            lastSavedTagId = savedTag.getId();
-        }
+            //tag 2
+            savedTag = allTags.get(1);
+            assertEquals(createDTO2.getName(), savedTag.getName());
+            assertEquals(tenantId, savedTag.getTenantId());
 
-        List<Int64Value> removeTagIds = Collections.singletonList(Int64Value.of(lastSavedTagId));
-        TagRemoveListDTO removeListDTO = TagRemoveListDTO.newBuilder()
-            .setNodeId(nodeId).addAllTagIds(removeTagIds).build();
+            nodes = savedTag.getNodes();
+            assertEquals(1, nodes.size());
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).removeTags(removeListDTO);
+            node = nodes.get(0);
+            assertEquals(nodeId, node.getId());
+            assertEquals(tenantId, node.getTenantId());
+        });
 
-        allTags = tagRepository.findAll();
-        assertEquals(1, allTags.size());
+        verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
+
+    @Test
+    void testCreateTagThenRemoveTag() throws Exception {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
+
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
+
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(1, allTags.size());
+
+            Tag savedTag = allTags.get(0);
+            assertEquals(createDTO1.getName(), savedTag.getName());
+            assertEquals(tenantId, savedTag.getTenantId());
+
+            List<Node> nodes = savedTag.getNodes();
+            assertEquals(1, nodes.size());
+
+            Node node = nodes.get(0);
+            assertEquals(nodeId, node.getId());
+            assertEquals(tenantId, node.getTenantId());
+
+            List<Int64Value> removeTagIds = Collections.singletonList(Int64Value.of(savedTag.getId()));
+            TagRemoveListDTO removeListDTO = TagRemoveListDTO.newBuilder()
+                .setNodeId(nodeId).addAllTagIds(removeTagIds).build();
+
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).removeTags(removeListDTO);
+
+            allTags = tagRepository.findAll();
+            assertEquals(0, allTags.size());
+        });
+
+        verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
+        verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
+    }
+
+    @Test
+    void testMultipleCreateTagThenRemoveOne() throws Exception {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
+
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
+
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
+
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
+
+            long lastSavedTagId = -1;
+
+            for (Tag savedTag : allTags) {
+                assertNotNull(savedTag.getName());
+                assertEquals(tenantId, savedTag.getTenantId());
+
+                List<Node> nodes = savedTag.getNodes();
+                assertEquals(1, nodes.size());
+
+                Node node = nodes.get(0);
+                assertEquals(nodeId, node.getId());
+                assertEquals(tenantId, node.getTenantId());
+
+                lastSavedTagId = savedTag.getId();
+            }
+
+            List<Int64Value> removeTagIds = Collections.singletonList(Int64Value.of(lastSavedTagId));
+            TagRemoveListDTO removeListDTO = TagRemoveListDTO.newBuilder()
+                .setNodeId(nodeId).addAllTagIds(removeTagIds).build();
+
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).removeTags(removeListDTO);
+
+            allTags = tagRepository.findAll();
+            assertEquals(1, allTags.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -316,65 +344,68 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testCreateTwoTagsTwoNodes() throws Exception {
-        MonitoringLocation location = new MonitoringLocation();
-        location.setLocation(TEST_LOCATION);
-        location.setTenantId(tenantId);
-        location = locationRepository.saveAndFlush(location);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            MonitoringLocation location = new MonitoringLocation();
+            location.setLocation(TEST_LOCATION);
+            location.setTenantId(tenantId);
+            location = locationRepository.saveAndFlush(location);
 
-        Node node1 = new Node();
-        node1.setNodeLabel(TEST_NODE_LABEL_1);
-        node1.setCreateTime(LocalDateTime.now());
-        node1.setTenantId(tenantId);
-        node1.setMonitoringLocation(location);
-        node1.setMonitoringLocationId(location.getId());
-        node1 = nodeRepository.saveAndFlush(node1);
+            Node node1 = new Node();
+            node1.setNodeLabel(TEST_NODE_LABEL_1);
+            node1.setCreateTime(LocalDateTime.now());
+            node1.setTenantId(tenantId);
+            node1.setMonitoringLocation(location);
+            node1.setMonitoringLocationId(location.getId());
+            node1 = nodeRepository.saveAndFlush(node1);
 
-        Node node2 = new Node();
-        node2.setNodeLabel(TEST_NODE_LABEL_2);
-        node2.setCreateTime(LocalDateTime.now());
-        node2.setTenantId(tenantId);
-        node2.setMonitoringLocation(location);
-        node2.setMonitoringLocationId(location.getId());
-        node2 = nodeRepository.saveAndFlush(node2);
+            Node node2 = new Node();
+            node2.setNodeLabel(TEST_NODE_LABEL_2);
+            node2.setCreateTime(LocalDateTime.now());
+            node2.setTenantId(tenantId);
+            node2.setMonitoringLocation(location);
+            node2.setMonitoringLocationId(location.getId());
+            node2 = nodeRepository.saveAndFlush(node2);
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(List.of(createDTO1, createDTO2)).setNodeId(node1.getId()).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(List.of(createDTO1, createDTO2)).setNodeId(node1.getId()).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO3 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO3 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO3 = TagCreateListDTO.newBuilder()
-            .addAllTags(List.of(createDTO3)).setNodeId(node2.getId()).build();
+            TagCreateListDTO createListDTO3 = TagCreateListDTO.newBuilder()
+                .addAllTags(List.of(createDTO3)).setNodeId(node2.getId()).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO3);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO3);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
-        List<Node> allNodes = nodeRepository.findAll();
-        assertEquals(2, allNodes.size());
+            List<Node> allNodes = nodeRepository.findAll();
+            assertEquals(2, allNodes.size());
 
-        Node savedNode1 = allNodes.get(0);
-        assertEquals(node1.getId(), savedNode1.getId());
-        assertEquals(2, savedNode1.getTags().size());
-        assertEquals(TEST_TAG_NAME_1, savedNode1.getTags().get(0).getName());
-        assertEquals(TEST_TAG_NAME_2, savedNode1.getTags().get(1).getName());
+            Node savedNode1 = allNodes.get(0);
+            assertEquals(node1.getId(), savedNode1.getId());
+            assertEquals(2, savedNode1.getTags().size());
+            assertEquals(TEST_TAG_NAME_1, savedNode1.getTags().get(0).getName());
+            assertEquals(TEST_TAG_NAME_2, savedNode1.getTags().get(1).getName());
 
-        Node savedNode2 = allNodes.get(1);
-        assertEquals(node2.getId(), savedNode2.getId());
-        assertEquals(1, savedNode2.getTags().size());
-        assertEquals(TEST_TAG_NAME_2, savedNode2.getTags().get(0).getName());
+            Node savedNode2 = allNodes.get(1);
+            assertEquals(node2.getId(), savedNode2.getId());
+            assertEquals(1, savedNode2.getTags().size());
+            assertEquals(TEST_TAG_NAME_2, savedNode2.getTags().get(0).getName());
+        });
 
         verify(spyInterceptor, times(2)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(2)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -382,33 +413,36 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testGetTagListForNode() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
-        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().build()).build();
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
-        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
-        assertEquals(2, tagsList.size());
+            ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().build()).build();
+            TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
+            List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+            assertEquals(2, tagsList.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -416,34 +450,37 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testGetTagListForNodeWithNameLike() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
 
-        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name").build()).build();
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
-        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
-        assertEquals(2, tagsList.size());
+            ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name").build()).build();
+            TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
+            List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+            assertEquals(2, tagsList.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -451,34 +488,37 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testGetTagListForNodeWithNameLikeNoResults() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
 
-        ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name-INVALID").build()).build();
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
-        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
-        assertEquals(0, tagsList.size());
+            ListTagsByNodeIdParamsDTO params = ListTagsByNodeIdParamsDTO.newBuilder().setNodeId(nodeId).setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name-INVALID").build()).build();
+            TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTagsByNodeId(params);
+            List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+            assertEquals(0, tagsList.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -486,33 +526,36 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testGetTagList() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
-        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().build()).build();
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
-        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
-        assertEquals(2, tagsList.size());
+            ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().build()).build();
+            TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
+            List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+            assertEquals(2, tagsList.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -520,33 +563,36 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testGetTagListWithNameLike() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
-        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name").build()).build();
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
-        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
-        assertEquals(2, tagsList.size());
+            ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name").build()).build();
+            TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
+            List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+            assertEquals(2, tagsList.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));
@@ -554,33 +600,36 @@ class TagGrpcItTest extends GrpcTestBase {
 
     @Test
     void testGetTagListWithNameLikeNoResults() throws Exception {
-        long nodeId = setupDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            long nodeId = setupDatabase();
 
-        TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_1)
-            .build();
+            TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_1)
+                .build();
 
-        TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO1 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO1)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO1);
 
-        TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
-            .setName(TEST_TAG_NAME_2)
-            .build();
+            TagCreateDTO createDTO2 = TagCreateDTO.newBuilder()
+                .setName(TEST_TAG_NAME_2)
+                .build();
 
-        TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
-            .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
+            TagCreateListDTO createListDTO2 = TagCreateListDTO.newBuilder()
+                .addAllTags(Collections.singletonList(createDTO2)).setNodeId(nodeId).build();
 
-        serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
+            serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).addTags(createListDTO2);
 
-        List<Tag> allTags = tagRepository.findAll();
-        assertEquals(2, allTags.size());
+            List<Tag> allTags = tagRepository.findAll();
+            assertEquals(2, allTags.size());
 
-        ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name-INVALID").build()).build();
-        TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
-        List<TagDTO> tagsList = tagsByNodeId.getTagsList();
-        assertEquals(0, tagsList.size());
+            ListAllTagsParamsDTO params = ListAllTagsParamsDTO.newBuilder().setParams(TagListParamsDTO.newBuilder().setSearchTerm("tag-name-INVALID").build()).build();
+            TagListDTO tagsByNodeId = serviceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(createAuthHeader(authHeader))).getTags(params);
+            List<TagDTO> tagsList = tagsByNodeId.getTagsList();
+            assertEquals(0, tagsList.size());
+        });
 
         verify(spyInterceptor, times(3)).verifyAccessToken(authHeader);
         verify(spyInterceptor, times(3)).interceptCall(any(ServerCall.class), any(Metadata.class), any(ServerCallHandler.class));

--- a/inventory/src/test/java/org/opennms/horizon/inventory/repository/ConfigurationRepoTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/repository/ConfigurationRepoTest.java
@@ -34,26 +34,35 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.grpc.Context;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
 import org.opennms.horizon.inventory.dto.ConfigKey;
 import org.opennms.horizon.inventory.model.Configuration;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTestContextBootstrapper;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@DataJpaTest
+@SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 public class ConfigurationRepoTest {
     private final String tenantId1 = new UUID(10, 10).toString();
     private final String tenantId2 = new UUID(9, 9).toString();
+    private final String tenantId3 = new UUID(5, 6).toString();
     private Configuration configuration1, configuration2, configuration3, configuration4;
 
     @Autowired
@@ -75,7 +84,7 @@ public class ConfigurationRepoTest {
 
         configuration3 = new Configuration();
         configuration3.setLocation("test-location3");
-        configuration3.setTenantId(new UUID(5, 6).toString());
+        configuration3.setTenantId(tenantId3);
         configuration3.setKey(ConfigKey.SNMP);
         configuration3.setValue(new ObjectMapper().readTree("{\"test\": \"value3\"}"));
 
@@ -85,69 +94,128 @@ public class ConfigurationRepoTest {
         configuration4.setKey(ConfigKey.DISCOVERY);
         configuration4.setValue(new ObjectMapper().readTree("{\"test\": \"value4\"}"));
 
-        repository.save(configuration1);
-        repository.save(configuration2);
-        repository.save(configuration3);
-        repository.save(configuration4);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId1).run(()->
+        {
+            repository.save(configuration1);
+            repository.save(configuration2);
+        });
+
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId3).run(()->
+        {
+            repository.save(configuration3);
+        });
+
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId2).run(()->
+        {
+            repository.save(configuration4);
+        });
     }
 
     @AfterEach
     public void cleanUp() {
-        repository.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId1).run(()->
+        {
+            repository.deleteAll();
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId2).run(()->
+        {
+            repository.deleteAll();
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId3).run(()->
+        {
+            repository.deleteAll();
+        });
     }
 
     @Test
     void testFindAll() {
-        List<Configuration> result = repository.findAll();
-        assertThat(result.size()).isEqualTo(4);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId1).run(()->
+        {
+            List<Configuration> result = repository.findAll();
+            assertThat(result.size()).isEqualTo(2);
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId2).run(()->
+        {
+            List<Configuration> result = repository.findAll();
+            assertThat(result.size()).isEqualTo(1);
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId3).run(()->
+        {
+            List<Configuration> result = repository.findAll();
+            assertThat(result.size()).isEqualTo(1);
+        });
     }
 
     @Test
     void testFindByKey() {
-        Optional<Configuration> result = repository.getByTenantIdAndKey(configuration1.getTenantId(), configuration1.getKey());
-        assertThat(result.isPresent()).isTrue();
-        assertThat(result.get().getValue().toString()).isEqualTo("{\"test\":\"value1\"}");
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, configuration1.getTenantId()).run(()->
+        {
+            Optional<Configuration> result = repository.getByTenantIdAndKey(configuration1.getTenantId(), configuration1.getKey());
+            assertThat(result.isPresent()).isTrue();
+            assertThat(result.get().getValue().toString()).isEqualTo("{\"test\":\"value1\"}");
+        });
     }
 
     @Test
     void testFindByKeyNotExist() {
-        Optional<Configuration> result = repository.getByTenantIdAndKey(configuration1.getTenantId(), ConfigKey.UNRECOGNIZED);
-        assertThat(result.isPresent()).isFalse();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, configuration1.getTenantId()).run(()->
+        {
+            Optional<Configuration> result = repository.getByTenantIdAndKey(configuration1.getTenantId(), ConfigKey.UNRECOGNIZED);
+            assertThat(result.isPresent()).isFalse();
+        });
     }
 
     @Test
     void testFindByRandomTenantIdAndKey() {
-        Optional<Configuration> result = repository.getByTenantIdAndKey(new UUID(5,8).toString(), configuration1.getKey());
-        assertThat(result.isPresent()).isFalse();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, new UUID(5,8).toString()).run(()->
+        {
+            Optional<Configuration> result = repository.getByTenantIdAndKey(new UUID(5,8).toString(), configuration1.getKey());
+            assertThat(result.isPresent()).isFalse();
+        });
     }
 
     @Test
     void testFindByTenantIdAndRandomKey() {
-        Optional<Configuration> result = repository.getByTenantIdAndKey(configuration1.getTenantId(), ConfigKey.UNRECOGNIZED);
-        assertThat(result.isPresent()).isFalse();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, configuration1.getTenantId()).run(()->
+        {
+            Optional<Configuration> result = repository.getByTenantIdAndKey(configuration1.getTenantId(), ConfigKey.UNRECOGNIZED);
+            assertThat(result.isPresent()).isFalse();
+        });
     }
 
     @Test
     void testFindByLocation() {
-        List<Configuration> result = repository.findByTenantIdAndLocation(configuration1.getTenantId(), configuration1.getLocation());
-        assertThat(result.size()).isEqualTo(2);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, configuration1.getTenantId()).run(()->
+        {
+            List<Configuration> result = repository.findByTenantIdAndLocation(configuration1.getTenantId(), configuration1.getLocation());
+            assertThat(result.size()).isEqualTo(2);
+        });
     }
 
     @Test
     void testFindByLocationNotExist() {
-        List<Configuration> result = repository.findByTenantIdAndLocation(configuration1.getTenantId(), "Invalid location");
-        assertThat(result.size()).isZero();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, configuration1.getTenantId()).run(()->
+        {
+            List<Configuration> result = repository.findByTenantIdAndLocation(configuration1.getTenantId(), "Invalid location");
+            assertThat(result.isEmpty());
+        });
     }
 
     @Test
     void testFindByRandomTenantIdAndLocation() {
-        List<Configuration> result = repository.findByTenantIdAndLocation(new UUID(5,8).toString(), configuration1.getLocation());
-        assertThat(result.size()).isZero();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, new UUID(5,8).toString()).run(()->
+        {
+            List<Configuration> result = repository.findByTenantIdAndLocation(new UUID(5,8).toString(), configuration1.getLocation());
+            assertThat(result.isEmpty());
+        });
     }
 
     @Test
     void testFindByRandomLocation() {
-        List<Configuration> result = repository.findByTenantIdAndLocation(tenantId1, "Random location");
-        assertThat(result.size()).isZero();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, configuration1.getTenantId()).run(()->
+        {
+            List<Configuration> result = repository.findByTenantIdAndLocation(tenantId1, "Random location");
+            assertThat(result.isEmpty());
+        });
     }
 }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/repository/IpInterfaceRepositoryTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/repository/IpInterfaceRepositoryTest.java
@@ -29,15 +29,18 @@
 package org.opennms.horizon.inventory.repository;
 
 
+import io.grpc.Context;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
 import org.opennms.horizon.inventory.model.IpInterface;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.model.Node;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.net.InetAddress;
@@ -49,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DataJpaTest
+@SpringBootTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 class IpInterfaceRepositoryTest {
@@ -72,51 +75,74 @@ class IpInterfaceRepositoryTest {
 
     @Test
     void testFindByIpInterfaceForAGivenLocationAndIpAddress() throws UnknownHostException {
-        var node = nodeRepository.findByNodeLabel("node1");
-        assertNotNull(node);
-        var locationList = monitoringLocationRepository.findByLocation("location1");
-        assertFalse(locationList.isEmpty(), "Should have valid location");
-        var list = ipInterfaceRepository.findAll();
-        assertThat(list).isNotEmpty();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, "tenant1").run(()->
+        {
+            var node = nodeRepository.findByNodeLabel("node1");
+            assertNotNull(node);
+            var locationList = monitoringLocationRepository.findByLocation("location1");
+            assertFalse(locationList.isEmpty(), "Should have valid location");
+            var list = ipInterfaceRepository.findAll();
+            assertThat(list).isNotEmpty();
+        });
 
-        for (int i = 0; i < NUM_NODES; i++) {
-            var optional = ipInterfaceRepository.findByIpAddressAndLocationAndTenantId(
-                InetAddress.getByName("192.168.1." + i), "location" + i, "tenant" + i);
-            assertThat(optional).isNotEmpty();
-            assertThat(optional.get().getIpAddress()).isEqualTo(InetAddress.getByName("192.168.1." + i));
+        for (int count = 0; count < NUM_NODES; count++) {
+            final int i = count;
+            final InetAddress inetAddress = InetAddress.getByName("192.168.1." + i);
+            final String tenant = "tenant" + i;
 
-            // Check with invalid location
-            var optionalInterface = ipInterfaceRepository.findByIpAddressAndLocationAndTenantId(
-                InetAddress.getByName("192.168.1." + i), "location" + i + 3, "tenant" + i);
-            assertThat(optionalInterface).isEmpty();
+            Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenant).run(()->
+            {
+                var optional = ipInterfaceRepository.findByIpAddressAndLocationAndTenantId(
+                    inetAddress, "location" + i, tenant);
+                assertThat(optional).isNotEmpty();
+                assertThat(optional.get().getIpAddress()).isEqualTo(inetAddress);
 
-            // Check with invalid tenant
-            optionalInterface = ipInterfaceRepository.findByIpAddressAndLocationAndTenantId(
-                InetAddress.getByName("192.168.1." + i), "location" + i, "tenant2" + i + 3);
-            assertThat(optionalInterface).isEmpty();
+                // Check with invalid location
+                var optionalInterface = ipInterfaceRepository.findByIpAddressAndLocationAndTenantId(
+                    inetAddress, "location" + i + 3, tenant);
+                assertThat(optionalInterface).isEmpty();
+            });
+
+            final String invalidTenant = "tenant2" + i + 3;
+            Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, invalidTenant).run(()->
+            {
+                // Check with invalid tenant
+                var optionalInterface = ipInterfaceRepository.findByIpAddressAndLocationAndTenantId(
+                    inetAddress, "location" + i, invalidTenant);
+                assertThat(optionalInterface).isEmpty();
+            });
         }
 
     }
 
-    private void loadNodes() throws UnknownHostException {
-        for (int i = 0; i < NUM_NODES; i++) {
-            var node = new Node();
-            node.setNodeLabel("node" + i);
-            node.setCreateTime(LocalDateTime.now());
-            node.setTenantId("tenant" + i);
-            var location = new MonitoringLocation();
-            location.setLocation("location" + i);
-            location.setTenantId("tenant" + i);
-            monitoringLocationRepository.save(location);
-            node.setMonitoringLocation(location);
-            var ipInterface = new IpInterface();
-            ipInterface.setTenantId("tenant" + i);
-            ipInterface.setNode(node);
-            ipInterface.setIpAddress(InetAddress.getByName("192.168.1." + i));
-            var ipInterfaces = new ArrayList<IpInterface>();
-            ipInterfaces.add(ipInterface);
-            node.setIpInterfaces(ipInterfaces);
-            nodeRepository.save(node);
+    private void loadNodes() {
+        for (int count = 0; count < NUM_NODES; count++) {
+            final int i = count;
+            final String tenant = "tenant" + i;
+            Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenant).run(()->
+            {
+                var node = new Node();
+                node.setNodeLabel("node" + i);
+                node.setCreateTime(LocalDateTime.now());
+                node.setTenantId(tenant);
+                var location = new MonitoringLocation();
+                location.setLocation("location" + i);
+                location.setTenantId(tenant);
+                monitoringLocationRepository.save(location);
+                node.setMonitoringLocation(location);
+                var ipInterface = new IpInterface();
+                ipInterface.setTenantId(tenant);
+                ipInterface.setNode(node);
+                try {
+                    ipInterface.setIpAddress(InetAddress.getByName("192.168.1." + i));
+                } catch (UnknownHostException e) {
+                    throw new RuntimeException(e);
+                }
+                var ipInterfaces = new ArrayList<IpInterface>();
+                ipInterfaces.add(ipInterface);
+                node.setIpInterfaces(ipInterfaces);
+                nodeRepository.save(node);
+            });
         }
     }
 

--- a/inventory/src/test/java/org/opennms/horizon/inventory/repository/MonitoringLocationRepoTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/repository/MonitoringLocationRepoTest.java
@@ -35,21 +35,24 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import io.grpc.Context;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
-@DataJpaTest
+@SpringBootTest
 @AutoConfigureTestDatabase(replace= AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 public class MonitoringLocationRepoTest {
     private final String tenantId = new UUID(10, 10).toString();
+    private final String otherTenantId = new UUID(5, 6).toString();
     private MonitoringLocation location1, location2, location3;
 
     @Autowired
@@ -67,63 +70,102 @@ public class MonitoringLocationRepoTest {
 
         location3 = new MonitoringLocation();
         location3.setLocation("test-location3");
-        location3.setTenantId(new UUID(5,6).toString());
+        location3.setTenantId(otherTenantId);
 
-        repository.save(location1);
-        repository.save(location2);
-        repository.save(location3);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            repository.save(location1);
+            repository.save(location2);
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, otherTenantId).run(()->
+        {
+            repository.save(location3);
+        });
     }
 
     @AfterEach
     public void cleanUp() {
-        repository.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            repository.deleteAll();
+        });
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, otherTenantId).run(()->
+        {
+            repository.deleteAll();
+        });
     }
 
     @Test
     void testFindByTenantId() {
-        List<MonitoringLocation> result = repository.findByTenantId(tenantId);
-        assertThat(result.size()).isEqualTo(2);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            List<MonitoringLocation> result = repository.findByTenantId(tenantId);
+            assertThat(result.size()).isEqualTo(2);
+        });
     }
 
     @Test
     void testFindByRandomTenantId() {
-        List<MonitoringLocation> result = repository.findByTenantId( new UUID(5,7).toString());
-        assertThat(result.size()).isZero();
+        final String tenant = new UUID(5,7).toString();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenant).run(()->
+        {
+            List<MonitoringLocation> result = repository.findByTenantId(tenant);
+            assertThat(result.isEmpty());
+        });
     }
 
     @Test
     void testFindByLocation(){
-        Optional<MonitoringLocation> result = repository.findByLocation(location1.getLocation());
-        assertThat(result).isPresent();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            Optional<MonitoringLocation> result = repository.findByLocation(location1.getLocation());
+            assertThat(result).isPresent();
+        });
     }
 
     @Test
     void testFindByLocationNotExist(){
-        Optional<MonitoringLocation> result = repository.findByLocation("random location");
-        assertThat(result).isNotPresent();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            Optional<MonitoringLocation> result = repository.findByLocation("random location");
+            assertThat(result).isNotPresent();
+        });
     }
 
     @Test
     void testFindByLocationAndTenantId() {
-        Optional<MonitoringLocation> result = repository.findByLocationAndTenantId(location1.getLocation(), tenantId);
-        assertThat(result).isPresent();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            Optional<MonitoringLocation> result = repository.findByLocationAndTenantId(location1.getLocation(), tenantId);
+            assertThat(result).isPresent();
+        });
     }
 
     @Test
     void testFindByRandomLocationAndTenantId() {
-        Optional<MonitoringLocation> result = repository.findByLocationAndTenantId("invalid location", tenantId);
-        assertThat(result).isNotPresent();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            Optional<MonitoringLocation> result = repository.findByLocationAndTenantId("invalid location", tenantId);
+            assertThat(result).isNotPresent();
+        });
     }
 
     @Test
     void testFindByLocationAndRandomTenantId() {
-        Optional<MonitoringLocation> result = repository.findByLocationAndTenantId(location1.getLocation(), new UUID(5,8).toString());
-        assertThat(result).isNotPresent();
+        final String tenant = new UUID(5,7).toString();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenant).run(()->
+        {
+            Optional<MonitoringLocation> result = repository.findByLocationAndTenantId(location1.getLocation(), tenant);
+            assertThat(result).isNotPresent();
+        });
     }
 
     @Test
     void testFindByIdList(){
-        List<MonitoringLocation> result = repository.findByIdIn(Arrays.asList(location1.getId(),location2.getId(),location3.getId()));
-        assertThat(result.size()).isEqualTo(3);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(()->
+        {
+            List<MonitoringLocation> result = repository.findByIdIn(Arrays.asList(location1.getId(),location2.getId(),location3.getId()));
+            assertThat(result.size()).isEqualTo(2);
+        });
     }
 }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseServiceIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseServiceIntTest.java
@@ -1,11 +1,12 @@
 package org.opennms.horizon.inventory.service.taskset.response;
 
-import jakarta.transaction.Transactional;
+import io.grpc.Context;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
+import org.opennms.horizon.inventory.dto.MonitoredServiceDTO;
 import org.opennms.horizon.inventory.grpc.GrpcTestBase;
 import org.opennms.horizon.inventory.grpc.taskset.TestTaskSetGrpcService;
 import org.opennms.horizon.inventory.model.IpInterface;
@@ -18,6 +19,8 @@ import org.opennms.horizon.inventory.repository.MonitoredServiceRepository;
 import org.opennms.horizon.inventory.repository.MonitoredServiceTypeRepository;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
+import org.opennms.horizon.inventory.service.MonitoredServiceService;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.utils.InetAddressUtils;
 import org.opennms.taskset.contract.DetectorResponse;
 import org.opennms.taskset.contract.MonitorType;
@@ -63,6 +66,9 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
     @Autowired
     private MonitoredServiceRepository monitoredServiceRepository;
 
+    @Autowired
+    private MonitoredServiceService monitoredServiceService;
+
     private static TestTaskSetGrpcService testGrpcService;
 
     @BeforeAll
@@ -73,11 +79,14 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
 
     @AfterEach
     public void cleanUp() {
-        monitoredServiceRepository.deleteAll();
-        monitoredServiceTypeRepository.deleteAll();
-        ipInterfaceRepository.deleteAll();
-        nodeRepository.deleteAll();
-        monitoringLocationRepository.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            monitoredServiceRepository.deleteAll();
+            monitoredServiceTypeRepository.deleteAll();
+            ipInterfaceRepository.deleteAll();
+            nodeRepository.deleteAll();
+            monitoringLocationRepository.deleteAll();
+        });
 
         testGrpcService.reset();
     }
@@ -89,16 +98,26 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
     }
 
     @Test
-    @Transactional
-    void testAccept() throws UnknownHostException {
-        populateDatabase();
+    void testAccept() {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            try {
+                populateDatabase();
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
 
-        DetectorResponse response = DetectorResponse.newBuilder()
-            .setDetected(true).setIpAddress(TEST_IP_ADDRESS)
-            .setMonitorType(MonitorType.SNMP).build();
+            DetectorResponse response = DetectorResponse.newBuilder()
+                .setDetected(true).setIpAddress(TEST_IP_ADDRESS)
+                .setMonitorType(MonitorType.SNMP).build();
 
-        service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
+            service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
 
+            checkTestAcceptResults(response, 2);
+        });
+    }
+
+    private void checkTestAcceptResults(DetectorResponse response, int expected) {
         List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
         assertEquals(1, monitoredServiceTypes.size());
 
@@ -106,7 +125,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
         assertEquals(response.getMonitorType().name(), monitoredServiceType.getServiceName());
         assertEquals(TEST_TENANT_ID, monitoredServiceType.getTenantId());
 
-        List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
+        List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();;
         assertEquals(1, monitoredServices.size());
 
         MonitoredService monitoredService = monitoredServices.get(0);
@@ -116,146 +135,148 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
         assertEquals(TEST_TENANT_ID, monitoredService.getTenantId());
 
         MonitoredServiceType relatedType = monitoredService.getMonitoredServiceType();
-        assertEquals(monitoredServiceType, relatedType);
+        assertEquals(monitoredServiceType.getServiceName(), relatedType.getServiceName());
 
-        assertEquals(2, testGrpcService.getRequests().size());
+        assertEquals(expected, testGrpcService.getRequests().size());
     }
 
     @Test
-    @Transactional
     void testAcceptMultipleSameIpAddress() throws UnknownHostException {
-        populateDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            try {
+                populateDatabase();
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
 
-        DetectorResponse response = DetectorResponse.newBuilder()
-            .setDetected(true).setIpAddress(TEST_IP_ADDRESS)
-            .setMonitorType(MonitorType.SNMP).build();
+            DetectorResponse response = DetectorResponse.newBuilder()
+                .setDetected(true).setIpAddress(TEST_IP_ADDRESS)
+                .setMonitorType(MonitorType.SNMP).build();
 
-        int numberOfCalls = 2;
+            int numberOfCalls = 2;
 
-        for (int index = 0; index < numberOfCalls; index++) {
-            service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
-        }
+            for (int index = 0; index < numberOfCalls; index++) {
+                service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
+            }
 
-        List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
-        assertEquals(1, monitoredServiceTypes.size());
-
-        MonitoredServiceType monitoredServiceType = monitoredServiceTypes.get(0);
-        assertEquals(response.getMonitorType().name(), monitoredServiceType.getServiceName());
-        assertEquals(TEST_TENANT_ID, monitoredServiceType.getTenantId());
-
-        List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
-        assertEquals(1, monitoredServices.size());
-
-        MonitoredService monitoredService = monitoredServices.get(0);
-        IpInterface ipInterface = monitoredService.getIpInterface();
-
-        assertEquals(TEST_IP_ADDRESS, InetAddressUtils.toIpAddrString(ipInterface.getIpAddress()));
-        assertEquals(TEST_TENANT_ID, monitoredService.getTenantId());
-
-        MonitoredServiceType relatedType = monitoredService.getMonitoredServiceType();
-        assertEquals(monitoredServiceType, relatedType);
-
-        assertEquals(numberOfCalls*2, testGrpcService.getRequests().size());
+            checkTestAcceptResults(response, numberOfCalls * 2);
+        });
     }
 
     @Test
-    @Transactional
     void testAcceptNotDetected() throws UnknownHostException {
-        populateDatabase();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            try {
+                populateDatabase();
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
 
-        DetectorResponse response = DetectorResponse.newBuilder()
-            .setDetected(false).setIpAddress(TEST_IP_ADDRESS)
-            .setMonitorType(MonitorType.SNMP).build();
+            DetectorResponse response = DetectorResponse.newBuilder()
+                .setDetected(false).setIpAddress(TEST_IP_ADDRESS)
+                .setMonitorType(MonitorType.SNMP).build();
 
-        service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
+            service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
 
-        List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
-        assertEquals(0, monitoredServiceTypes.size());
+            List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
+            assertEquals(0, monitoredServiceTypes.size());
 
-        List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
-        assertEquals(0, monitoredServices.size());
+            List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
+            assertEquals(0, monitoredServices.size());
 
-        assertEquals(0, testGrpcService.getRequests().size());
+            assertEquals(0, testGrpcService.getRequests().size());
+        });
     }
 
     @Test
-    @Transactional
-    void testAcceptMultipleSameIpAddressDifferentMonitorType() throws UnknownHostException {
-        populateDatabase();
+    void testAcceptMultipleSameIpAddressDifferentMonitorType() {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            try {
+                populateDatabase();
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
 
-        DetectorResponse.Builder builder = DetectorResponse.newBuilder()
-            .setDetected(true).setIpAddress(TEST_IP_ADDRESS);
+            DetectorResponse.Builder builder = DetectorResponse.newBuilder()
+                .setDetected(true).setIpAddress(TEST_IP_ADDRESS);
 
-        int numberOfCalls = 2;
+            int numberOfCalls = 2;
 
-        MonitorType[] monitorTypes = {MonitorType.ICMP, MonitorType.SNMP};
+            MonitorType[] monitorTypes = {MonitorType.ICMP, MonitorType.SNMP};
 
-        for (int index = 0; index < numberOfCalls; index++) {
+            for (int index = 0; index < numberOfCalls; index++) {
 
-            DetectorResponse response = builder
-                .setMonitorType(monitorTypes[index]).build();
+                DetectorResponse response = builder
+                    .setMonitorType(monitorTypes[index]).build();
 
-            service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
-        }
+                service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
+            }
 
-        List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
-        assertEquals(monitorTypes.length, monitoredServiceTypes.size());
+            List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
+            assertEquals(monitorTypes.length, monitoredServiceTypes.size());
 
-        List<String> monitoredServiceNames =
-            monitoredServiceTypes.stream()
-                .map(MonitoredServiceType::getServiceName)
-                .collect(Collectors.toList());
+            List<String> monitoredServiceNames =
+                monitoredServiceTypes.stream()
+                    .map(MonitoredServiceType::getServiceName)
+                    .collect(Collectors.toList());
 
-        assertEquals(monitorTypes.length, monitoredServiceNames.size());
+            assertEquals(monitorTypes.length, monitoredServiceNames.size());
 
-        for (int index = 0; index < monitorTypes.length; index++) {
-            assertEquals(monitorTypes[index].getValueDescriptor().getName(), monitoredServiceNames.get(index));
-        }
+            for (int index = 0; index < monitorTypes.length; index++) {
+                assertEquals(monitorTypes[index].getValueDescriptor().getName(), monitoredServiceNames.get(index));
+            }
 
-        List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
-        assertEquals(monitorTypes.length, monitoredServices.size());
+            List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
+            assertEquals(monitorTypes.length, monitoredServices.size());
 
-        for (MonitoredService monitoredService : monitoredServices) {
-            IpInterface ipInterface = monitoredService.getIpInterface();
+            for (MonitoredService monitoredService : monitoredServices) {
+                IpInterface ipInterface = monitoredService.getIpInterface();
 
-            assertEquals(TEST_IP_ADDRESS, InetAddressUtils.toIpAddrString(ipInterface.getIpAddress()));
-            assertEquals(TEST_TENANT_ID, monitoredService.getTenantId());
-        }
+                assertEquals(TEST_IP_ADDRESS, InetAddressUtils.toIpAddrString(ipInterface.getIpAddress()));
+                assertEquals(TEST_TENANT_ID, monitoredService.getTenantId());
+            }
 
-        var taskDefinitions = testGrpcService.getTaskDefinitions(TEST_LOCATION);
-        var monitorTasks = taskDefinitions.stream().filter(taskDefinition ->
-                taskDefinition.getType().equals(TaskType.MONITOR))
-            .filter(taskDefinition -> taskDefinition.getPluginName().contains(MonitorType.SNMP.name()) ||
-                taskDefinition.getPluginName().contains(MonitorType.ICMP.name())).toList();
+            var taskDefinitions = testGrpcService.getTaskDefinitions(TEST_LOCATION);
+            var monitorTasks = taskDefinitions.stream().filter(taskDefinition ->
+                    taskDefinition.getType().equals(TaskType.MONITOR))
+                .filter(taskDefinition -> taskDefinition.getPluginName().contains(MonitorType.SNMP.name()) ||
+                    taskDefinition.getPluginName().contains(MonitorType.ICMP.name())).toList();
 
-        assertEquals(2, monitorTasks.size());
+            assertEquals(2, monitorTasks.size());
 
-        var collectorTasks = taskDefinitions.stream().filter(taskDefinition ->
-                taskDefinition.getType().equals(TaskType.COLLECTOR))
-            .filter(taskDefinition -> taskDefinition.getPluginName().contains(MonitorType.SNMP.name())).toList();
+            var collectorTasks = taskDefinitions.stream().filter(taskDefinition ->
+                    taskDefinition.getType().equals(TaskType.COLLECTOR))
+                .filter(taskDefinition -> taskDefinition.getPluginName().contains(MonitorType.SNMP.name())).toList();
 
-        assertEquals(1, collectorTasks.size());
+            assertEquals(1, collectorTasks.size());
+        });
     }
 
     private void populateDatabase() throws UnknownHostException {
+        final InetAddress inetAddress = InetAddress.getByName(TEST_IP_ADDRESS);
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            MonitoringLocation monitoringLocation = new MonitoringLocation();
+            monitoringLocation.setLocation(TEST_LOCATION);
+            monitoringLocation.setTenantId(TEST_TENANT_ID);
+            monitoringLocation = monitoringLocationRepository.save(monitoringLocation);
 
-        MonitoringLocation monitoringLocation = new MonitoringLocation();
-        monitoringLocation.setLocation(TEST_LOCATION);
-        monitoringLocation.setTenantId(TEST_TENANT_ID);
-        monitoringLocation = monitoringLocationRepository.save(monitoringLocation);
+            Node node = new Node();
+            node.setNodeLabel(TEST_NODE_LABEL);
+            node.setCreateTime(LocalDateTime.now());
+            node.setTenantId(TEST_TENANT_ID);
+            node.setMonitoringLocation(monitoringLocation);
+            node = nodeRepository.save(node);
 
-        Node node = new Node();
-        node.setNodeLabel(TEST_NODE_LABEL);
-        node.setCreateTime(LocalDateTime.now());
-        node.setTenantId(TEST_TENANT_ID);
-        node.setMonitoringLocation(monitoringLocation);
-        node = nodeRepository.save(node);
+            IpInterface ipInterface = new IpInterface();
+            ipInterface.setIpAddress(inetAddress);
+            ipInterface.setTenantId(TEST_TENANT_ID);
+            ipInterface.setNode(node);
 
-        IpInterface ipInterface = new IpInterface();
-        ipInterface.setIpAddress(InetAddress.getByName(TEST_IP_ADDRESS));
-        ipInterface.setTenantId(TEST_TENANT_ID);
-        ipInterface.setNode(node);
-
-        ipInterfaceRepository.save(ipInterface);
+            ipInterfaceRepository.save(ipInterface);
+        });
     }
 }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseServiceIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseServiceIntTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import io.grpc.Context;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -61,6 +62,7 @@ import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.opennms.horizon.inventory.repository.SnmpInterfaceRepository;
 import org.opennms.horizon.inventory.service.NodeService;
+import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.utils.InetAddressUtils;
 import org.opennms.node.scan.contract.IpInterfaceResult;
 import org.opennms.node.scan.contract.NodeInfoResult;
@@ -114,12 +116,14 @@ class ScannerResponseServiceIntTest extends GrpcTestBase {
     }
 
     @AfterEach
-    @Transactional
     public void cleanUp() {
-        ipInterfaceRepository.deleteAll();
-        nodeRepository.deleteAll();
-        credentialRepository.deleteAll();
-        locationRepository.deleteAll();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            ipInterfaceRepository.deleteAll();
+            nodeRepository.deleteAll();
+            credentialRepository.deleteAll();
+            locationRepository.deleteAll();
+        });
         testGrpcService.reset();
     }
 
@@ -130,70 +134,83 @@ class ScannerResponseServiceIntTest extends GrpcTestBase {
     }
 
     @Test
-    @Transactional
     void testAzureAccept() throws Exception {
-        AzureCredential credential = createAzureCredential();
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            AzureCredential credential = createAzureCredential();
 
-        AzureScanItem scanItem = AzureScanItem.newBuilder()
-            .setId("/subscriptions/sub-id/resourceGroups/resource-group/providers/Microsoft.Compute/virtualMachines/vm-name")
-            .setName("vm-name")
-            .setResourceGroup("resource-group")
-            .setCredentialId(credential.getId())
-            .build();
+            AzureScanItem scanItem = AzureScanItem.newBuilder()
+                .setId("/subscriptions/sub-id/resourceGroups/resource-group/providers/Microsoft.Compute/virtualMachines/vm-name")
+                .setName("vm-name")
+                .setResourceGroup("resource-group")
+                .setCredentialId(credential.getId())
+                .build();
 
-        List<AzureScanItem> azureScanItems = Collections.singletonList(scanItem);
-        AzureScanResponse azureScanResponse = AzureScanResponse.newBuilder().addAllResults(azureScanItems).build();
-        ScannerResponse response = ScannerResponse.newBuilder().setResult(Any.pack(azureScanResponse)).build();
+            List<AzureScanItem> azureScanItems = Collections.singletonList(scanItem);
+            AzureScanResponse azureScanResponse = AzureScanResponse.newBuilder().addAllResults(azureScanItems).build();
+            ScannerResponse response = ScannerResponse.newBuilder().setResult(Any.pack(azureScanResponse)).build();
 
-        service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
+            try {
+                service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+            }
 
-        // monitor and collect tasks
-        assertEquals(2, testGrpcService.getRequests().size());
+            // monitor and collect tasks
+            assertEquals(2, testGrpcService.getRequests().size());
 
-        List<Node> allNodes = nodeRepository.findAll();
-        assertEquals(1, allNodes.size());
+            List<Node> allNodes = nodeRepository.findAll();
+            assertEquals(1, allNodes.size());
 
-        Node node = allNodes.get(0);
-        assertNotNull(node);
-        assertEquals(TEST_TENANT_ID, node.getTenantId());
-        assertEquals("vm-name (resource-group)", node.getNodeLabel());
-        assertNotNull(node.getMonitoringLocation());
+            Node node = allNodes.get(0);
+            assertNotNull(node);
+            assertEquals(TEST_TENANT_ID, node.getTenantId());
+            assertEquals("vm-name (resource-group)", node.getNodeLabel());
+            assertNotNull(node.getMonitoringLocation());
 
-        List<IpInterface> allIpInterfaces = ipInterfaceRepository.findAll();
-        assertEquals(1, allIpInterfaces.size());
-        IpInterface ipInterface = allIpInterfaces.get(0);
-        assertEquals(TEST_TENANT_ID, ipInterface.getTenantId());
-        assertEquals("127.0.0.1", InetAddressUtils.toIpAddrString(ipInterface.getIpAddress()));
+            List<IpInterface> allIpInterfaces = ipInterfaceRepository.findAll();
+            assertEquals(1, allIpInterfaces.size());
+            IpInterface ipInterface = allIpInterfaces.get(0);
+            assertEquals(TEST_TENANT_ID, ipInterface.getTenantId());
+            assertEquals("127.0.0.1", InetAddressUtils.toIpAddrString(ipInterface.getIpAddress()));
+        });
     }
 
     @Test
-    void testAcceptNodeScanResult() throws InvalidProtocolBufferException {
-        String managedIp = "127.0.0.1";
-        Node node = createNode(managedIp);
-        int ifIndex = 1;
-        SnmpInterface snmpIf = createSnmpInterface(node, ifIndex);
-        NodeScanResult result = createNodeScanResult(node.getId(), managedIp, ifIndex);
+    void testAcceptNodeScanResult() {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, TEST_TENANT_ID).run(()->
+        {
+            String managedIp = "127.0.0.1";
+            Node node = createNode(managedIp);
+            int ifIndex = 1;
+            SnmpInterface snmpIf = createSnmpInterface(node, ifIndex);
+            NodeScanResult result = createNodeScanResult(node.getId(), managedIp, ifIndex);
 
-        service.accept(TEST_TENANT_ID, TEST_LOCATION, ScannerResponse.newBuilder().setResult(Any.pack(result)).build());
-        assertNodeSystemGroup(node, null);
-        nodeRepository.findByIdAndTenantId(node.getId(), TEST_TENANT_ID).ifPresentOrElse(dbNode ->
-            assertNodeSystemGroup(dbNode, result.getNodeInfo()), () -> fail("Node not found"));
+            try {
+                service.accept(TEST_TENANT_ID, TEST_LOCATION, ScannerResponse.newBuilder().setResult(Any.pack(result)).build());
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+            }
+            assertNodeSystemGroup(node, null);
+            nodeRepository.findByIdAndTenantId(node.getId(), TEST_TENANT_ID).ifPresentOrElse(dbNode ->
+                assertNodeSystemGroup(dbNode, result.getNodeInfo()), () -> fail("Node not found"));
 
-        assertIpInterface(node.getIpInterfaces().get(0), null);
-        List<IpInterface> ipIfList = ipInterfaceRepository.findByNodeId(node.getId());
-        assertThat(ipIfList.get(0)).extracting(ipIf -> ipIf.getIpAddress().getHostAddress()).isEqualTo(managedIp);
-        assertThat(ipIfList).asList().hasSize(result.getIpInterfacesList().size());
-        IntStream.range(0, ipIfList.size())
-            .forEach(i -> assertIpInterface(ipIfList.get(i), result.getIpInterfaces(i)));
+            assertIpInterface(node.getIpInterfaces().get(0), null);
+            List<IpInterface> ipIfList = ipInterfaceRepository.findByNodeId(node.getId());
+            assertThat(ipIfList.get(0)).extracting(ipIf -> ipIf.getIpAddress().getHostAddress()).isEqualTo(managedIp);
+            assertThat(ipIfList).asList().hasSize(result.getIpInterfacesList().size());
+            IntStream.range(0, ipIfList.size())
+                .forEach(i -> assertIpInterface(ipIfList.get(i), result.getIpInterfaces(i)));
 
-        List<SnmpInterface> snmpInterfaceList = snmpInterfaceRepository.findByTenantId(TEST_TENANT_ID);
-        assertThat(snmpInterfaceList).asList().hasSize(2);
-        assertThat(snmpIf.getIfIndex()).isEqualTo(ifIndex);
-        assertSnmpInterfaces(snmpIf, null);
-        IntStream.range(0, snmpInterfaceList.size())
-            .forEach(i -> assertSnmpInterfaces(snmpInterfaceList.get(i), result.getSnmpInterfaces(i)));
-
+            List<SnmpInterface> snmpInterfaceList = snmpInterfaceRepository.findByTenantId(TEST_TENANT_ID);
+            assertThat(snmpInterfaceList).asList().hasSize(2);
+            assertThat(snmpIf.getIfIndex()).isEqualTo(ifIndex);
+            assertSnmpInterfaces(snmpIf, null);
+            IntStream.range(0, snmpInterfaceList.size())
+                .forEach(i -> assertSnmpInterfaces(snmpInterfaceList.get(i), result.getSnmpInterfaces(i)));
+        });
     }
+
     private Node createNode(String ipAddress) {
         NodeCreateDTO createDTO = NodeCreateDTO.newBuilder()
             .setLabel("test-node")


### PR DESCRIPTION
## Description
Use Hibernate tenancy feature in inventory

## Jira link(s)
- https://issues.opennms.org/browse/HS-1013

## Flagged for review
Repo methods like findByTenantId are no longer needed, as hibernate takes care of all that stuff for us using the TenantIdentifierResolver. However they all still work even if they aren't removed.
If needed they can be removed in a future story.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
