### PR TITLE
HS-1209: Get Tags by Passive Discovery ID

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcTagService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcTagService.java
@@ -91,6 +91,14 @@ public class GrpcTagService {
     }
 
     @GraphQLQuery
+    public Mono<List<Tag>> getTagsByPassiveDiscoveryId(@GraphQLArgument(name = "passiveDiscoveryId") Long activeDiscoveryId,
+                                                      @GraphQLArgument(name = "searchTerm") String searchTerm,
+                                                      @GraphQLEnvironment ResolutionEnvironment env) {
+        List<TagDTO> tagsList = client.getTagsByPassiveDiscoveryId(activeDiscoveryId, searchTerm, headerUtil.getAuthHeader(env)).getTagsList();
+        return Mono.just(tagsList.stream().map(mapper::protoToTag).toList());
+    }
+
+    @GraphQLQuery
     public Mono<List<Tag>> getTags(@GraphQLArgument(name = "searchTerm") String searchTerm,
                                    @GraphQLEnvironment ResolutionEnvironment env) {
         List<TagDTO> tagsList = client.getTags(searchTerm, headerUtil.getAuthHeader(env)).getTagsList();

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/InventoryClient.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/grpc/InventoryClient.java
@@ -259,6 +259,17 @@ public class InventoryClient {
             .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getTagsByEntityId(params);
     }
 
+    public TagListDTO getTagsByPassiveDiscoveryId(long passiveDiscoveryId, String searchTerm, String accessToken) {
+        Metadata metadata = new Metadata();
+        metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);
+        ListTagsByEntityIdParamsDTO params = ListTagsByEntityIdParamsDTO.newBuilder()
+            .setPassiveDiscoveryId(passiveDiscoveryId)
+            .setParams(buildTagListParams(searchTerm))
+            .build();
+        return tagStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata))
+            .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS).getTagsByEntityId(params);
+    }
+
     public TagListDTO getTags(String searchTerm, String accessToken) {
         Metadata metadata = new Metadata();
         metadata.put(GrpcConstants.AUTHORIZATION_METADATA_KEY, accessToken);

--- a/rest-server/src/test/java/org/opennms/horizon/server/service/GraphQLTagServiceTest.java
+++ b/rest-server/src/test/java/org/opennms/horizon/server/service/GraphQLTagServiceTest.java
@@ -190,7 +190,7 @@ class GraphQLTagServiceTest {
     }
 
     @Test
-    void testGetTagsFromAzureCredential() throws JSONException {
+    void testGetTagsFromActiveDiscovery() throws JSONException {
 
         TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
         TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
@@ -224,7 +224,7 @@ class GraphQLTagServiceTest {
     }
 
     @Test
-    void testGetTagsFromAzureCredentialWithSearchTerm() throws JSONException {
+    void testGetTagsFromActiveDiscoveryWithSearchTerm() throws JSONException {
 
         TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
         TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
@@ -254,6 +254,74 @@ class GraphQLTagServiceTest {
             .jsonPath("$.data.tagsByActiveDiscoveryId[1].name").isEqualTo(TEST_TAG_NAME_2);
 
         verify(mockClient, times(1)).getTagsByActiveDiscoveryId(1L, "abc", accessToken);
+        verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
+    }
+
+    @Test
+    void testGetTagsFromPassiveDiscovery() throws JSONException {
+
+        TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
+        TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
+        TagListDTO tagListDTO = TagListDTO.newBuilder().addTags(tagDTO1).addTags(tagDTO2).build();
+        when(mockClient.getTagsByPassiveDiscoveryId(anyLong(), any(), anyString())).thenReturn(tagListDTO);
+
+        String getRequest = "query { " +
+            "    tagsByPassiveDiscoveryId (passiveDiscoveryId: 1) { " +
+            "        id, " +
+            "        tenantId, " +
+            "        name " +
+            "    }" +
+            "}";
+        webClient.post()
+            .uri(GRAPHQL_PATH)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(createPayload(getRequest))
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody()
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[0].id").isEqualTo(1)
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[0].tenantId").isNotEmpty()
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[0].name").isEqualTo(TEST_TAG_NAME_1)
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[1].id").isEqualTo(2)
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[1].tenantId").isNotEmpty()
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[1].name").isEqualTo(TEST_TAG_NAME_2);
+
+        verify(mockClient, times(1)).getTagsByPassiveDiscoveryId(1L, null, accessToken);
+        verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
+    }
+
+    @Test
+    void testGetTagsFromPassiveDiscoveryWithSearchTerm() throws JSONException {
+
+        TagDTO tagDTO1 = TagDTO.newBuilder().setName(TEST_TAG_NAME_1).setTenantId(TEST_TENANT_ID).setId(1L).build();
+        TagDTO tagDTO2 = TagDTO.newBuilder().setName(TEST_TAG_NAME_2).setTenantId(TEST_TENANT_ID).setId(2L).build();
+        TagListDTO tagListDTO = TagListDTO.newBuilder().addTags(tagDTO1).addTags(tagDTO2).build();
+        when(mockClient.getTagsByPassiveDiscoveryId(anyLong(), anyString(), anyString())).thenReturn(tagListDTO);
+
+        String getRequest = "query { " +
+            "    tagsByPassiveDiscoveryId (passiveDiscoveryId: 1, searchTerm: \"abc\") { " +
+            "        id, " +
+            "        tenantId, " +
+            "        name " +
+            "    }" +
+            "}";
+        webClient.post()
+            .uri(GRAPHQL_PATH)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(createPayload(getRequest))
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody()
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[0].id").isEqualTo(1)
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[0].tenantId").isNotEmpty()
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[0].name").isEqualTo(TEST_TAG_NAME_1)
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[1].id").isEqualTo(2)
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[1].tenantId").isNotEmpty()
+            .jsonPath("$.data.tagsByPassiveDiscoveryId[1].name").isEqualTo(TEST_TAG_NAME_2);
+
+        verify(mockClient, times(1)).getTagsByPassiveDiscoveryId(1L, "abc", accessToken);
         verify(mockHeaderUtil, times(1)).getAuthHeader(any(ResolutionEnvironment.class));
     }
 


### PR DESCRIPTION
## Description
HS-1209: Get Tags by Passive Discovery ID

REQUEST
```
query {
    tagsByPassiveDiscoveryId (passiveDiscoveryId: 1) {
        id,
        tenantId,
        name
    }
}
```

RESPONSE
```
{
    "data": {
        "tagsByPassiveDiscoveryId": [
            {
                "id": 1,
                "tenantId": "opennms-prime",
                "name": "tag1"
            }
        ]
    }
}
```

Just needed to add the BFF component

## Jira link(s)
- https://issues.opennms.org/browse/HS-1209


## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
