### PR TITLE
HS-1180: Update the basic build-tools to work with maven changes that prevent …

### DIFF
--- a/build-tools/basic/helm-values.yaml
+++ b/build-tools/basic/helm-values.yaml
@@ -1,5 +1,7 @@
 Namespace: tilt-instance
 Host: localhost
+Port: 8123
+Protocol: http
 TLS:
   Enabled: False
 Keycloak:
@@ -32,7 +34,31 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
+  MinionGateway:
+    Resources:
+      Limits:
+        Cpu: '0'
+        Memory: '0'
+      Requests:
+        Cpu: '0'
+        Memory: '0'
+  Inventory:
+    Resources:
+      Limits:
+        Cpu: '0'
+        Memory: '0'
+      Requests:
+        Cpu: '0'
+        Memory: '0'
   Notification:
+    Resources:
+      Limits:
+        Cpu: '0'
+        Memory: '0'
+      Requests:
+        Cpu: '0'
+        Memory: '0'
+  Events:
     Resources:
       Limits:
         Cpu: '0'
@@ -81,3 +107,5 @@ Prometheus:
       Requests:
         Cpu: 100m
         Memory: 100Mi
+Kafka:
+  LocalPort: 24092

--- a/build-tools/basic/mk-docker-images.sh
+++ b/build-tools/basic/mk-docker-images.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 ########################################################################################################################
 ##
-## opennms/grafana-dev
+## opennms/grafana
 ## opennms/horizon-stream-api
 ## opennms/horizon-stream-core
-## opennms/horizon-stream-keycloak-dev
+## opennms/horizon-stream-keycloak
 ## opennms/horizon-stream-minion
 ## opennms/horizon-stream-minion-gateway
 ## opennms/horizon-stream-notification
@@ -25,55 +25,55 @@ time {
 	echo "==="
 	echo "=== MINION-GATEWAY IMAGE"
 	echo "==="
-	mvn -f minion-gateway/main jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-minion-gateway:local-basic
+	mvn -f minion-gateway/main install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-minion-gateway:local-basic
 
 	echo ""
 	echo "==="
 	echo "=== MINION-GATEWAY-GRPC-PROXY IMAGE"
 	echo "==="
-	mvn -f minion-gateway-grpc-proxy/main jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic
+	mvn -f minion-gateway-grpc-proxy/main install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic
 
 	echo ""
 	echo "=== REST-SERVER (AKA API) IMAGE"
 	echo "==="
 	echo "==="
-	mvn -f rest-server jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-rest-server:local-basic
+	mvn -f rest-server install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-rest-server:local-basic
 
 	echo ""
 	echo "==="
 	echo "=== INVENTORY IMAGE"
 	echo "==="
-	mvn -f inventory jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-inventory:local-basic
+	mvn -f inventory install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-inventory:local-basic
 
 		echo ""
   	echo "==="
   	echo "=== ALARM SERVICE IMAGE"
   	echo "==="
-  	mvn -f alert jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-alert:local-basic
+  	mvn -f alarm install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-alarm:local-basic
 
 	echo ""
 	echo "==="
 	echo "=== NOTIFICATION IMAGE"
 	echo "==="
-	mvn -f notifications jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-notification:local-basic
+	mvn -f notifications install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-notification:local-basic
 
 	echo ""
 	echo "==="
 	echo "=== METRICS PROCESSOR IMAGE"
 	echo "==="
-	mvn -f metrics-processor jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-metrics-processor:local-basic
+	mvn -f metrics-processor install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-metrics-processor:local-basic
 
-  echo ""
-  echo "==="
-  echo "=== EVENTS IMAGE"
-  echo "==="
-  mvn -f events jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-events:local-basic
+	echo ""
+	echo "==="
+	echo "=== EVENTS IMAGE"
+	echo "==="
+	mvn -f events install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-events:local-basic
 
-  echo ""
-  echo "==="
-  echo "=== DATACHOICES IMAGE"
-  echo "==="
-  mvn -f events jib:dockerBuild -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-datachoices:local-basic
+	echo ""
+	echo "==="
+	echo "=== DATACHOICES IMAGE"
+	echo "==="
+	mvn -f events install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-datachoices:local-basic
 
 	echo ""
 	echo "==="
@@ -81,14 +81,14 @@ time {
 	echo "==="
 	DOCKER_BUILDKIT=1 docker build \
 		--target development \
-		-t opennms/horizon-stream-keycloak-dev:local-basic \
+		-t opennms/horizon-stream-keycloak:local-basic \
 		keycloak-ui
 
 	echo ""
 	echo "==="
 	echo "=== GRAFANA IMAGE"
 	echo "==="
-	docker build -t opennms/horizon-stream-grafana-dev:local-basic grafana
+	docker build -t opennms/horizon-stream-grafana:local-basic grafana
 
 	echo ""
 	echo "==="

--- a/build-tools/basic/push-images-to-kind.sh
+++ b/build-tools/basic/push-images-to-kind.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Please avoid committing tweaks to this script.
+
 docker pull docker.io/bitnami/kafka:3
 docker pull docker.io/bitnami/zookeeper:3.7
 docker pull mailhog/mailhog:latest
@@ -8,26 +10,49 @@ docker pull opennms/minion:29.0.10
 docker pull postgres:13.3-alpine
 docker pull busybox
 
-kind load docker-image docker.io/bitnami/kafka:3
-kind load docker-image docker.io/bitnami/zookeeper:3.7
-kind load docker-image mailhog/mailhog:latest
-kind load docker-image nginx:1.21.6-alpine
-kind load docker-image opennms/minion:29.0.10
-kind load docker-image postgres:13.3-alpine
-kind load docker-image busybox
+# Don't use "kind load" - it is slow
+# (see the bug fix for "kind load" multiple images simultaneously - when this is available, using the following kind load instead should be just as fast)
+# (bug report here: https://github.com/kubernetes-sigs/kind/issues/3063)
+# 
+# kind load docker-image docker.io/bitnami/kafka:3 \
+# 	docker.io/bitnami/zookeeper:3.7 \
+# 	mailhog/mailhog:latest \
+# 	nginx:1.21.6-alpine \
+# 	opennms/minion:29.0.10 \
+# 	postgres:13.3-alpine \
+# 	busybox \
+# 	"opennms/horizon-stream-grafana-dev:local-basic" \
+# 	"opennms/horizon-stream-core:local-basic" \
+# 	"opennms/horizon-stream-minion:local-basic" \
+# 	"opennms/horizon-stream-ui:local-basic" \
+# 	"opennms/horizon-stream-keycloak-dev:local-basic" \
+# 	"opennms/horizon-stream-inventory:local-basic" \
+# 	"opennms/horizon-stream-alarm:local-basic" \
+# 	"opennms/horizon-stream-notification:local-basic" \
+# 	"opennms/horizon-stream-rest-server:local-basic" \
+# 	"opennms/horizon-stream-minion-gateway:local-basic" \
+# 	"opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic" \
+# 	"opennms/horizon-stream-metrics-processor:local-basic" \
+# 	"opennms/horizon-stream-events:local-basic" \
+# 	"opennms/horizon-stream-datachoices:local-basic"
 
-kind load docker-image "opennms/horizon-stream-grafana-dev:local-basic"
-kind load docker-image "opennms/horizon-stream-core:local-basic"
-kind load docker-image "opennms/horizon-stream-minion:local-basic"
-kind load docker-image "opennms/horizon-stream-ui:local-basic"
-kind load docker-image "opennms/horizon-stream-keycloak-dev:local-basic"
-kind load docker-image "opennms/horizon-stream-inventory:local-basic"
-kind load docker-image "opennms/horizon-stream-alert:local-basic"
-kind load docker-image "opennms/horizon-stream-notification:local-basic"
-kind load docker-image "opennms/horizon-stream-rest-server:local-basic"
-kind load docker-image "opennms/horizon-stream-minion-gateway:local-basic"
-kind load docker-image "opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic"
-kind load docker-image "opennms/horizon-stream-metrics-processor:local-basic"
-kind load docker-image "opennms/horizon-stream-events:local-basic"
-kind load docker-image "opennms/horizon-stream-datachoices:local-basic"
+(
+	docker save \
+		"opennms/horizon-stream-alarm:local-basic" \
+		"opennms/horizon-stream-datachoices:local-basic" \
+		"opennms/horizon-stream-events:local-basic" \
+		"opennms/horizon-stream-grafana:local-basic" \
+		"opennms/horizon-stream-inventory:local-basic" \
+		"opennms/horizon-stream-keycloak:local-basic" \
+		"opennms/horizon-stream-metrics-processor:local-basic" \
+		"opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic" \
+		"opennms/horizon-stream-minion-gateway:local-basic" \
+		"opennms/horizon-stream-minion:local-basic" \
+		"opennms/horizon-stream-notification:local-basic" \
+		"opennms/horizon-stream-rest-server:local-basic" \
+		"opennms/horizon-stream-ui:local-basic"
+) | \
+(
+	docker exec -i "kind-control-plane" ctr images import --snapshotter overlayfs -
+)
 

--- a/build-tools/basic/push-images-to-kind.sh
+++ b/build-tools/basic/push-images-to-kind.sh
@@ -13,46 +13,50 @@ docker pull busybox
 # Don't use "kind load" - it is slow
 # (see the bug fix for "kind load" multiple images simultaneously - when this is available, using the following kind load instead should be just as fast)
 # (bug report here: https://github.com/kubernetes-sigs/kind/issues/3063)
-# 
-# kind load docker-image docker.io/bitnami/kafka:3 \
-# 	docker.io/bitnami/zookeeper:3.7 \
-# 	mailhog/mailhog:latest \
-# 	nginx:1.21.6-alpine \
-# 	opennms/minion:29.0.10 \
-# 	postgres:13.3-alpine \
-# 	busybox \
-# 	"opennms/horizon-stream-grafana-dev:local-basic" \
-# 	"opennms/horizon-stream-core:local-basic" \
-# 	"opennms/horizon-stream-minion:local-basic" \
-# 	"opennms/horizon-stream-ui:local-basic" \
-# 	"opennms/horizon-stream-keycloak-dev:local-basic" \
-# 	"opennms/horizon-stream-inventory:local-basic" \
-# 	"opennms/horizon-stream-alarm:local-basic" \
-# 	"opennms/horizon-stream-notification:local-basic" \
-# 	"opennms/horizon-stream-rest-server:local-basic" \
-# 	"opennms/horizon-stream-minion-gateway:local-basic" \
-# 	"opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic" \
-# 	"opennms/horizon-stream-metrics-processor:local-basic" \
-# 	"opennms/horizon-stream-events:local-basic" \
-# 	"opennms/horizon-stream-datachoices:local-basic"
 
-(
-	docker save \
-		"opennms/horizon-stream-alarm:local-basic" \
-		"opennms/horizon-stream-datachoices:local-basic" \
-		"opennms/horizon-stream-events:local-basic" \
-		"opennms/horizon-stream-grafana:local-basic" \
-		"opennms/horizon-stream-inventory:local-basic" \
-		"opennms/horizon-stream-keycloak:local-basic" \
-		"opennms/horizon-stream-metrics-processor:local-basic" \
-		"opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic" \
-		"opennms/horizon-stream-minion-gateway:local-basic" \
-		"opennms/horizon-stream-minion:local-basic" \
-		"opennms/horizon-stream-notification:local-basic" \
-		"opennms/horizon-stream-rest-server:local-basic" \
-		"opennms/horizon-stream-ui:local-basic"
-) | \
-(
-	docker exec -i "kind-control-plane" ctr images import --snapshotter overlayfs -
-)
+# Reverting to the slow kind load; don't load multiple at once (as per the bug above)
 
+kind load docker-image docker.io/bitnami/kafka:3
+kind load docker-image docker.io/bitnami/zookeeper:3.7
+kind load docker-image mailhog/mailhog:latest
+kind load docker-image nginx:1.21.6-alpine
+kind load docker-image opennms/minion:29.0.10
+kind load docker-image postgres:13.3-alpine
+kind load docker-image busybox
+kind load docker-image "opennms/horizon-stream-grafana-dev:local-basic"
+kind load docker-image "opennms/horizon-stream-core:local-basic"
+kind load docker-image "opennms/horizon-stream-minion:local-basic"
+kind load docker-image "opennms/horizon-stream-ui:local-basic"
+kind load docker-image "opennms/horizon-stream-keycloak-dev:local-basic"
+kind load docker-image "opennms/horizon-stream-inventory:local-basic"
+kind load docker-image "opennms/horizon-stream-alarm:local-basic"
+kind load docker-image "opennms/horizon-stream-notification:local-basic"
+kind load docker-image "opennms/horizon-stream-rest-server:local-basic"
+kind load docker-image "opennms/horizon-stream-minion-gateway:local-basic"
+kind load docker-image "opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic"
+kind load docker-image "opennms/horizon-stream-metrics-processor:local-basic"
+kind load docker-image "opennms/horizon-stream-events:local-basic"
+kind load docker-image "opennms/horizon-stream-datachoices:local-basic"
+
+###
+### FASTER WAY TO LOAD - HOWEVER, for some reason this is not loading all of the images, and tags are wrong
+###
+# (
+# 	docker save \
+# 		"opennms/horizon-stream-alarm:local-basic" \
+# 		"opennms/horizon-stream-datachoices:local-basic" \
+# 		"opennms/horizon-stream-events:local-basic" \
+# 		"opennms/horizon-stream-grafana:local-basic" \
+# 		"opennms/horizon-stream-inventory:local-basic" \
+# 		"opennms/horizon-stream-keycloak:local-basic" \
+# 		"opennms/horizon-stream-metrics-processor:local-basic" \
+# 		"opennms/horizon-stream-minion-gateway-grpc-proxy:local-basic" \
+# 		"opennms/horizon-stream-minion-gateway:local-basic" \
+# 		"opennms/horizon-stream-minion:local-basic" \
+# 		"opennms/horizon-stream-notification:local-basic" \
+# 		"opennms/horizon-stream-rest-server:local-basic" \
+# 		"opennms/horizon-stream-ui:local-basic"
+# ) | \
+# (
+# 	docker exec -i "kind-control-plane" ctr images import --snapshotter overlayfs -
+# )


### PR DESCRIPTION
…the command-line target "jib:dockerBuild" from working on multi-module builds

- Also improve the image push to speed up loading images into Kind
- Remove the no-longer-used "-dev" suffix from the Grafana and Keycloak image names

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-1180

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
