### PR TITLE
JIB: Use a specific hash to avoid pulls

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -129,7 +129,7 @@
         <zjsonpatch.version>0.4.12</zjsonpatch.version>
         <mockito.version>4.8.0</mockito.version>
         <jupiter.version>5.9.0</jupiter.version>
-        <jib.version>3.2.1</jib.version>
+        <jib.version>3.3.1</jib.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <failsafe.version>3.0.0-M7</failsafe.version>
         <zjsonpatch.version>0.4.12</zjsonpatch.version>
@@ -955,6 +955,7 @@
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>${jib.version}</version>
                     <configuration>
+                        <from><image>eclipse-temurin:17-jre@sha256:592f2d372afeb13bc3c5a28e49c7ca6b5e5688e767cb0b9e21a70caaacfc4cec</image></from>
                         <!--suppress MavenModelInspection -->
                         <skip>${application.docker.skip}</skip>
                         <to>


### PR DESCRIPTION
Specify the default image and the specific hash to reduce the number of pulls.

Also upgrade the JIB plugin to the latest version while we're here.