### PR TITLE
HS-1146: Add mutation for passive discovery toggle

### DIFF
--- a/ui/src/components/Discovery/DiscoveryListCard.vue
+++ b/ui/src/components/Discovery/DiscoveryListCard.vue
@@ -13,7 +13,7 @@
         <div @click="$emit('selectDiscovery', item)" class="pointer">
           {{ item.configName?.toUpperCase() || item.name?.toUpperCase() }}
         </div>
-        <BasicToggle v-if="passive" :toggle="item.toggle" @toggle="(isToggled) => $emit('toggleDiscovery', item, isToggled)" />
+        <BasicToggle v-if="passive" :toggle="item.toggle" @toggle="(isToggled) => $emit('toggleDiscovery', item.id, isToggled)" />
       </div>
     </div>
     <div

--- a/ui/src/containers/Discovery.vue
+++ b/ui/src/containers/Discovery.vue
@@ -93,10 +93,12 @@ import { DiscoveryInput } from '@/types/discovery'
 import { DiscoveryType } from '@/components/Discovery/discovery.constants'
 import discoveryText from '@/components/Discovery/discovery.text'
 import { useDiscoveryQueries } from '@/store/Queries/discoveryQueries'
+import { useDiscoveryMutations } from '@/store/Mutations/discoveryMutations'
 import { IAutocompleteItemType } from '@featherds/autocomplete'
 import { ActiveDiscovery, PassiveDiscovery } from '@/types/graphql'
 
 const discoveryQueries = useDiscoveryQueries()
+const discoveryMutations = useDiscoveryMutations()
 
 type TDiscoveryAutocomplete = DiscoveryInput & { _text: string }
 
@@ -146,8 +148,10 @@ const showDiscovery = (discovery: IAutocompleteItemType | IAutocompleteItemType[
   }
 }
 
-const toggleDiscovery = (item: any, isToggled: boolean) => {
-  // call mutation to turn on / off passive discovery, when available.
+const toggleDiscovery = (id: string, toggle: boolean) => {
+  discoveryMutations.togglePassiveDiscovery({ 
+    toggle: { id, toggle }
+  })
 }
 
 const handleCancel = () => {

--- a/ui/src/graphql/Discovery/togglePassiveDiscoveryMutation.graphql
+++ b/ui/src/graphql/Discovery/togglePassiveDiscoveryMutation.graphql
@@ -1,0 +1,6 @@
+mutation TogglePassiveDiscovery($toggle: PassiveDiscoveryToggleInput!) {
+  togglePassiveDiscovery(toggle: $toggle) {
+    id
+    toggle
+  }
+}

--- a/ui/src/store/Mutations/discoveryMutations.ts
+++ b/ui/src/store/Mutations/discoveryMutations.ts
@@ -1,6 +1,11 @@
 import { defineStore } from 'pinia'
 import { useMutation } from 'villus'
-import { AddAzureCredentialDocument, CreateActiveDiscoveryDocument, UpsertPassiveDiscoveryDocument } from '@/types/graphql'
+import { 
+  AddAzureCredentialDocument, 
+  CreateActiveDiscoveryDocument, 
+  UpsertPassiveDiscoveryDocument,
+  TogglePassiveDiscoveryDocument
+} from '@/types/graphql'
 
 export const useDiscoveryMutations = defineStore('discoveryMutations', () => {
   // Create Azure
@@ -20,6 +25,11 @@ export const useDiscoveryMutations = defineStore('discoveryMutations', () => {
     isFetching: isFetchingPassiveDiscovery
   } = useMutation(UpsertPassiveDiscoveryDocument)
 
+    // Toggle Passive Discoveries
+    const {
+      execute: togglePassiveDiscovery
+    } = useMutation(TogglePassiveDiscoveryDocument)
+
   return {
     addAzureCreds,
     azureError: computed(() => error),
@@ -30,5 +40,6 @@ export const useDiscoveryMutations = defineStore('discoveryMutations', () => {
     upsertPassiveDiscovery,
     passiveDiscoveryError: computed(() => passiveDiscoveryError.value),
     isFetchingPassiveDiscovery: computed(() => isFetchingPassiveDiscovery.value),
+    togglePassiveDiscovery
   }
 })

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -122,6 +122,7 @@ export type Mutation = {
   discoveryByNodeIds?: Maybe<Scalars['Boolean']>;
   removeTags?: Maybe<Scalars['Boolean']>;
   savePagerDutyConfig?: Maybe<Scalars['Boolean']>;
+  togglePassiveDiscovery?: Maybe<PassiveDiscoveryToggle>;
   upsertPassiveDiscovery?: Maybe<PassiveDiscovery>;
 };
 
@@ -181,6 +182,12 @@ export type MutationSavePagerDutyConfigArgs = {
 
 
 /** Mutation root */
+export type MutationTogglePassiveDiscoveryArgs = {
+  toggle?: InputMaybe<PassiveDiscoveryToggleInput>;
+};
+
+
+/** Mutation root */
 export type MutationUpsertPassiveDiscoveryArgs = {
   discovery?: InputMaybe<PassiveDiscoveryUpsertInput>;
 };
@@ -228,6 +235,17 @@ export type PassiveDiscovery = {
   name?: Maybe<Scalars['String']>;
   snmpCommunities?: Maybe<Array<Maybe<Scalars['String']>>>;
   snmpPorts?: Maybe<Array<Maybe<Scalars['Int']>>>;
+  toggle: Scalars['Boolean'];
+};
+
+export type PassiveDiscoveryToggle = {
+  __typename?: 'PassiveDiscoveryToggle';
+  id: Scalars['Long'];
+  toggle: Scalars['Boolean'];
+};
+
+export type PassiveDiscoveryToggleInput = {
+  id: Scalars['Long'];
   toggle: Scalars['Boolean'];
 };
 
@@ -432,6 +450,13 @@ export type CreateActiveDiscoveryMutationVariables = Exact<{
 
 
 export type CreateActiveDiscoveryMutation = { __typename?: 'Mutation', createActiveDiscovery?: { __typename?: 'ActiveDiscovery', configName?: string, ipAddresses?: Array<string>, location?: string, snmpConfig?: { __typename?: 'SNMPConfig', ports?: Array<number>, readCommunities?: Array<string> } } };
+
+export type TogglePassiveDiscoveryMutationVariables = Exact<{
+  toggle: PassiveDiscoveryToggleInput;
+}>;
+
+
+export type TogglePassiveDiscoveryMutation = { __typename?: 'Mutation', togglePassiveDiscovery?: { __typename?: 'PassiveDiscoveryToggle', id: any, toggle: boolean } };
 
 export type UpsertPassiveDiscoveryMutationVariables = Exact<{
   passiveDiscovery: PassiveDiscoveryUpsertInput;
@@ -643,6 +668,7 @@ export const EventsByNodeIdPartsFragmentDoc = {"kind":"Document","definitions":[
 export const NodeByIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeByIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"node"},"name":{"kind":"Name","value":"findNodeById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"objectId"}},{"kind":"Field","name":{"kind":"Name","value":"systemContact"}},{"kind":"Field","name":{"kind":"Name","value":"systemDescr"}},{"kind":"Field","name":{"kind":"Name","value":"systemLocation"}},{"kind":"Field","name":{"kind":"Name","value":"systemName"}},{"kind":"Field","name":{"kind":"Name","value":"location"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"location"}}]}},{"kind":"Field","name":{"kind":"Name","value":"ipInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"hostname"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"netmask"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPrimary"}}]}},{"kind":"Field","name":{"kind":"Name","value":"snmpInterfaces"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"ifAdminStatus"}},{"kind":"Field","name":{"kind":"Name","value":"ifAlias"}},{"kind":"Field","name":{"kind":"Name","value":"ifDescr"}},{"kind":"Field","name":{"kind":"Name","value":"ifIndex"}},{"kind":"Field","name":{"kind":"Name","value":"ifName"}},{"kind":"Field","name":{"kind":"Name","value":"ifOperatorStatus"}},{"kind":"Field","name":{"kind":"Name","value":"ifSpeed"}},{"kind":"Field","name":{"kind":"Name","value":"ifType"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"physicalAddr"}}]}}]}}]}}]} as unknown as DocumentNode<NodeByIdPartsFragment, unknown>;
 export const AddAzureCredentialDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddAzureCredential"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"azureCredential"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AzureCredentialCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addAzureCredential"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"azureCredential"},"value":{"kind":"Variable","name":{"kind":"Name","value":"azureCredential"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTimeMsec"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"subscriptionId"}},{"kind":"Field","name":{"kind":"Name","value":"clientId"}}]}}]}}]} as unknown as DocumentNode<AddAzureCredentialMutation, AddAzureCredentialMutationVariables>;
 export const CreateActiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateActiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"activeDiscovery"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateDiscoveryConfigRequestInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createActiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"request"},"value":{"kind":"Variable","name":{"kind":"Name","value":"activeDiscovery"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"configName"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddresses"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"snmpConfig"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ports"}},{"kind":"Field","name":{"kind":"Name","value":"readCommunities"}}]}}]}}]}}]} as unknown as DocumentNode<CreateActiveDiscoveryMutation, CreateActiveDiscoveryMutationVariables>;
+export const TogglePassiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"TogglePassiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"toggle"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"PassiveDiscoveryToggleInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"togglePassiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"toggle"},"value":{"kind":"Variable","name":{"kind":"Name","value":"toggle"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"toggle"}}]}}]}}]} as unknown as DocumentNode<TogglePassiveDiscoveryMutation, TogglePassiveDiscoveryMutationVariables>;
 export const UpsertPassiveDiscoveryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpsertPassiveDiscovery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"passiveDiscovery"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"PassiveDiscoveryUpsertInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"upsertPassiveDiscovery"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"discovery"},"value":{"kind":"Variable","name":{"kind":"Name","value":"passiveDiscovery"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"snmpCommunities"}},{"kind":"Field","name":{"kind":"Name","value":"snmpPorts"}},{"kind":"Field","name":{"kind":"Name","value":"toggle"}}]}}]}}]} as unknown as DocumentNode<UpsertPassiveDiscoveryMutation, UpsertPassiveDiscoveryMutationVariables>;
 export const DeleteMinionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"DeleteMinion"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"deleteMinion"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}]}}]} as unknown as DocumentNode<DeleteMinionMutation, DeleteMinionMutationVariables>;
 export const AddNodeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddNode"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"node"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"NodeCreateInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addNode"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"node"},"value":{"kind":"Variable","name":{"kind":"Name","value":"node"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"tenantId"}}]}}]}}]} as unknown as DocumentNode<AddNodeMutation, AddNodeMutationVariables>;


### PR DESCRIPTION
## Description
Works in the discovery sidebar, but it's not yet on the edit page itself. Will come after overall edit functionality.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1146

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
