### PR TITLE
HS-1249 Include cxf-karaf-commands in minion software distribution.

### DIFF
--- a/minion/assembly/pom.xml
+++ b/minion/assembly/pom.xml
@@ -102,6 +102,9 @@
                         <feature>aries-blueprint</feature>
                         <feature>shell-compat</feature>
                     </installedFeatures>
+                    <installedBundles>
+                        <bundle>mvn:org.apache.cxf.karaf/cxf-karaf-commands/${cxf.version}</bundle>
+                    </installedBundles>
                     <startupFeatures>
                         <feature>eventadmin</feature>
                     </startupFeatures>


### PR DESCRIPTION
## Description
Minion startup should be possible with no internet access. This means that all "system" dependencies should be embedded into its image/archive.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1249

## Flagged for review

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
