### PR TITLE
HS-1237: update the basic build-tools scripts: granafa and keycloak n…

### DIFF
--- a/build-tools/basic/mk-docker-images.sh
+++ b/build-tools/basic/mk-docker-images.sh
@@ -3,7 +3,6 @@
 ##
 ## opennms/grafana
 ## opennms/horizon-stream-api
-## opennms/horizon-stream-core
 ## opennms/horizon-stream-keycloak
 ## opennms/horizon-stream-minion
 ## opennms/horizon-stream-minion-gateway
@@ -45,11 +44,11 @@ time {
 	echo "==="
 	mvn -f inventory install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-inventory:local-basic
 
-		echo ""
-  	echo "==="
-  	echo "=== ALARM SERVICE IMAGE"
-  	echo "==="
-  	mvn -f alarm install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-alarm:local-basic
+	echo ""
+	echo "==="
+	echo "=== ALERT SERVICE IMAGE"
+	echo "==="
+	mvn -f alert install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-alert:local-basic
 
 	echo ""
 	echo "==="

--- a/build-tools/basic/push-images-to-kind.sh
+++ b/build-tools/basic/push-images-to-kind.sh
@@ -23,13 +23,12 @@ kind load docker-image nginx:1.21.6-alpine
 kind load docker-image opennms/minion:29.0.10
 kind load docker-image postgres:13.3-alpine
 kind load docker-image busybox
-kind load docker-image "opennms/horizon-stream-grafana-dev:local-basic"
-kind load docker-image "opennms/horizon-stream-core:local-basic"
+kind load docker-image "opennms/horizon-stream-grafana:local-basic"
 kind load docker-image "opennms/horizon-stream-minion:local-basic"
 kind load docker-image "opennms/horizon-stream-ui:local-basic"
-kind load docker-image "opennms/horizon-stream-keycloak-dev:local-basic"
+kind load docker-image "opennms/horizon-stream-keycloak:local-basic"
 kind load docker-image "opennms/horizon-stream-inventory:local-basic"
-kind load docker-image "opennms/horizon-stream-alarm:local-basic"
+kind load docker-image "opennms/horizon-stream-alert:local-basic"
 kind load docker-image "opennms/horizon-stream-notification:local-basic"
 kind load docker-image "opennms/horizon-stream-rest-server:local-basic"
 kind load docker-image "opennms/horizon-stream-minion-gateway:local-basic"
@@ -43,7 +42,7 @@ kind load docker-image "opennms/horizon-stream-datachoices:local-basic"
 ###
 # (
 # 	docker save \
-# 		"opennms/horizon-stream-alarm:local-basic" \
+# 		"opennms/horizon-stream-alert:local-basic" \
 # 		"opennms/horizon-stream-datachoices:local-basic" \
 # 		"opennms/horizon-stream-events:local-basic" \
 # 		"opennms/horizon-stream-grafana:local-basic" \

--- a/build-tools/basic/run-cluster.sh
+++ b/build-tools/basic/run-cluster.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 helm upgrade -i opennms ./charts/opennms -f build-tools/basic/helm-values.yaml \
-  --set Grafana.Image=opennms/horizon-stream-grafana-dev:local-basic \
-  --set Keycloak.Image=opennms/horizon-stream-keycloak-dev:local-basic \
+  --set Grafana.Image=opennms/horizon-stream-grafana:local-basic \
+  --set Keycloak.Image=opennms/horizon-stream-keycloak:local-basic \
   --set OpenNMS.API.Image=opennms/horizon-stream-rest-server:local-basic \
-  --set OpenNMS.Alarm.Image=opennms/horizon-stream-alarm:local-basic \
+  --set OpenNMS.Alert.Image=opennms/horizon-stream-alert:local-basic \
   --set OpenNMS.DataChoices.Image=opennms/horizon-stream-datachoices:local-basic \
   --set OpenNMS.Events.Image=opennms/horizon-stream-events:local-basic \
   --set OpenNMS.Inventory.Image=opennms/horizon-stream-inventory:local-basic \

--- a/build-tools/basic/run-port-forwards.sh
+++ b/build-tools/basic/run-port-forwards.sh
@@ -14,9 +14,6 @@ kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace de
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-alert 32080:8080 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-alert 32050:5005 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-notifications 15050:5005 &
-kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-core 11080:8181 &
-kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-core 11022:8101 &
-kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-core 11050:5005 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-minion 12080:8181 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-minion 12022:8102 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-minion 12050:5005 &

--- a/build-tools/basic/stop-dev-pods.sh
+++ b/build-tools/basic/stop-dev-pods.sh
@@ -12,7 +12,6 @@
 
 kubectl delete deployment opennms-notifications
 kubectl delete deployment opennms-rest-server
-kubectl delete deployment opennms-core
 kubectl delete deployment opennms-minion
 kubectl delete deployment opennms-ui
 kubectl delete deployment opennms-minion-gateway
@@ -20,4 +19,4 @@ kubectl delete deployment opennms-minion-gateway-grpc-proxy
 kubectl delete deployment opennms-metrics-processor
 kubectl delete deployment opennms-events
 kubectl delete deployment opennms-datachoices
-
+kubectl delete deployment opennms-alert


### PR DESCRIPTION
…o longer use "-dev" suffix.  Some lingering "alarm" service names changed to "alert"

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-1237

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
