### PR TITLE
AR-28: Add CODEOWNERS for architecture docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Architecture docs:
+/doc/architecture/** @OpenNMS-Cloud/architecture


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- PRs that touch this folder need to be approved by the "architecture" team
- Primarily for ADRs

## Jira link(s)
- https://issues.opennms.org/browse/AR-28

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->
- Created an "Architecture" team and had to explicitly give it write access to the repo for this to work.

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
