### PR TITLE
consolidate base image for services to use: eclipse-temurin:17-jre

### DIFF
--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -329,11 +329,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <configuration>
-                    <from>
-                        <image>openjdk:17</image>
-                    </from>
-                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -307,11 +307,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <configuration>
-                    <from>
-                        <image>openjdk:17</image>
-                    </from>
-                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -130,7 +130,7 @@
         <zjsonpatch.version>0.4.12</zjsonpatch.version>
         <mockito.version>4.8.0</mockito.version>
         <jupiter.version>5.9.0</jupiter.version>
-        <jib.version>3.2.1</jib.version>
+        <jib.version>3.3.1</jib.version>
         <surefire.version>3.0.0-M7</surefire.version>
         <failsafe.version>3.0.0-M7</failsafe.version>
         <zjsonpatch.version>0.4.12</zjsonpatch.version>
@@ -957,7 +957,9 @@
                     <version>${jib.version}</version>
                     <configuration>
                         <from>
-                            <image>eclipse-temurin:17-jre@sha256:592f2d372afeb13bc3c5a28e49c7ca6b5e5688e767cb0b9e21a70caaacfc4cec</image>
+                            <!-- Make sure to use the hash of the manifest list (multi-arch) vs the hash of a particular manifest (single-arch) when updating
+                                 See https://github.com/docker/roadmap/issues/262#issuecomment-1161515179 for an example on how to do this -->
+                            <image>eclipse-temurin:17-jre@sha256:c61c6a48364d05ea89504489aecddd8af8c32dba6df2257da4131fe244284f50</image>
                         </from>
                         <!--suppress MavenModelInspection -->
                         <skip>${application.docker.skip}</skip>

--- a/rest-server/src/main/docker/Dockerfile
+++ b/rest-server/src/main/docker/Dockerfile
@@ -1,4 +1,0 @@
-FROM eclipse-temurin:11
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Also update referenced hash to point to the manifest list vs a particular image, and bump up the jib plugin to the latest.