### PR TITLE
HS-1135: Added Aspect for dealing with multi tenancy for Kafka listeners

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/TenantAwareKafkaListener.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/TenantAwareKafkaListener.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.kafka;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TenantAwareKafkaListener {
+    boolean skipOnMissing() default false;
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/TenantAwareKafkaListenerAspect.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/TenantAwareKafkaListenerAspect.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.kafka;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.opennms.horizon.notifications.tenant.TenantContext;
+import org.opennms.horizon.shared.constants.GrpcConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.support.converter.KafkaMessageHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+public class TenantAwareKafkaListenerAspect {
+    private static final Logger LOG = LoggerFactory.getLogger(TenantAwareKafkaListenerAspect.class);
+
+    @Around(("@annotation(listener)"))
+    public Object getTenant(ProceedingJoinPoint joinPoint, TenantAwareKafkaListener listener) throws Throwable {
+        boolean foundTenant = false;
+
+        Object[] args = joinPoint.getArgs();
+        for (Object arg:args) {
+            if (arg instanceof KafkaMessageHeaders) {
+                Object tenantId = ((KafkaMessageHeaders)arg).get(GrpcConstants.TENANT_ID_KEY);
+                if (tenantId instanceof byte[]) {
+                    String strTenantId = new String((byte[]) tenantId);
+                    TenantContext.setTenantId(strTenantId);
+                    foundTenant = true;
+                    break;
+                }
+            }
+        }
+
+        if (foundTenant) {
+            Object proceed = joinPoint.proceed();
+            TenantContext.clear();
+            return proceed;
+        } else {
+            LOG.warn("Failed to find tenant id");
+            if (listener.skipOnMissing()) {
+                // TODO: log args.
+                return null;
+            } else {
+                return joinPoint.proceed();
+            }
+        }
+    }
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/TenantAwareKafkaListenerAspect.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/TenantAwareKafkaListenerAspect.java
@@ -61,9 +61,12 @@ public class TenantAwareKafkaListenerAspect {
         }
 
         if (foundTenant) {
-            Object proceed = joinPoint.proceed();
-            TenantContext.clear();
-            return proceed;
+            try {
+                Object proceed = joinPoint.proceed();
+                return proceed;
+            } finally {
+                TenantContext.clear();
+            }
         } else {
             LOG.warn("Failed to find tenant id");
             if (listener.skipOnMissing()) {

--- a/notifications/src/main/java/org/opennms/horizon/notifications/tenant/WithTenant.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/tenant/WithTenant.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.tenant;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithTenant {
+    String tenantId() default "";
+    int tenantIdArg() default -1;
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/tenant/WithTenantAspect.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/tenant/WithTenantAspect.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.tenant;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.opennms.horizon.notifications.grpc.config.TenantLookup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+public class WithTenantAspect {
+    private static final Logger LOG = LoggerFactory.getLogger(WithTenantAspect.class);
+
+    @Autowired
+    private TenantLookup tenantLookup;
+
+    @Around(("@annotation(withTenant)"))
+    public Object getTenant(ProceedingJoinPoint joinPoint, WithTenant withTenant) throws Throwable {
+        String tenantId = withTenant.tenantId();
+        int tenantIdArg = withTenant.tenantIdArg();
+
+        if (tenantIdArg >= 0) {
+            Object[] args = joinPoint.getArgs();
+            if (args.length <= tenantIdArg) {
+                throw new RuntimeException("TenantIdArg position is greater than the number of arguments to the method");
+            }
+            tenantId = String.valueOf(args[tenantIdArg]);
+        }
+
+        if (tenantId == null || tenantId.isEmpty()) {
+            tenantId = tenantLookup.lookupTenantId().orElseThrow();
+        }
+        TenantContext.setTenantId(tenantId);
+
+        Object proceed = joinPoint.proceed();
+        TenantContext.clear();
+        return proceed;
+    }
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/tenant/WithTenantAspect.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/tenant/WithTenantAspect.java
@@ -61,10 +61,13 @@ public class WithTenantAspect {
         if (tenantId == null || tenantId.isEmpty()) {
             tenantId = tenantLookup.lookupTenantId().orElseThrow();
         }
-        TenantContext.setTenantId(tenantId);
 
-        Object proceed = joinPoint.proceed();
-        TenantContext.clear();
-        return proceed;
+        try {
+            TenantContext.setTenantId(tenantId);
+            Object proceed = joinPoint.proceed();
+            return proceed;
+        } finally {
+            TenantContext.clear();
+        }
     }
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
@@ -16,6 +16,7 @@ import org.opennms.horizon.notifications.exceptions.NotificationConfigUninitiali
 import org.opennms.horizon.notifications.exceptions.NotificationException;
 import org.opennms.horizon.notifications.service.NotificationService;
 import org.opennms.horizon.notifications.tenant.TenantContext;
+import org.opennms.horizon.notifications.tenant.WithTenant;
 import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
 import org.slf4j.Logger;
@@ -165,10 +166,11 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
     }
 
     @Then("verify {string} key is {string}")
+    @WithTenant(tenantIdArg = 0)
     public void verifyKey(String tenantId, String key) {
         System.out.println("JH Verifying tenant="+tenantId);
         System.out.println("JH Verifying key="+key);
-        try (TenantContext tc = TenantContext.withTenantId(tenantId)){
+        try {
             PagerDutyConfigDTO configDTO = pagerDutyDao.getConfig();
             assertEquals(key, configDTO.getIntegrationKey());
         } catch (NotificationConfigUninitializedException e) {
@@ -177,8 +179,9 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
     }
 
     @Then("verify {string} key is not set")
+    @WithTenant(tenantIdArg = 0)
     public void verifyKeyIsNotSet(String tenantId) {
-        try (TenantContext tc = TenantContext.withTenantId(tenantId)){
+        try {
             pagerDutyDao.getConfig();
             fail("Config should not be initialised");
         } catch (NotificationConfigUninitializedException e) {


### PR DESCRIPTION
## Description
Draft PR showing POC work on Aspect for Kafka Listener to retrieve Tenant from header info.
Also include a parameter, so can choose to skip processing if tenant is not present.
(If you wish to perform something different in the event of a missing tenant id, can always call TenantLookup.getTenantId in the method with KafkaListener on it, and process according to your wishes.)

The second commit has added a WithTenant aspect. This should make tests look nicer. Also anywhere that doesn't come in from a GRPC call or via a KafkaListener.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1135

## Flagged for review
n/a

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
