### PR TITLE
HS-1204: Add aggregator POM at root of the repo

### DIFF
--- a/.github/actions/java-install-prereqs/action.yml
+++ b/.github/actions/java-install-prereqs/action.yml
@@ -6,9 +6,11 @@ runs:
   steps:
     - name: Install parent-pom and shared-lib
       run: |
+        # Install parent pom into repository, non recursively
         mvn -B -Dstyle.color=always \
             install -f parent-pom -DskipTests
 
+        # Install shared-lib into repository
         mvn -B -Dstyle.color=always \
             install -f shared-lib -DskipTests
       shell: bash

--- a/.github/actions/java-install-prereqs/action.yml
+++ b/.github/actions/java-install-prereqs/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Install parent-pom and shared-lib
       run: |
-        # Install parent pom into repository, non recursively
+        # Install parent pom into repository
         mvn -B -Dstyle.color=always \
             install -f parent-pom -DskipTests
 

--- a/.github/workflows/feature-parent-pom.yml
+++ b/.github/workflows/feature-parent-pom.yml
@@ -4,7 +4,7 @@ on:
 # Currently triggered by develop workflow, so this trigger is disabled for now until we can fully separate them
 #  pull_request:
 #    paths:
-#      - 'parent-pom/**'
+#      - 'parent-pom/pom.xml'
   workflow_call:
 
 jobs:
@@ -37,4 +37,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           # sonar.projectKey cannot be defined in this project's pom.xml, all child projects would inherit its value
-          project-key: ${{ secrets.SONAR_CLOUD_PROJECT_KEY }} 
+          project-key: ${{ secrets.SONAR_CLOUD_PROJECT_KEY }}

--- a/.tiltignore
+++ b/.tiltignore
@@ -4,4 +4,4 @@ charts/opennms-operator/charts
 charts/opennms-operator/tmpcharts
 charts/opennms-operator-dependencies/charts
 charts/opennms-operator-dependencies/tmpcharts
-*.iml
+**/*.iml

--- a/Tiltfile
+++ b/Tiltfile
@@ -162,7 +162,7 @@ k8s_yaml(
 ## Shared ##
 local_resource(
     'parent-pom',
-    cmd='mvn clean install -N',
+    cmd='mvn clean install -DskipTests=true',
     dir='parent-pom',
     deps=['./parent-pom'],
     ignore=['**/target'],

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -3,7 +3,7 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <version>0.1.0-SNAPSHOT</version>
+
     <parent>
         <groupId>org.opennms.horizon</groupId>
         <artifactId>horizon-parent</artifactId>

--- a/events/grpc/pom.xml
+++ b/events/grpc/pom.xml
@@ -12,7 +12,6 @@
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>grpc</artifactId>
     <name>OpenNMS Horizon Stream :: Events :: Grpc</name>
-    <version>0.1.0-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -12,8 +12,8 @@
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>main</artifactId>
     <name>OpenNMS Horizon Stream :: Events :: Main</name>
-    <version>0.1.0-SNAPSHOT</version>
     <description>Events Service</description>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/events/persistence/pom.xml
+++ b/events/persistence/pom.xml
@@ -12,7 +12,6 @@
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>persistence</artifactId>
     <name>OpenNMS Horizon Stream :: Events :: Persistence</name>
-    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <sonar.coverage.exclusions>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -17,7 +17,6 @@
     </description>
 
     <artifactId>events</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/events/traps/pom.xml
+++ b/events/traps/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>traps</artifactId>
     <name>OpenNMS Horizon Stream :: Events :: Traps</name>
-    <version>0.1.0-SNAPSHOT</version>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock-api</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock :: API</name>
     <description>

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock-client</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock :: Client</name>
     <description>

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock-main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock :: Main</name>
     <description>

--- a/inventory/testtools/minion-gateway-wiremock/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock</name>

--- a/metrics-processor/flows/pom.xml
+++ b/metrics-processor/flows/pom.xml
@@ -13,7 +13,6 @@
     </description>
 
     <artifactId>flows</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
 
     <dependencies>

--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -15,7 +15,6 @@
     </description>
 
     <artifactId>main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>

--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -7,6 +7,7 @@
         <groupId>org.opennms.horizon</groupId>
         <artifactId>horizon-parent</artifactId>
         <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../parent-pom</relativePath>
     </parent>
 
     <name>OpenNMS Horizon Stream :: Metrics Processor</name>

--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -16,7 +16,6 @@
     </description>
 
     <artifactId>metrics-processor</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <application.docker.image.name>opennms/horizon-stream-metrics-processor</application.docker.image.name>

--- a/metrics-processor/timeseries/pom.xml
+++ b/metrics-processor/timeseries/pom.xml
@@ -15,7 +15,6 @@
     </description>
 
     <artifactId>timeseries</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <java.version>17</java.version>

--- a/minion-gateway-grpc-proxy/pom.xml
+++ b/minion-gateway-grpc-proxy/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <version>0.1.0-SNAPSHOT</version>
+
     <parent>
         <groupId>org.opennms.horizon</groupId>
         <artifactId>horizon-parent</artifactId>

--- a/minion-gateway/pom.xml
+++ b/minion-gateway/pom.xml
@@ -17,7 +17,6 @@
 
     <groupId>org.opennms.horizon.minion.gateway</groupId>
     <artifactId>minion-gateway</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/minion/docker-assembly/pom.xml
+++ b/minion/docker-assembly/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.opennms.horizon.minion</groupId>
             <artifactId>assembly</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>tar.gz</type>
             <!--<classifier>tar.gz</classifier>-->
         </dependency>

--- a/minion/icmp/icmp-jna/pom.xml
+++ b/minion/icmp/icmp-jna/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
           <groupId>org.opennms.horizon.shared</groupId>
           <artifactId>horizon-common-utils</artifactId>
-          <version>0.1.0-SNAPSHOT</version>
+          <version>${project.version}</version>
       </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/minion/minion-flows/flows-parser/pom.xml
+++ b/minion/minion-flows/flows-parser/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-      <groupId>org.opennms.horizon.minion</groupId>
-      <artifactId>minion-flows</artifactId>
+    <groupId>org.opennms.horizon.minion</groupId>
+    <artifactId>minion-flows</artifactId>
     <version>0.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock-api</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock :: API</name>
     <description>

--- a/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock-client</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock :: Client</name>
     <description>

--- a/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>minion-gateway-wiremock-main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
     <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock :: Main</name>
     <description>

--- a/minion/testtools/minion-gateway-wiremock/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/pom.xml
@@ -12,7 +12,6 @@
 
     <groupId>org.opennms.horizon.minion</groupId>
     <artifactId>minion-gateway-wiremock</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock</name>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -15,7 +15,6 @@
     <description>A microservice responsible for generating notifications from alerts.</description>
 
 	<artifactId>notifications</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
 
     <properties>
         <application.docker.image.name>opennms/horizon-stream-notification</application.docker.image.name>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <name>OpenNMS Horizon Stream :: Horizon Parent</name>
+    <name>OpenNMS Horizon Stream :: Parent POM</name>
     <description>
         Top-level Parent POM with standard dependency versions for use across multiple top-level projects.
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>OpenNMS Horizon Stream</name>
+    <description>
+        Aggregator POM for Horizon Stream.
+
+        This POM file is only to enable better IDE support and should not be used to instrument builds. Top-level projects should be built individually.
+
+        `maven-enforcer-plugin` is used to discourage its use.
+    </description>
+
+    <groupId>org.opennms.horizon</groupId>
+    <artifactId>horizon-stream</artifactId>
+    <version>0.0.0</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>alert</module>
+        <module>datachoices</module>
+        <module>events</module>
+        <module>external-it</module>
+        <module>inventory</module>
+        <module>metrics-processor</module>
+        <module>minion</module>
+        <module>minion-gateway</module>
+        <module>minion-gateway-grpc-proxy</module>
+        <module>notifications</module>
+        <module>parent-pom</module>
+        <module>rest-server</module>
+        <module>shared-lib</module>
+        <module>tooling/ignite-tool</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>ban-aggregator-pom</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <alwaysFail>
+                                    <message>
+                                        This aggregator POM is only for IDE support and should never be part of a build! Top-level projects should be built individually.
+                                    </message>
+                                </alwaysFail>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -18,7 +18,6 @@
     </description>
 
 	<artifactId>rest-server</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
 
 	<properties>
         <application.docker.image.name>opennms/horizon-stream-rest-server</application.docker.image.name>

--- a/shared-lib/notifications/pom.xml
+++ b/shared-lib/notifications/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <version>0.1.0-SNAPSHOT</version>
+
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -15,7 +15,6 @@
 
     <groupId>org.opennms.horizon.shared</groupId>
     <artifactId>shared-lib</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
## Description
- Adds an aggregator POM that defines top-level projects as modules
- IntelliJ's "Cannot reconnect" Maven issue no longer appears to happen
- Initial project import is much more smooth
- Changing branches works well, no more issues caused by new/removed modules
- Cleanup of unnecessary version elements in pom files

## Jira link(s)
- https://issues.opennms.org/browse/HS-1204

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
