### PR TITLE
HS-1148: Make sure _text is not included in payload

### DIFF
--- a/ui/src/components/Discovery/DiscoveryAzureForm.vue
+++ b/ui/src/components/Discovery/DiscoveryAzureForm.vue
@@ -98,7 +98,12 @@ const selectLocation = (location: Required<Location[]>) =>
 
 const tagsAutocompleteRef = ref()
 const tagsSelectedListener = (tags: Record<string, string>[]) => {
-  const tagsSelected = tags.map((name) => ({ ...name }))
+  const tagsSelected = tags.map((tag) => {
+    delete tag._text
+    delete tag.id
+    delete tag.tenantId
+    return tag
+  })
   store.selectTags(tagsSelected)
 }
 


### PR DESCRIPTION
## Description
Fixes an issue with props added to the payload, causing GQL error

## Jira link(s)
- https://issues.opennms.org/browse/HS-1148

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
