### PR TITLE
HS-1184 - moved sonar cloud project key to GHA secrets

### DIFF
--- a/.github/workflows/feature-parent-pom.yml
+++ b/.github/workflows/feature-parent-pom.yml
@@ -37,4 +37,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           # sonar.projectKey cannot be defined in this project's pom.xml, all child projects would inherit its value
-          project-key: 'opennms_horizon-stream_parent-pom'
+          project-key: ${{ secrets.SONAR_CLOUD_PROJECT_KEY }} 


### PR DESCRIPTION
## Description
Moved sonar cloud project key to GHA secrets

## Jira link(s)
- https://issues.opennms.org/browse/HS-1184

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
