### PR TITLE
HS-1245: Disable develop workflow when PR only touches non-code paths

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,9 +8,14 @@ on:
 # This workflow is triggered instead of individual workflows that filter based on paths.
 # If we want to fully separate individual workflows out of this one, we need fully reproducible builds.
 # Just use this one for now. The downside is it will run redundant workflows for code that didn't change.
-#    types: [labeled]
     branches:
       - 'develop'
+    paths:
+      - '!CHANGELOG/**'
+      - '!build-tools/**'
+      - '!doc/**'
+      - '!tooling/**'
+      - '!tools/**'
   workflow_call:
     inputs:
       image-tag:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,11 +11,11 @@ on:
     branches:
       - 'develop'
     paths-ignore:
-      - '!CHANGELOG/**'
-      - '!build-tools/**'
-      - '!doc/**'
-      - '!tooling/**'
-      - '!tools/**'
+      - 'CHANGELOG/**'
+      - 'build-tools/**'
+      - 'doc/**'
+      - 'tooling/**'
+      - 'tools/**'
   workflow_call:
     inputs:
       image-tag:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -10,7 +10,7 @@ on:
 # Just use this one for now. The downside is it will run redundant workflows for code that didn't change.
     branches:
       - 'develop'
-    paths:
+    paths-ignore:
       - '!CHANGELOG/**'
       - '!build-tools/**'
       - '!doc/**'

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - 'develop'
     paths-ignore:
+      - '.github/**'
       - 'CHANGELOG/**'
       - 'build-tools/**'
       - 'doc/**'


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- Disables the trigger for develop workflow when only non-code paths change
- Still triggers when code paths do change

The ignored folders may also contain code, but they are not used in any tests in the develop workflow.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1245

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
