### PR TITLE
HS-1103: Add Active Discovery Config table persistence

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/ActiveDiscoveryConfig.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/ActiveDiscoveryConfig.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.model;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@Entity(name = "active_discovery_config")
+public class ActiveDiscoveryConfig extends TenantAwareEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotNull
+    @Column(name = "location")
+    private String location;
+
+    @NotNull
+    @Column(name = "profile_name")
+    private String profileName;
+
+    @NotNull
+    @Column(name = "discovery_config", columnDefinition = "jsonb")
+    @JdbcTypeCode( SqlTypes.JSON )
+    private DiscoveryConfig discoveryConfig;
+}

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/DiscoveryConfig.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/DiscoveryConfig.java
@@ -39,7 +39,7 @@ public class DiscoveryConfig {
 
     private List<String> ipAddresses;
 
-    private String communityString;
+    private List<String> communityString;
 
     private List<Integer> snmpPorts;
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/model/DiscoveryConfig.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/model/DiscoveryConfig.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.model;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiscoveryConfig {
+
+    private List<String> ipAddresses;
+
+    private String communityString;
+
+    private List<Integer> snmpPorts;
+}

--- a/inventory/src/main/java/org/opennms/horizon/inventory/repository/ActiveDiscoveryConfigRepository.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/repository/ActiveDiscoveryConfigRepository.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.repository;
+
+import java.util.Optional;
+
+import org.opennms.horizon.inventory.model.ActiveDiscoveryConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ActiveDiscoveryConfigRepository extends JpaRepository<ActiveDiscoveryConfig, Long> {
+
+    Optional<ActiveDiscoveryConfig> findByLocation(String location);
+
+    Optional<ActiveDiscoveryConfig> findByLocationAndProfileName(String location, String profileName);
+
+}

--- a/inventory/src/main/resources/db/changelog/changelog.xml
+++ b/inventory/src/main/resources/db/changelog/changelog.xml
@@ -22,4 +22,5 @@
     <include file="db/changelog/hs-0.1.0/tables/azure-credential-tags.xml" />
     <include file="db/changelog/hs-0.1.0/tables/ip-snmp-interfaces.xml" />
     <include file="db/changelog/hs-0.1.0/tables/node-scan-type.xml" />
+    <include file="/db/changelog/hs-0.1.0/tables/active-discovery-config.xml" />
 </databaseChangeLog>

--- a/inventory/src/main/resources/db/changelog/hs-0.1.0/tables/active-discovery-config.xml
+++ b/inventory/src/main/resources/db/changelog/hs-0.1.0/tables/active-discovery-config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="bjanssens" id="0.1.0-active-discovery-config">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="active_discovery_config"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="active_discovery_config">
+            <column name="id" type="BIGINT" autoIncrement="true"/>
+
+            <column name="tenant_id" type="text">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="location" type="text">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="profile_name" type="text">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="discovery_config" type="jsonb">
+                <constraints nullable="false"/>
+            </column>
+
+        </createTable>
+
+        <addPrimaryKey tableName="active_discovery_config" columnNames="id" constraintName="pk_active_discovery_config_id"/>
+
+    </changeSet>
+</databaseChangeLog>

--- a/inventory/src/test/java/org/opennms/horizon/inventory/repository/ActiveDiscoveryConfigRepositoryTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/repository/ActiveDiscoveryConfigRepositoryTest.java
@@ -1,0 +1,68 @@
+package org.opennms.horizon.inventory.repository;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opennms.horizon.inventory.SpringContextTestInitializer;
+import org.opennms.horizon.inventory.model.ActiveDiscoveryConfig;
+import org.opennms.horizon.inventory.model.DiscoveryConfig;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import io.grpc.Context;
+
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(initializers = {SpringContextTestInitializer.class})
+public class ActiveDiscoveryConfigRepositoryTest {
+
+    private static final String tenantId = "tenant-1";
+
+    @Autowired
+    private ActiveDiscoveryConfigRepository repository;
+
+    @Test
+    public void testActiveDiscoveryConfigPersistence() {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(() ->
+        {
+            var discoveryConfig = new DiscoveryConfig();
+            discoveryConfig.setSnmpPorts(Collections.singletonList(1161));
+            discoveryConfig.setCommunityString("OpenNMS");
+            discoveryConfig.setIpAddresses(Arrays.asList("127.0.0.1", "127.0.0.2"));
+            var activeDiscoveryConfig = new ActiveDiscoveryConfig();
+            activeDiscoveryConfig.setLocation("MINION");
+            activeDiscoveryConfig.setProfileName("Profile-1");
+            activeDiscoveryConfig.setTenantId(tenantId);
+            activeDiscoveryConfig.setDiscoveryConfig(discoveryConfig);
+            var persisted = repository.save(activeDiscoveryConfig);
+            Assertions.assertNotNull(persisted);
+            Assertions.assertEquals("MINION", activeDiscoveryConfig.getLocation());
+            Assertions.assertEquals("Profile-1", activeDiscoveryConfig.getProfileName());
+            Assertions.assertEquals("OpenNMS", activeDiscoveryConfig.getDiscoveryConfig().getCommunityString());
+            Assertions.assertEquals("127.0.0.1", activeDiscoveryConfig.getDiscoveryConfig().getIpAddresses().get(0));
+            Assertions.assertEquals("127.0.0.2", activeDiscoveryConfig.getDiscoveryConfig().getIpAddresses().get(1));
+            Assertions.assertEquals(1161, activeDiscoveryConfig.getDiscoveryConfig().getSnmpPorts().get(0));
+
+            var optional = repository.findByLocation("MINION");
+            Assertions.assertTrue(optional.isPresent());
+
+            optional = repository.findByLocationAndProfileName("MINION", "Profile-1");
+            Assertions.assertTrue(optional.isPresent());
+        });
+
+    }
+
+    @AfterEach
+    public void destroy() {
+        Context.current().withValue(GrpcConstants.TENANT_ID_CONTEXT_KEY, tenantId).run(() ->
+            repository.deleteAll());
+    }
+
+}

--- a/inventory/src/test/java/org/opennms/horizon/inventory/repository/ActiveDiscoveryConfigRepositoryTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/repository/ActiveDiscoveryConfigRepositoryTest.java
@@ -34,7 +34,7 @@ public class ActiveDiscoveryConfigRepositoryTest {
         {
             var discoveryConfig = new DiscoveryConfig();
             discoveryConfig.setSnmpPorts(Collections.singletonList(1161));
-            discoveryConfig.setCommunityString("OpenNMS");
+            discoveryConfig.setCommunityString(Collections.singletonList("OpenNMS"));
             discoveryConfig.setIpAddresses(Arrays.asList("127.0.0.1", "127.0.0.2"));
             var activeDiscoveryConfig = new ActiveDiscoveryConfig();
             activeDiscoveryConfig.setLocation("MINION");
@@ -45,7 +45,7 @@ public class ActiveDiscoveryConfigRepositoryTest {
             Assertions.assertNotNull(persisted);
             Assertions.assertEquals("MINION", activeDiscoveryConfig.getLocation());
             Assertions.assertEquals("Profile-1", activeDiscoveryConfig.getProfileName());
-            Assertions.assertEquals("OpenNMS", activeDiscoveryConfig.getDiscoveryConfig().getCommunityString());
+            Assertions.assertEquals("OpenNMS", activeDiscoveryConfig.getDiscoveryConfig().getCommunityString().get(0));
             Assertions.assertEquals("127.0.0.1", activeDiscoveryConfig.getDiscoveryConfig().getIpAddresses().get(0));
             Assertions.assertEquals("127.0.0.2", activeDiscoveryConfig.getDiscoveryConfig().getIpAddresses().get(1));
             Assertions.assertEquals(1161, activeDiscoveryConfig.getDiscoveryConfig().getSnmpPorts().get(0));


### PR DESCRIPTION
- created table active-discovery-config
- created repository ActiveDiscoveryConfigRepository 
- created entity ActiveDiscoveryConfig

HS-1103

## Description
Currently, Active Discovery is being persisted in generic Config table.
But we need to move this to Active Discovery Config table that consists of 

1. tenant_id
2. location
3. profile name
4. IPAddresses (ranges/specific/cidr) 
5. SNMP community strings 
6. SNMP agent config ports. 

4-5-6 can be combined one DTO that can be saved as json.

This task involves creating **table**, **entity**, **repository**.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1103

## Flagged for review


## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
