### PR TITLE
HS-1160: Update keycloak to support v18

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -17,7 +17,7 @@
     "generate": "graphql-codegen --config codegen.yml"
   },
   "dependencies": {
-    "@dsb-norge/vue-keycloak-js": "^2.1.5-beta",
+    "@dsb-norge/vue-keycloak-js": "^2.2.0",
     "@featherds/app-bar": "0.12.16",
     "@featherds/app-layout": "0.12.16",
     "@featherds/app-rail": "0.12.16",

--- a/ui/src/composables/useKeycloak.ts
+++ b/ui/src/composables/useKeycloak.ts
@@ -1,10 +1,10 @@
-import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
+import Keycloak from 'keycloak-js'
 
-const keycloak = ref<KeycloakInstance>()
+const keycloak = ref<Keycloak>()
 
 const useKeycloak = () => {
 
-  const setKeycloak = (kc: KeycloakInstance) => {
+  const setKeycloak = (kc: Keycloak) => {
     keycloak.value = kc
   }
 

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -3,7 +3,7 @@ import App from './App.vue'
 import router from './router'
 import { createPinia } from 'pinia'
 import VueKeycloak from '@dsb-norge/vue-keycloak-js'
-import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
+import Keycloak from 'keycloak-js'
 import keycloakConfig from '../keycloak.config'
 import useKeycloak from './composables/useKeycloak'
 import '@featherds/styles'
@@ -33,7 +33,7 @@ const app = createApp(App)
       url: keycloakConfig.url,
       clientId: keycloakConfig.clientId
     },
-    onReady: (kc: KeycloakInstance) => {
+    onReady: (kc: Keycloak) => {
       setKeycloak(kc)
       const gqlClient = getGqlClient(kc)
       app.use(gqlClient)

--- a/ui/src/services/gqlService.ts
+++ b/ui/src/services/gqlService.ts
@@ -1,11 +1,11 @@
 import { definePlugin, createClient, defaultPlugins } from 'villus'
-import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
+import Keycloak from 'keycloak-js'
 import useSnackbar from '@/composables/useSnackbar'
 
 const { showSnackbar } = useSnackbar()
 
 // creates a villus gql client instance
-const getGqlClient = (kc: KeycloakInstance) => {
+const getGqlClient = (kc: Keycloak) => {
   // auth plugin to append token headers
   const authPlugin = ({ opContext }: any) => {
     opContext.headers.Authorization = `Bearer ${kc.token}`

--- a/ui/tests/Appliances/appliances.test.ts
+++ b/ui/tests/Appliances/appliances.test.ts
@@ -4,7 +4,7 @@ import DevicesTable from '@/components/Appliances/AppliancesNodesTable.vue'
 import MinionsTable from '@/components/Appliances/AppliancesMinionsTable.vue'
 import AppliancesAddNodeCtrl from '@/components/Appliances/AppliancesAddNodeCtrl.vue'
 import useKeycloak from '@/composables/useKeycloak'
-import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
+import Keycloak from 'keycloak-js'
 import setupWrapper from 'tests/setupWrapper'
 import dateFormatDirective from '@/directives/v-date'
 
@@ -20,7 +20,7 @@ const wrapper = setupWrapper({
 
 it('should have a header', async () => {
   const { setKeycloak } = useKeycloak()
-  await setKeycloak({ authenticated: true } as KeycloakInstance)
+  await setKeycloak({ authenticated: true } as Keycloak)
 
   const headerWelcome = wrapper.get('[data-test="header-welcome"]')
   expect(headerWelcome.exists()).toBe(true)

--- a/ui/tests/Layout/menubar.test.ts
+++ b/ui/tests/Layout/menubar.test.ts
@@ -1,7 +1,7 @@
 import Menubar from '@/components/Layout/Menubar.vue'
 import useKeycloak from '@/composables/useKeycloak'
 import useTheme from '@/composables/useTheme'
-import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
+import Keycloak from 'keycloak-js'
 import setupWrapper from 'tests/setupWrapper'
 
 test('The menubar mounts', () => {
@@ -14,7 +14,7 @@ test('The menubar mounts', () => {
 test('The toggle dark btn triggers the composible function, and the ref updates', async () => {
   // mock authenticate to show dark/light mode btn
   const { setKeycloak } = useKeycloak()
-  setKeycloak({ authenticated: true } as KeycloakInstance)
+  setKeycloak({ authenticated: true } as Keycloak)
 
   // get theme hook, mock on change theme callback
   const theme = useTheme()

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -522,12 +522,12 @@
   resolved "https://registry.yarnpkg.com/@dash14/svg-pan-zoom/-/svg-pan-zoom-3.6.9.tgz#e73b5a71f73ce00f20ab3484260f45e6c6512ed7"
   integrity sha512-6u+KTQec+9+3bRdk2mReix8AGsp2mB40cw0iYfQQzo22QBkeCNpXl2amnfwQzK7xB9oH/62Wvf2z7l6l2w+csA==
 
-"@dsb-norge/vue-keycloak-js@^2.1.5-beta":
-  version "2.1.5-beta"
-  resolved "https://registry.yarnpkg.com/@dsb-norge/vue-keycloak-js/-/vue-keycloak-js-2.1.5-beta.tgz#84b04344ad1ac8ef1aab77f070de8301c0a837c8"
-  integrity sha512-3FXU2u0FdCTXHTbOqy44zae9Idc5bs1IFBQNDmunBnNGycEuzdyNcc+wcj3GS1VLKff28Vo4IhRgYkJGFSLXcw==
+"@dsb-norge/vue-keycloak-js@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@dsb-norge/vue-keycloak-js/-/vue-keycloak-js-2.2.0.tgz#551e53577f004fb0a23531fade7367f288c2a47a"
+  integrity sha512-XYdfMCR/Z2D8u/3o4kVmvlWwwpIyGSVpb2PAgU2qEb5I/XrXpdORTWHMyF0VpEjlc4sbgA1VdC1Jf2lTZfbcXA==
   dependencies:
-    keycloak-js "15.1.1"
+    keycloak-js "18.0.1"
 
 "@esbuild/android-arm64@0.16.17":
   version "0.16.17"
@@ -2415,12 +2415,7 @@ base64-arraybuffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
-base64-js@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
-
-base64-js@^1.3.1:
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4189,7 +4184,7 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
-js-sha256@0.9.0:
+js-sha256@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
   integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
@@ -4298,13 +4293,13 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-keycloak-js@15.1.1:
-  version "15.1.1"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-15.1.1.tgz#4f3ef77fde377a506ec21e5e4790c0ba96ec97f6"
-  integrity sha512-PPu70WfSI2CWX7GoF5AQ4HkqYJLTAOV/25wDG//9S5SUOhqIDxKjAv6P54hy8nKt2+rIZF2kqpv7FNEmBN2W4g==
+keycloak-js@18.0.1:
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-18.0.1.tgz#0c6dedfa8bbb266bac1b16a14b032d65c6afd2d2"
+  integrity sha512-IRXToYpbIrkyfLeNNJly2OjUCf11ncx2Sdsg257NVDwjOYE923osu47w8pfxEVWpTaS14/Y2QjbTHciuBK0RBQ==
   dependencies:
-    base64-js "1.3.1"
-    js-sha256 "0.9.0"
+    base64-js "^1.5.1"
+    js-sha256 "^0.9.0"
 
 klona@^2.0.4:
   version "2.0.6"


### PR DESCRIPTION
## Description
Seems like there are flaky errors like `dsb-vue-keycloak.esm.js:165 Error: Failure during initialization of keycloak-js adapter at dsb-vue-keycloak.esm.js:162:23`, that could to do with the UI keycloak pckg itself. Current package only supports kc v15, but updating supports v18.

Looks like the dockerfile is using quay.io/keycloak/keycloak:19.0.2 but I'm hoping that at least supporting v18 may solve some of these issues. Tested locally and it ran successfully.


## Jira link(s)
- https://issues.opennms.org/browse/HS-1160

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
