### PR TITLE
HS-1258: Use TenantedTaskSetResults  in Minion Gateway.  

### DIFF
--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/AzureDiscoveryStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/AzureDiscoveryStepDefinitions.java
@@ -50,15 +50,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class AzureDiscoveryStepDefinitions {
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
     private AzureActiveDiscoveryCreateDTO createDiscoveryDto;
     private AzureActiveDiscoveryDTO discoveryDto;
     private TagCreateDTO tagCreateDto1;
     private TagListDTO tagList;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public AzureDiscoveryStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     /*

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/IcmpDiscoveryStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/IcmpDiscoveryStepDefinitions.java
@@ -64,13 +64,12 @@ import java.util.stream.Stream;
 public class IcmpDiscoveryStepDefinitions {
 
     private static final Logger LOG = LoggerFactory.getLogger(InventoryProcessingStepDefinitions.class);
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
     private IcmpActiveDiscoveryCreateDTO icmpDiscovery;
     private long activeDiscoveryId;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public IcmpDiscoveryStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     @Given("[ICMP Discovery] External GRPC Port in system property {string}")

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/IcmpDiscoveryStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/IcmpDiscoveryStepDefinitions.java
@@ -52,6 +52,7 @@ import org.opennms.taskset.contract.PingResponse;
 import org.opennms.taskset.contract.ScannerResponse;
 import org.opennms.taskset.contract.TaskResult;
 import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,8 +150,9 @@ public class IcmpDiscoveryStepDefinitions {
                     .setScannerResponse(ScannerResponse.newBuilder().setResult(Any.pack(scanResult)).build())
                     .build();
 
-            TaskSetResults taskSetResults =
-                TaskSetResults.newBuilder()
+            TenantedTaskSetResults taskSetResults =
+                TenantedTaskSetResults.newBuilder()
+                    .setTenantId(backgroundHelper.getTenantId())
                     .addResults(taskResult)
                     .build();
             var producerRecord = new ProducerRecord<String, byte[]>(topic, taskSetResults.toByteArray());

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/InventoryProcessingStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/InventoryProcessingStepDefinitions.java
@@ -55,7 +55,7 @@ import org.opennms.horizon.inventory.testtool.miniongateway.wiremock.client.Mini
 import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.contract.DetectorResponse;
 import org.opennms.taskset.contract.TaskResult;
-import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -342,8 +342,9 @@ public class InventoryProcessingStepDefinitions {
                     .setDetectorResponse(detectorResponse)
                     .build();
 
-            TaskSetResults taskSetResults =
-                TaskSetResults.newBuilder()
+            TenantedTaskSetResults taskSetResults =
+                TenantedTaskSetResults.newBuilder()
+                    .setTenantId(backgroundHelper.getTenantId())
                     .addResults(taskResult)
                     .build();
 

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/InventoryProcessingStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/InventoryProcessingStepDefinitions.java
@@ -117,6 +117,7 @@ public class InventoryProcessingStepDefinitions {
     @Given("Grpc TenantId {string}")
     public void grpcTenantId(String tenantId) {
         backgroundHelper.grpcTenantId(tenantId);
+        minionGatewayWiremockTestSteps.setTaskTenantId(tenantId);
     }
 
     @Given("Minion at location {string} with system Id {string}")

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/NodeStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/NodeStepDefinitions.java
@@ -18,14 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NodeStepDefinitions {
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
     private NodeDTO node;
     private MonitoringLocationDTO monitoringLocation;
     private NodeList fetchedNodeList;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public NodeStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     /*

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/PassiveDiscoveryStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/PassiveDiscoveryStepDefinitions.java
@@ -50,15 +50,14 @@ import static org.junit.Assert.assertEquals;
 
 
 public class PassiveDiscoveryStepDefinitions {
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
     private PassiveDiscoveryUpsertDTO passiveDiscoveryUpsertDTO;
     private PassiveDiscoveryDTO createdDiscovery;
     private PassiveDiscoveryListDTO fetchedPassiveDiscoveryList;
     private TagListDTO tagList;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public PassiveDiscoveryStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     /*

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/tags/ActiveDiscoveryTaggingStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/tags/ActiveDiscoveryTaggingStepDefinitions.java
@@ -64,16 +64,15 @@ import static org.junit.Assert.assertNotNull;
 
 // using icmp active discovery here but can be any subclass of ActiveDiscovery
 public class ActiveDiscoveryTaggingStepDefinitions {
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
 
     private IcmpActiveDiscoveryDTO activeDiscovery1;
     private IcmpActiveDiscoveryDTO activeDiscovery2;
     private TagListDTO addedTagList;
     private TagListDTO fetchedTagList;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public ActiveDiscoveryTaggingStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     /*

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/tags/NodeTaggingStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/tags/NodeTaggingStepDefinitions.java
@@ -62,16 +62,15 @@ import static org.junit.Assert.assertNotNull;
 
 
 public class NodeTaggingStepDefinitions {
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
 
     private NodeDTO node1;
     private NodeDTO node2;
     private TagListDTO addedTagList;
     private TagListDTO fetchedTagList;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public NodeTaggingStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     /*

--- a/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/tags/PassiveDiscoveryTaggingStepDefinitions.java
+++ b/inventory/docker-it/src/test/java/org/opennms/horizon/inventory/cucumber/steps/tags/PassiveDiscoveryTaggingStepDefinitions.java
@@ -59,16 +59,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class PassiveDiscoveryTaggingStepDefinitions {
-    private static InventoryBackgroundHelper backgroundHelper;
+    private final InventoryBackgroundHelper backgroundHelper;
 
     private PassiveDiscoveryDTO passiveDiscovery1;
     private PassiveDiscoveryDTO passiveDiscovery2;
     private TagListDTO addedTagList;
     private TagListDTO fetchedTagList;
 
-    @BeforeAll
-    public static void beforeAll() {
-        backgroundHelper = new InventoryBackgroundHelper();
+    public PassiveDiscoveryTaggingStepDefinitions(InventoryBackgroundHelper backgroundHelper) {
+        this.backgroundHelper = backgroundHelper;
     }
 
     /*

--- a/inventory/docker-it/src/test/resources/org/opennms/horizon/inventory/icmp-active-discovery.feature
+++ b/inventory/docker-it/src/test/resources/org/opennms/horizon/inventory/icmp-active-discovery.feature
@@ -4,7 +4,7 @@ Feature: Active Discovery
     Given [ICMP Discovery] External GRPC Port in system property "application-external-grpc-port"
     Given [ICMP Discovery] Kafka Bootstrap URL in system property "kafka.bootstrap-servers"
     Given MOCK Minion Gateway Base URL in system property "mock-minion-gateway.rest-url"
-    Given [ICMP Discovery] Grpc TenantId "tenant-icmp-discovery"
+    Given Grpc TenantId "tenant-icmp-discovery"
     Given [ICMP Discovery] Create Grpc Connection for Inventory
 
 

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumer.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumer.java
@@ -50,6 +50,7 @@ import org.opennms.taskset.contract.MonitorResponse;
 import org.opennms.taskset.contract.MonitorType;
 import org.opennms.taskset.contract.TaskResult;
 import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -149,6 +150,7 @@ public class MinionHeartbeatConsumer {
     }
 
     private void publishResult(String systemId, String location, String tenantId, long responseTime) {
+        // TODO: use a separate structure from TaskSetResult - this is not the result of processing a TaskSet
         MonitorResponse monitorResponse = MonitorResponse.newBuilder()
             .setStatus("UP")
             .setResponseTimeMs(responseTime)
@@ -161,11 +163,12 @@ public class MinionHeartbeatConsumer {
             .setLocation(location)
             .setMonitorResponse(monitorResponse)
             .build();
-        TaskSetResults results = TaskSetResults.newBuilder()
+        TenantedTaskSetResults results = TenantedTaskSetResults.newBuilder()
+            .setTenantId(tenantId)
             .addResults(result)
             .build();
+
         ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(kafkaTopic, results.toByteArray());
-        producerRecord.headers().add(new RecordHeader(GrpcConstants.TENANT_ID_KEY, tenantId.getBytes()));
         kafkaTemplate.send(producerRecord);
     }
 }

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
@@ -28,12 +28,8 @@
 
 package org.opennms.horizon.inventory.service.taskset.publisher;
 
-import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
-import io.grpc.Metadata;
-import io.grpc.stub.MetadataUtils;
 import lombok.Setter;
-import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.contract.TaskDefinition;
 import org.opennms.taskset.service.contract.AddSingleTaskOp;
 import org.opennms.taskset.service.contract.RemoveSingleTaskOp;
@@ -63,8 +59,6 @@ public class GrpcTaskSetPublisher implements TaskSetPublisher {
     // Test helpers to overcome static method calls which are challenging, at best, to mock
     @Setter
     private Function<ManagedChannel, io.grpc.stub.AbstractBlockingStub<TaskSetServiceBlockingStub>> taskSetServiceBlockingStubSupplier = this::supplyDefaultTaskSetServiceBlockingStub;
-    @Setter
-    private Function<Metadata, ClientInterceptor> attachHeadersInterceptorFunction = MetadataUtils::newAttachHeadersInterceptor;
 
     public GrpcTaskSetPublisher(ManagedChannel channel, long deadline) {
         this.channel = channel;

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
@@ -133,19 +133,14 @@ public class GrpcTaskSetPublisher implements TaskSetPublisher {
         try {
             UpdateTasksRequest.Builder request =
                 UpdateTasksRequest.newBuilder()
+                    .setTenantId(tenantId)
                     .setLocation(location)
                     ;
 
             populateUpdateRequestOp.accept(request);
 
-            Metadata metadata = new Metadata();
-            metadata.put(GrpcConstants.TENANT_ID_REQUEST_KEY, tenantId);
-
-            ClientInterceptor attachHeadersInterceptor = attachHeadersInterceptorFunction.apply(metadata);
-
             UpdateTasksResponse response =
                 taskSetServiceStub
-                    .withInterceptors(attachHeadersInterceptor)
                     .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS)
                     .updateTasks(request.build())
                 ;

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumerTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumerTest.java
@@ -107,6 +107,7 @@ public class MinionHeartbeatConsumerTest {
     @Test
     void testAcceptHeartbeatsDelay() throws InterruptedException {
         messageConsumer.receiveMessage(heartbeat.toByteArray(), headers);
+        // TODO: rework to eliminate use of slee() which leads to intermittent failures
         Thread.sleep(1000);
         messageConsumer.receiveMessage(heartbeat.toByteArray(), headers);
         Thread.sleep(100);

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/component/TaskSetResultsConsumerTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/component/TaskSetResultsConsumerTest.java
@@ -36,14 +36,12 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opennms.horizon.inventory.service.taskset.response.DetectorResponseService;
 import org.opennms.horizon.inventory.service.taskset.response.ScannerResponseService;
-import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.contract.DetectorResponse;
 import org.opennms.taskset.contract.ScannerResponse;
 import org.opennms.taskset.contract.TaskResult;
-import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collections;
 
 import static org.mockito.Mockito.times;
 
@@ -71,13 +69,12 @@ public class TaskSetResultsConsumerTest {
             .setScannerResponse(response)
             .build();
 
-        TaskSetResults results = TaskSetResults.newBuilder()
-            .addResults(taskResult).build();
+        TenantedTaskSetResults results = TenantedTaskSetResults.newBuilder()
+            .setTenantId(TEST_TENANT_ID)
+            .addResults(taskResult)
+            .build();
 
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(GrpcConstants.TENANT_ID_KEY, TEST_TENANT_ID.getBytes());
-
-        consumer.receiveMessage(results.toByteArray(), headers);
+        consumer.receiveMessage(results.toByteArray(), Collections.EMPTY_MAP);
 
         Mockito.verify(scannerService, times(1))
             .accept(TEST_TENANT_ID, TEST_LOCATION, response);
@@ -93,13 +90,11 @@ public class TaskSetResultsConsumerTest {
             .setDetectorResponse(response)
             .build();
 
-        TaskSetResults results = TaskSetResults.newBuilder()
+        TenantedTaskSetResults results = TenantedTaskSetResults.newBuilder()
+            .setTenantId(TEST_TENANT_ID)
             .addResults(taskResult).build();
 
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(GrpcConstants.TENANT_ID_KEY, TEST_TENANT_ID.getBytes());
-
-        consumer.receiveMessage(results.toByteArray(), headers);
+        consumer.receiveMessage(results.toByteArray(), Collections.EMPTY_MAP);
 
         Mockito.verify(detectorService, times(1))
             .accept(TEST_TENANT_ID, TEST_LOCATION, response);

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/grpc/discovery/AzureActiveDiscoveryGrpcItTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/grpc/discovery/AzureActiveDiscoveryGrpcItTest.java
@@ -94,6 +94,7 @@ class AzureActiveDiscoveryGrpcItTest extends GrpcTestBase {
     private static final String TEST_DIRECTORY_ID = "directory-id";
     private static final String DEFAULT_LOCATION = "Default";
     private static final String TEST_TAG_NAME_1 = "tag-name-1";
+    private static final String TEST_TENANT_ID = "tenant-id";
 
     private AzureActiveDiscoveryServiceGrpc.AzureActiveDiscoveryServiceBlockingStub serviceStub;
 

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/src/main/java/org/opennms/horizon/inventory/testtool/miniongateway/wiremock/client/MinionGatewayWiremockTestSteps.java
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/src/main/java/org/opennms/horizon/inventory/testtool/miniongateway/wiremock/client/MinionGatewayWiremockTestSteps.java
@@ -142,7 +142,7 @@ public class MinionGatewayWiremockTestSteps {
     @Then("verify the task set update is published for icmp discovery within {int}ms")
     public void verifyTheTaskSetUpdateIsPublishedForIcmpDiscoveryWithinMs(int timeout) {
         String taskIdPattern = "discovery:\\d+/" + taskLocation;
-        commonVerifyTaskSetUpdate((record) -> isMatchingAddTask(record, taskLocation, taskIdPattern), timeout);
+        commonVerifyTaskSetUpdate((record) -> isMatchingAddTask(record, taskTenantId, taskLocation, taskIdPattern), timeout);
     }
 
 
@@ -156,7 +156,9 @@ public class MinionGatewayWiremockTestSteps {
                 for (var update : record.getUpdateList()) {
                     if (update.hasAddTask()) {
                         if (update.getAddTask().hasTaskDefinition()) {
-                            return update.getAddTask().getTaskDefinition().getId().matches(taskIdPattern);
+                            if (update.getAddTask().getTaskDefinition().getId().matches(taskIdPattern)) {
+                                return true;
+                            }
                         }
                     }
                 }

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/src/main/java/org/opennms/horizon/inventory/testtool/miniongateway/wiremock/client/MinionGatewayWiremockTestSteps.java
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/src/main/java/org/opennms/horizon/inventory/testtool/miniongateway/wiremock/client/MinionGatewayWiremockTestSteps.java
@@ -62,6 +62,9 @@ public class MinionGatewayWiremockTestSteps {
     private String taskIpAddress;
 
     @Setter
+    private String taskTenantId = "opennms-prime";
+
+    @Setter
     private String taskLocation = "Default";
 
     @Setter
@@ -115,7 +118,7 @@ public class MinionGatewayWiremockTestSteps {
     public void verifyTheTaskSetUpdateIsPublishedForDeviceWithNodeScanWithinMs(int timeout) {
         String taskIdPattern = "nodeScan=node_id/" + nodeId;
 
-        commonVerifyTaskSetUpdate((record) -> isMatchingAddTask(record, taskLocation, taskIdPattern), timeout);
+        commonVerifyTaskSetUpdate((record) -> isMatchingAddTask(record, taskTenantId, taskLocation, taskIdPattern), timeout);
     }
 
     @Then("verify the task set update is published with device monitor within {int}ms")
@@ -133,7 +136,7 @@ public class MinionGatewayWiremockTestSteps {
     @Then("verify the task set update is published with removal of task with suffix {string} within {int}ms")
     public void verifyTheTaskSetUpdateIsPublishedWithRemovalOfTaskWithSuffixWithinMs(String taskSuffix, int timeout) {
         String taskIdPattern = "nodeId:\\d+/ip=" + taskIpAddress + "/" + taskSuffix;
-        commonVerifyTaskSetUpdate((record) -> isMatchingRemoveTask(record, taskLocation, taskIdPattern), timeout);
+        commonVerifyTaskSetUpdate((record) -> isMatchingRemoveTask(record, taskTenantId, taskLocation, taskIdPattern), timeout);
     }
 
     @Then("verify the task set update is published for icmp discovery within {int}ms")
@@ -147,12 +150,14 @@ public class MinionGatewayWiremockTestSteps {
 // Internals
 //----------------------------------------
 
-    private boolean isMatchingAddTask(UpdateTasksRequest record, String location,  String taskIdPattern) {
-        if (Objects.equals(record.getLocation(), location)) {
-            for (var update : record.getUpdateList()) {
-                if (update.hasAddTask()) {
-                    if (update.getAddTask().hasTaskDefinition()) {
-                        return update.getAddTask().getTaskDefinition().getId().matches(taskIdPattern);
+    private boolean isMatchingAddTask(UpdateTasksRequest record, String tenantId, String location,  String taskIdPattern) {
+        if (Objects.equals(record.getTenantId(), tenantId)) {
+            if (Objects.equals(record.getLocation(), location)) {
+                for (var update : record.getUpdateList()) {
+                    if (update.hasAddTask()) {
+                        if (update.getAddTask().hasTaskDefinition()) {
+                            return update.getAddTask().getTaskDefinition().getId().matches(taskIdPattern);
+                        }
                     }
                 }
             }
@@ -161,12 +166,14 @@ public class MinionGatewayWiremockTestSteps {
         return false;
     }
 
-    private boolean isMatchingRemoveTask(UpdateTasksRequest record, String location, String taskIdPattern) {
-        if (Objects.equals(record.getLocation(), location)) {
-            for (var update : record.getUpdateList()) {
-                if (update.hasRemoveTask()) {
-                    if (update.getRemoveTask().getTaskId().matches(taskIdPattern)) {
-                        return true;
+    private boolean isMatchingRemoveTask(UpdateTasksRequest record, String tenantId, String location, String taskIdPattern) {
+        if (Objects.equals(record.getTenantId(), tenantId)) {
+            if (Objects.equals(record.getLocation(), location)) {
+                for (var update : record.getUpdateList()) {
+                    if (update.hasRemoveTask()) {
+                        if (update.getRemoveTask().getTaskId().matches(taskIdPattern)) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/metrics-processor/main/src/test/java/org/opennms/horizon/tsdata/TSDataProcessorTest.java
+++ b/metrics-processor/main/src/test/java/org/opennms/horizon/tsdata/TSDataProcessorTest.java
@@ -113,7 +113,7 @@ class TSDataProcessorTest {
             .build());
 
         TenantedTaskSetResults taskSetResults = TenantedTaskSetResults.newBuilder()
-            .setTenantId("opennms-prime")
+            .setTenantId(TENANT_ID)
             .addAllResults(taskResultList)
             .build();
 

--- a/minion-gateway/docker-it/src/test/java/org/opennms/horizon/stepdefs/MinionGatewayTestSteps.java
+++ b/minion-gateway/docker-it/src/test/java/org/opennms/horizon/stepdefs/MinionGatewayTestSteps.java
@@ -72,14 +72,11 @@ import org.opennms.taskset.service.contract.UpdateTasksResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -123,7 +120,7 @@ public class MinionGatewayTestSteps {
     private String mockLocation;
     private String mockSystemId;
     private String applicationBaseUrl;
-    private Map<String, String> grpcHeaders = new TreeMap<>();
+    private String mockTenantId;
 
 
     //
@@ -246,9 +243,9 @@ public class MinionGatewayTestSteps {
         this.mockLocation = mockLocation;
     }
 
-    @Given("GRPC header {string} = {string}")
-    public void grpcHeader(String headerName, String headerValue) {
-        grpcHeaders.put(headerName, headerValue);
+    @Given("mock tenant ID {string}")
+    public void tenantID(String tenantId) {
+        this.mockTenantId = tenantId;
     }
 
     @Then("create Cloud RPC connection")
@@ -597,17 +594,13 @@ public class MinionGatewayTestSteps {
 
             UpdateTasksRequest updateTasksRequest =
                 UpdateTasksRequest.newBuilder()
+                    .setTenantId(mockTenantId)
                     .addUpdate(updateSingleTaskOp)
                     .build();
 
             rpcException = null;
             try {
-                ListenableFuture<UpdateTasksResponse> future =
-                    taskSetServiceStub
-                        .withInterceptors(
-                            prepareGrpcHeaderInterceptor()
-                        )
-                    .updateTasks(updateTasksRequest)
+                ListenableFuture<UpdateTasksResponse> future = taskSetServiceStub.updateTasks(updateTasksRequest)
                 ;
 
                 updateTasksResponse = future.get(timeout, TimeUnit.MILLISECONDS);
@@ -757,7 +750,9 @@ public class MinionGatewayTestSteps {
     private Metadata prepareGrpcHeaders() {
         Metadata result = new Metadata();
 
-        grpcHeaders.forEach((key, value) -> result.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value));
+        if (mockTenantId != null) {
+            result.put(Metadata.Key.of("tenant-id", Metadata.ASCII_STRING_MARSHALLER), mockTenantId);
+        }
 
         return result;
     }

--- a/minion-gateway/docker-it/src/test/resources/org/opennms/horizon/minion-gateway.feature
+++ b/minion-gateway/docker-it/src/test/resources/org/opennms/horizon/minion-gateway.feature
@@ -6,7 +6,7 @@ Feature: Minion Gateway RPC Request Processing
     Given Kafka Bootstrap URL in system property "kafka.bootstrap-servers"
 
   Scenario: Send an RPC Request to a Minion that is not connected to the gateway
-    Given GRPC header "tenant-id" = "x-tenant-x"
+    Given mock tenant ID "x-tenant-x"
     Given Generated RPC Request ID
     Given RPC Request System ID "x-system-id-001-x"
     Given RPC Request Location "x-location-001-x"
@@ -17,12 +17,11 @@ Feature: Minion Gateway RPC Request Processing
     Then verify RPC exception states active connection could not be found
 
   Scenario: Send an RPC Request to a "Minion" that is connected to the gateway
-    Given GRPC header "tenant-id" = "x-tenant-x"
+    Given mock tenant ID "x-tenant-x"
     Given mock system id "x-system-id-001-x"
     Given mock location "x-location-001-x"
     Then create Cloud RPC connection
 
-    Given GRPC header "tenant-id" = "x-tenant-x"
     Given Generated RPC Request ID
     Given RPC Request System ID "x-system-id-001-x"
     Given RPC Request Location "x-location-001-x"
@@ -32,27 +31,25 @@ Feature: Minion Gateway RPC Request Processing
     Then verify RPC request was received by test rpc request server with timeout 3000ms
 
   Scenario: Send a Task Set to a "Minion" that is connected to the gateway
-    Given GRPC header "tenant-id" = "x-tenant-x"
+    Given mock tenant ID "x-tenant-x"
     Given mock system id "x-system-id-001-x"
     Given mock location "x-location-001-x"
     Then create Cloud RPC connection
     Then create Cloud-To-Minion Message connection
 
-    Given GRPC header "tenant-id" = "x-tenant-x"
     Then send task set to the Minion Gateway until successful with timeout 5000ms
     Then verify task set was received by cloud-to-minion message connection with timeout 3000ms
 
   Scenario: Send a Task Set Result to the Gateway and verify it is delivered to Kafka
-    Given GRPC header "tenant-id" = "x-tenant-x"
+    Given mock tenant ID "x-tenant-x"
     Then create Minion-to-Cloud Message connection
     Then send task set monitor result to the Minion Gateway until successful with timeout 5000ms
     Then verify task set result was published to Kafka with tenant id = "x-tenant-x" and timeout 3000ms
 
   Scenario: Register for Twin updates to the Gateway via the external GRPC API (MinionToCloudRPC)
-    Given GRPC header "tenant-id" = "x-tenant-x"
+    Given mock tenant ID "x-tenant-x"
     Then create Minion-to-Cloud RPC Request connection
 
-    Given GRPC header "tenant-id" = "x-tenant-x"
     Given Generated RPC Request ID
     Given RPC Request System ID "x-system-id-001-x"
     Given RPC Request Location "x-location-001-x"

--- a/minion-gateway/docker-it/src/test/resources/org/opennms/horizon/minion-gateway.feature
+++ b/minion-gateway/docker-it/src/test/resources/org/opennms/horizon/minion-gateway.feature
@@ -46,8 +46,7 @@ Feature: Minion Gateway RPC Request Processing
     Given GRPC header "tenant-id" = "x-tenant-x"
     Then create Minion-to-Cloud Message connection
     Then send task set monitor result to the Minion Gateway until successful with timeout 5000ms
-    Then verify task set result was published to Kafka with timeout 3000ms
-    Then verify the "tenant-id" header on Kafka = "x-tenant-x"
+    Then verify task set result was published to Kafka with tenant id = "x-tenant-x" and timeout 3000ms
 
   Scenario: Register for Twin updates to the Gateway via the external GRPC API (MinionToCloudRPC)
     Given GRPC header "tenant-id" = "x-tenant-x"

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/GrpcIpcServer.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/GrpcIpcServer.java
@@ -29,6 +29,8 @@
 package org.opennms.horizon.shared.grpc.common;
 
 import io.grpc.BindableService;
+import io.grpc.ServerInterceptor;
+
 import java.io.IOException;
 import java.util.Properties;
 
@@ -42,6 +44,12 @@ public interface GrpcIpcServer {
      *
      * @param bindableService The service that needs to be added */
     void startServer(BindableService bindableService) throws IOException;
+
+    /**
+     * Starts server, this will not immediately start server but schedules server start after certain delay.
+     *
+     * @param bindableService The service that needs to be added */
+    void startServerWithInterceptors(BindableService bindableService, ServerInterceptor... interceptors) throws IOException;
 
     /**
      * Stops the Server.

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/GrpcIpcServerBuilder.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/GrpcIpcServerBuilder.java
@@ -31,6 +31,8 @@ package org.opennms.horizon.shared.grpc.common;
 import io.grpc.BindableService;
 import io.grpc.Server;
 import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.ServerServiceDefinition;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import java.io.IOException;
@@ -88,6 +90,24 @@ public class GrpcIpcServerBuilder implements GrpcIpcServer {
             serverBuilder.addService(bindableService);
             services.add(bindableService);
         }
+        if (!serverStartScheduled) {
+            startServerWithDelay(delay.toMillis());
+            serverStartScheduled = true;
+        }
+    }
+
+    @Override
+    public void startServerWithInterceptors(BindableService bindableService, ServerInterceptor... interceptors) throws IOException {
+        initializeServerFromConfig();
+
+        if (!services.contains(bindableService)) {
+            serverBuilder.addService(bindableService);
+
+            ServerServiceDefinition serverServiceDefinition = ServerInterceptors.intercept(bindableService, interceptors);
+            serverBuilder.addService(serverServiceDefinition);
+            services.add(bindableService);
+        }
+
         if (!serverStartScheduled) {
             startServerWithDelay(delay.toMillis());
             serverStartScheduled = true;

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcIpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcIpcServerConfig.java
@@ -57,7 +57,7 @@ public class GrpcIpcServerConfig {
     }
 
     @Bean(name = "internalGrpcIpcServer", destroyMethod = "stopServer")
-    public GrpcIpcServer prepareInternalGrpcIpcServerTenantIdInterceptor(@Autowired TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor) {
+    public GrpcIpcServer prepareInternalGrpcIpcServerTenantIdInterceptor() {
         Properties properties = new Properties();
         properties.setProperty(GrpcIpcUtils.GRPC_MAX_INBOUND_SIZE, Long.toString(maxMessageSize));
 

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcIpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcIpcServerConfig.java
@@ -57,13 +57,12 @@ public class GrpcIpcServerConfig {
     }
 
     @Bean(name = "internalGrpcIpcServer", destroyMethod = "stopServer")
-    public GrpcIpcServer prepareInternalGrpcIpcServer(@Autowired TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor) {
+    public GrpcIpcServer prepareInternalGrpcIpcServerTenantIdInterceptor(@Autowired TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor) {
         Properties properties = new Properties();
         properties.setProperty(GrpcIpcUtils.GRPC_MAX_INBOUND_SIZE, Long.toString(maxMessageSize));
 
         return new GrpcIpcServerBuilder(properties, internalGrpcPort, "PT10S", Arrays.asList(
-            new LoggingInterceptor(),
-            tenantIDGrpcServerInterceptor
+            new LoggingInterceptor()
         ));
     }
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
@@ -19,6 +19,8 @@ import org.opennms.horizon.shared.ipc.grpc.server.manager.impl.RpcRequestTracker
 import org.opennms.horizon.shared.ipc.grpc.server.manager.rpc.LocationIndependentRpcClientFactoryImpl;
 import org.opennms.horizon.shared.ipc.grpc.server.manager.rpcstreaming.MinionRpcStreamConnectionManager;
 import org.opennms.horizon.shared.ipc.grpc.server.manager.rpcstreaming.impl.MinionRpcStreamConnectionManagerImpl;
+import org.opennms.horizon.shared.protobuf.mapper.TenantedTaskSetResultsMapper;
+import org.opennms.horizon.shared.protobuf.mapper.impl.TenantedTaskSetResultsMapperImpl;
 import org.opennms.miniongateway.grpc.server.heartbeat.HeartbeatKafkaForwarder;
 import org.opennms.miniongateway.grpc.server.flows.FlowKafkaForwarder;
 import org.opennms.miniongateway.grpc.server.tasktresults.TaskResultsKafkaForwarder;
@@ -43,6 +45,11 @@ public class GrpcServerConfig {
 
     @Autowired
     private MetricRegistry metricRegistry;
+
+    @Bean
+    public TenantedTaskSetResultsMapper tenantedTaskSetResultsMapper() {
+        return new TenantedTaskSetResultsMapperImpl();
+    }
 
     @Bean
     public RpcConnectionTracker rpcConnectionTracker() {

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsKafkaForwarder.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsKafkaForwarder.java
@@ -28,69 +28,69 @@
 
 package org.opennms.miniongateway.grpc.server.tasktresults;
 
-import com.google.protobuf.Message;
-import com.swrve.ratelimitedlogger.RateLimitedLog;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.internals.RecordHeader;
-import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.grpc.common.TenantIDGrpcServerInterceptor;
 import org.opennms.horizon.shared.ipc.sink.api.MessageConsumer;
 import org.opennms.horizon.shared.ipc.sink.api.SinkModule;
+import org.opennms.horizon.shared.protobuf.mapper.TenantedTaskSetResultsMapper;
+import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-
 /**
  * Forwarder of TaskResults - received via GRPC and forwarded to Kafka.
  */
 @Component
-public class TaskResultsKafkaForwarder implements MessageConsumer<Message, Message> {
+public class TaskResultsKafkaForwarder implements MessageConsumer<TaskSetResults, TaskSetResults> {
 
     public static final String DEFAULT_TASK_RESULTS_TOPIC = "task-set.results";
 
     private final Logger logger = LoggerFactory.getLogger(TaskResultsKafkaForwarder.class);
 
-    private final RateLimitedLog usingDefaultTenantIdLog =
-        RateLimitedLog
-            .withRateLimit(logger)
-            .maxRate(1)
-            .every(Duration.ofMinutes(1))
-            .build();
-
-    @Autowired
     @Qualifier("kafkaByteArrayProducerTemplate")
-    private KafkaTemplate<String, byte[]> kafkaTemplate;
+    private final KafkaTemplate<String, byte[]> kafkaTemplate;
+    private final TenantIDGrpcServerInterceptor tenantIDGrpcInterceptor;
+    private final TenantedTaskSetResultsMapper tenantedTaskSetResultsMapper;
 
-    @Autowired
-    private TenantIDGrpcServerInterceptor tenantIDGrpcInterceptor;
+    private final String kafkaTopic;
 
-    @Value("${task.results.kafka-topic:" + DEFAULT_TASK_RESULTS_TOPIC + "}")
-    private String kafkaTopic;
+    public TaskResultsKafkaForwarder(
+        KafkaTemplate<String, byte[]> kafkaTemplate,
+        TenantIDGrpcServerInterceptor tenantIDGrpcInterceptor,
+        TenantedTaskSetResultsMapper tenantedTaskSetResultsMapper,
+        @Value("${task.results.kafka-topic:" + DEFAULT_TASK_RESULTS_TOPIC + "}")
+        String kafkaTopic) {
+
+        this.kafkaTemplate = kafkaTemplate;
+        this.tenantIDGrpcInterceptor = tenantIDGrpcInterceptor;
+        this.tenantedTaskSetResultsMapper = tenantedTaskSetResultsMapper;
+        this.kafkaTopic = kafkaTopic;
+    }
 
     @Override
-    public SinkModule<Message, Message> getModule() {
+    public SinkModule<TaskSetResults, TaskSetResults> getModule() {
         return new TaskResultsModule();
     }
 
     @Override
-    public void handleMessage(Message messageLog) {
+    public void handleMessage(TaskSetResults messageLog) {
         // Retrieve the Tenant ID from the TenantID GRPC Interceptor
         String tenantId = tenantIDGrpcInterceptor.readCurrentContextTenantId();
         logger.debug("Received results; sending to Kafka: tenant-id: {}; kafka-topic={}; message={}", tenantId, kafkaTopic, messageLog);
-        byte[] rawContent = messageLog.toByteArray();
-        var producerRecord = new ProducerRecord<String, byte[]>(kafkaTopic, rawContent);
-        // add tenant id to kafka header
-        producerRecord.headers().add(new RecordHeader(GrpcConstants.TENANT_ID_KEY,
-            tenantId.getBytes(StandardCharsets.UTF_8)));
 
+        // Map to tenanted
+        TenantedTaskSetResults tenantedTaskSetResults = tenantedTaskSetResultsMapper.mapBareToTenanted(tenantId, messageLog);
+
+        // Convert to bytes
+        byte[] rawContent = tenantedTaskSetResults.toByteArray();
+        var producerRecord = new ProducerRecord<String, byte[]>(kafkaTopic, rawContent);
+
+        // Send to Kafka
         this.kafkaTemplate.send(producerRecord);
     }
-
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsModule.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsModule.java
@@ -7,6 +7,10 @@ import org.opennms.horizon.shared.ipc.sink.api.AsyncPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.SinkModule;
 import org.opennms.taskset.contract.TaskSetResults;
 
+/**
+ * Sink Module for TaskSetResults that is used for handling results sent by Minions.  Since the results are received
+ * from Minions, there is no explicit Tenant ID in the structures.
+ */
 public class TaskResultsModule implements SinkModule<TaskSetResults, TaskSetResults> {
 
     public static final String MODULE_ID = "task-set-result";

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsModule.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsModule.java
@@ -1,14 +1,13 @@
 package org.opennms.miniongateway.grpc.server.tasktresults;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.google.protobuf.Message;
 import org.opennms.horizon.shared.ipc.sink.aggregation.IdentityAggregationPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.AggregationPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.AsyncPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.SinkModule;
 import org.opennms.taskset.contract.TaskSetResults;
 
-public class TaskResultsModule implements SinkModule<Message, Message> {
+public class TaskResultsModule implements SinkModule<TaskSetResults, TaskSetResults> {
 
     public static final String MODULE_ID = "task-set-result";
 
@@ -23,12 +22,12 @@ public class TaskResultsModule implements SinkModule<Message, Message> {
     }
 
     @Override
-    public byte[] marshal(Message message) {
+    public byte[] marshal(TaskSetResults message) {
         return message.toByteArray();
     }
 
     @Override
-    public Message unmarshal(byte[] content) {
+    public TaskSetResults unmarshal(byte[] content) {
         try {
             return TaskSetResults.parseFrom(content);
         } catch (InvalidProtocolBufferException e) {
@@ -37,17 +36,17 @@ public class TaskResultsModule implements SinkModule<Message, Message> {
     }
 
     @Override
-    public byte[] marshalSingleMessage(Message message) {
-        return marshal(message);
+    public byte[] marshalSingleMessage(TaskSetResults message) {
+        return marshal((TaskSetResults) message);
     }
 
     @Override
-    public Message unmarshalSingleMessage(byte[] message) {
+    public TaskSetResults unmarshalSingleMessage(byte[] message) {
         return unmarshal(message);
     }
 
     @Override
-    public AggregationPolicy<Message, Message, ?> getAggregationPolicy() {
+    public AggregationPolicy<TaskSetResults, TaskSetResults, ?> getAggregationPolicy() {
         return new IdentityAggregationPolicy<>();
     }
 

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/taskset/internal/TaskSetIgniteStorageImpl.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/taskset/internal/TaskSetIgniteStorageImpl.java
@@ -3,7 +3,6 @@ package org.opennms.miniongateway.taskset.internal;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.opennms.miniongateway.grpc.server.model.TenantKey;
-import org.opennms.miniongateway.taskset.service.TaskSetGrpcServiceUpdateProcessor;
 import org.opennms.miniongateway.taskset.service.TaskSetStorage;
 import org.opennms.miniongateway.taskset.service.TaskSetStorageListener;
 import org.opennms.miniongateway.taskset.service.TaskSetStorageUpdateFunction;

--- a/minion-gateway/main/src/test/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsKafkaForwarderTest.java
+++ b/minion-gateway/main/src/test/java/org/opennms/miniongateway/grpc/server/tasktresults/TaskResultsKafkaForwarderTest.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *
+ */
+
+package org.opennms.miniongateway.grpc.server.tasktresults;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.opennms.horizon.shared.grpc.common.TenantIDGrpcServerInterceptor;
+import org.opennms.horizon.shared.protobuf.mapper.TenantedTaskSetResultsMapper;
+import org.opennms.taskset.contract.TaskResult;
+import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.junit.Assert.*;
+
+public class TaskResultsKafkaForwarderTest {
+
+    public static final String TEST_AFTER_COPY_TENANT_ID = "x-tenant-after-copy-x";
+
+    private TaskResultsKafkaForwarder taskResultsKafkaForwarder;
+
+    private KafkaTemplate<String, byte[]> mockKafkaTemplate;
+    private TenantIDGrpcServerInterceptor mockTenantIDGrpcInterceptor;
+    private TenantedTaskSetResultsMapper mockTenantedTaskSetResultsMapper;
+
+    private TaskSetResults testTaskSetResults;
+    private TaskResult testTaskResult;
+    private TenantedTaskSetResults testTenantedTaskSetResults;
+
+    @Before
+    public void setUp() throws Exception {
+       /*
+        KafkaTemplate<String, byte[]> kafkaTemplate,
+        TenantIDGrpcServerInterceptor tenantIDGrpcInterceptor,
+        TenantedTaskSetResultsMapper tenantedTaskSetResultsMapper) {
+        */
+
+        mockKafkaTemplate = Mockito.mock(KafkaTemplate.class);
+        mockTenantIDGrpcInterceptor = Mockito.mock(TenantIDGrpcServerInterceptor.class);
+        mockTenantedTaskSetResultsMapper = Mockito.mock(TenantedTaskSetResultsMapper.class);
+
+        testTaskResult =
+            TaskResult.newBuilder()
+                .build();
+
+        testTaskSetResults =
+            TaskSetResults.newBuilder()
+                .addResults(testTaskResult)
+                .build();
+
+        testTenantedTaskSetResults =
+            TenantedTaskSetResults.newBuilder()
+                .setTenantId(TEST_AFTER_COPY_TENANT_ID)   // Use a distinct tenant id, even though it is unrealistic, for test verification purposes
+                .build();
+
+        taskResultsKafkaForwarder = new TaskResultsKafkaForwarder(mockKafkaTemplate, mockTenantIDGrpcInterceptor, mockTenantedTaskSetResultsMapper, "x-kafka-topic-x");
+
+        Mockito.when(mockTenantIDGrpcInterceptor.readCurrentContextTenantId()).thenReturn("x-tenant-x");
+        Mockito.when(mockTenantedTaskSetResultsMapper.mapBareToTenanted("x-tenant-x", testTaskSetResults)).thenReturn(testTenantedTaskSetResults);
+    }
+
+    @Test
+    public void testHandleMessage() throws InvalidProtocolBufferException {
+        //
+        // Setup Test Data and Interactions
+        //
+
+        //
+        // Execute
+        //
+        taskResultsKafkaForwarder.handleMessage(testTaskSetResults);
+
+        //
+        // Verify the Results
+        //
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ProducerRecord<String, byte[]>> producerRecordCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
+
+        Mockito.verify(mockKafkaTemplate).send(producerRecordCaptor.capture());
+        ProducerRecord<String, byte[]> producerRecord = producerRecordCaptor.getValue();
+
+        assertNotNull(producerRecord);
+        assertEquals("x-kafka-topic-x", producerRecord.topic());
+
+        byte[] raw = producerRecord.value();
+        var tenantedTaskSetResults = TenantedTaskSetResults.parseFrom(raw);
+
+        assertEquals(TEST_AFTER_COPY_TENANT_ID, tenantedTaskSetResults.getTenantId());
+    }
+}

--- a/minion-gateway/rpc-request-server/src/main/java/org/opennms/miniongateway/rpcrequest/service/RpcRequestGrpcService.java
+++ b/minion-gateway/rpc-request-server/src/main/java/org/opennms/miniongateway/rpcrequest/service/RpcRequestGrpcService.java
@@ -7,6 +7,7 @@ import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcRequestServiceGrpc;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
 import org.opennms.horizon.shared.grpc.common.GrpcIpcServer;
+import org.opennms.horizon.shared.grpc.common.TenantIDGrpcServerInterceptor;
 import org.opennms.miniongateway.rpcrequest.RpcRequestRouter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,13 +35,17 @@ public class RpcRequestGrpcService extends RpcRequestServiceGrpc.RpcRequestServi
     @Setter
     private GrpcIpcServer grpcIpcServer;
 
+    @Autowired
+    private TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor;
+
 //========================================
 // Lifecycle
 //----------------------------------------
 
     @PostConstruct
     public void start() throws IOException {
-        grpcIpcServer.startServer(this);
+        // TODO: use explicit tenant-id handling
+        grpcIpcServer.startServerWithInterceptors(this, tenantIDGrpcServerInterceptor);
         log.info("Initiated RPC-Request GRPC Service");
     }
 

--- a/minion-gateway/task-set-service/src/main/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceUpdateProcessor.java
+++ b/minion-gateway/task-set-service/src/main/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceUpdateProcessor.java
@@ -18,11 +18,6 @@ public class TaskSetGrpcServiceUpdateProcessor implements TaskSetStorageUpdateFu
     private static final Logger LOG = LoggerFactory.getLogger(TaskSetGrpcServiceUpdateProcessor.class);
 
     /**
-     * ID of the tenant to which the task set belongs.
-     */
-    private final String tenantId;
-
-    /**
      * The request with updates to apply to the task set.
      */
     private final UpdateTasksRequest updateTasksRequest;
@@ -55,8 +50,7 @@ public class TaskSetGrpcServiceUpdateProcessor implements TaskSetStorageUpdateFu
 // Constructor
 //----------------------------------------
 
-    public TaskSetGrpcServiceUpdateProcessor(String tenantId, UpdateTasksRequest updateTasksRequest) {
-        this.tenantId = tenantId;
+    public TaskSetGrpcServiceUpdateProcessor(UpdateTasksRequest updateTasksRequest) {
         this.updateTasksRequest = updateTasksRequest;
     }
 
@@ -94,7 +88,7 @@ public class TaskSetGrpcServiceUpdateProcessor implements TaskSetStorageUpdateFu
         addNewTasks(updateTasksRequest, updatedTaskSetBuilder);
 
         LOG.debug("Remove tasks: tenant={}; location={}; added-count={}; replaced-count={}; removed-count={}",
-            tenantId, updateTasksRequest.getLocation(), numNew, numReplaced, numRemoved);
+            updateTasksRequest.getTenantId(), updateTasksRequest.getLocation(), numNew, numReplaced, numRemoved);
 
         // Determine the return value based on whether there was an actual change
         TaskSet result;
@@ -123,7 +117,7 @@ public class TaskSetGrpcServiceUpdateProcessor implements TaskSetStorageUpdateFu
                     requestedRemovalIds.add(update.getRemoveTask().getTaskId());
                 } else {
                     LOG.error("Ignoring unrecognized update request with no add-task and no remove-task: tenant-id={}; location={}",
-                        tenantId, request.getLocation());
+                        request.getTenantId(), request.getLocation());
                 }
             }
         );

--- a/minion-gateway/task-set-service/src/main/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceUpdateProcessorFactory.java
+++ b/minion-gateway/task-set-service/src/main/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceUpdateProcessorFactory.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TaskSetGrpcServiceUpdateProcessorFactory  {
 
-    public TaskSetGrpcServiceUpdateProcessor create(String tenantId, UpdateTasksRequest updateTasksRequest) {
-        return new TaskSetGrpcServiceUpdateProcessor(tenantId, updateTasksRequest);
+    public TaskSetGrpcServiceUpdateProcessor create(UpdateTasksRequest updateTasksRequest) {
+        return new TaskSetGrpcServiceUpdateProcessor(updateTasksRequest);
     }
 }

--- a/minion-gateway/task-set-service/src/test/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceTest.java
+++ b/minion-gateway/task-set-service/src/test/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceTest.java
@@ -23,7 +23,6 @@ class TaskSetGrpcServiceTest {
     private TaskSetGrpcService target;
 
     private GrpcIpcServer mockGrpcIpcServer;
-    private TenantIDGrpcServerInterceptor mockTenantIDGrpcServerInterceptor;
     private TaskSetStorage mockTaskSetStorage;
     private StreamObserver<UpdateTasksResponse> mockUpdateTasksRepsonseStreamObserver;
     private TaskSetGrpcServiceUpdateProcessor mockTaskSetGrpcServiceUpdateProcessor;
@@ -55,13 +54,13 @@ class TaskSetGrpcServiceTest {
 
         testRequest =
             UpdateTasksRequest.newBuilder()
+                .setTenantId("x-tenant-id-x")
                 .setLocation("x-location-x")
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setAddTask(testAddSingleTaskOp).build())
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setRemoveTask(testRemoveSingleTaskOp).build())
                 .build();
 
         mockGrpcIpcServer = Mockito.mock(GrpcIpcServer.class);
-        mockTenantIDGrpcServerInterceptor = Mockito.mock(TenantIDGrpcServerInterceptor.class);
         mockTaskSetStorage = Mockito.mock(TaskSetStorage.class);
         mockUpdateTasksRepsonseStreamObserver = Mockito.mock(StreamObserver.class);
         mockTaskSetGrpcServiceUpdateProcessor = Mockito.mock(TaskSetGrpcServiceUpdateProcessor.class);
@@ -69,8 +68,7 @@ class TaskSetGrpcServiceTest {
 
         target = new TaskSetGrpcService();
 
-        Mockito.when(mockTenantIDGrpcServerInterceptor.readCurrentContextTenantId()).thenReturn("x-tenant-id-x");
-        Mockito.when(mockTaskSetGrpcServiceUpdateProcessorFactory.create("x-tenant-id-x", testRequest)).thenReturn(mockTaskSetGrpcServiceUpdateProcessor);
+        Mockito.when(mockTaskSetGrpcServiceUpdateProcessorFactory.create(testRequest)).thenReturn(mockTaskSetGrpcServiceUpdateProcessor);
     }
 
     @Test
@@ -101,7 +99,6 @@ class TaskSetGrpcServiceTest {
         //
         target.setGrpcIpcServer(mockGrpcIpcServer);
         target.setTaskSetStorage(mockTaskSetStorage);
-        target.setTenantIDGrpcServerInterceptor(mockTenantIDGrpcServerInterceptor);
         target.setTaskSetGrpcServiceUpdateProcessorFactory(mockTaskSetGrpcServiceUpdateProcessorFactory);
         target.updateTasks(testRequest, mockUpdateTasksRepsonseStreamObserver);
 
@@ -129,7 +126,6 @@ class TaskSetGrpcServiceTest {
         //
         target.setGrpcIpcServer(mockGrpcIpcServer);
         target.setTaskSetStorage(mockTaskSetStorage);
-        target.setTenantIDGrpcServerInterceptor(mockTenantIDGrpcServerInterceptor);
         target.setTaskSetGrpcServiceUpdateProcessorFactory(mockTaskSetGrpcServiceUpdateProcessorFactory);
 
         RuntimeException actualException = null;

--- a/minion-gateway/task-set-service/src/test/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceUpdateProcessorTest.java
+++ b/minion-gateway/task-set-service/src/test/java/org/opennms/miniongateway/taskset/service/TaskSetGrpcServiceUpdateProcessorTest.java
@@ -60,6 +60,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
 
         testRequestAdd1Remove1 =
             UpdateTasksRequest.newBuilder()
+                .setTenantId("x-tenant-id-x")
                 .setLocation("x-location-x")
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setAddTask(testAddSingleTaskOp1).build())
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setRemoveTask(testRemoveSingleTaskOp).build())
@@ -67,24 +68,28 @@ class TaskSetGrpcServiceUpdateProcessorTest {
 
         testRequestRemove1 =
             UpdateTasksRequest.newBuilder()
+                .setTenantId("x-tenant-id-x")
                 .setLocation("x-location-x")
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setRemoveTask(testRemoveSingleTaskOp).build())
                 .build();
 
         testRequestAdd1 =
             UpdateTasksRequest.newBuilder()
+                .setTenantId("x-tenant-id-x")
                 .setLocation("x-location-x")
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setAddTask(testAddSingleTaskOp1).build())
                 .build();
         
         testRequestNeitherAddNorRemove =
             UpdateTasksRequest.newBuilder()
+                .setTenantId("x-tenant-id-x")
                 .setLocation("x-location-x")
                 .addUpdate(UpdateSingleTaskOp.newBuilder().build())
                 .build();
 
         testRequestAddAnother1 =
             UpdateTasksRequest.newBuilder()
+                .setTenantId("x-tenant-id-x")
                 .setLocation("x-location-x")
                 .addUpdate(UpdateSingleTaskOp.newBuilder().setAddTask(testAddSingleTaskOp2).build())
                 .build();
@@ -96,7 +101,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
         // Setup Test Data and Interactions
         //
         TaskSet testEmptyOriginal = TaskSet.newBuilder().build();
-        var target = new TaskSetGrpcServiceUpdateProcessor("x-tenant-id-x", testRequestAdd1Remove1);
+        var target = new TaskSetGrpcServiceUpdateProcessor(testRequestAdd1Remove1);
 
         //
         // Execute
@@ -123,7 +128,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
                 .addTaskDefinition(testTaskDefinition1)
                 .addTaskDefinition(testRemovalTaskDefinition)
                 .build();
-        var target = new TaskSetGrpcServiceUpdateProcessor("x-tenant-id-x", testRequestAdd1Remove1);
+        var target = new TaskSetGrpcServiceUpdateProcessor(testRequestAdd1Remove1);
 
         //
         // Execute
@@ -146,7 +151,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
         // Setup Test Data and Interactions
         //
         TaskSet testEmptyOriginal = TaskSet.newBuilder().build();
-        var target = new TaskSetGrpcServiceUpdateProcessor("x-tenant-id-x", testRequestRemove1);
+        var target = new TaskSetGrpcServiceUpdateProcessor(testRequestRemove1);
 
         //
         // Execute
@@ -171,7 +176,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
             TaskSet.newBuilder()
                 .addTaskDefinition(testTaskDefinition1)
                 .build();
-        var target = new TaskSetGrpcServiceUpdateProcessor("x-tenant-id-x", testRequestAdd1);
+        var target = new TaskSetGrpcServiceUpdateProcessor(testRequestAdd1);
 
         //
         // Execute
@@ -193,7 +198,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
         // Setup Test Data and Interactions
         //
         TaskSet testEmptyOriginal = TaskSet.newBuilder().build();
-        var target = new TaskSetGrpcServiceUpdateProcessor("x-tenant-id-x", testRequestNeitherAddNorRemove);
+        var target = new TaskSetGrpcServiceUpdateProcessor(testRequestNeitherAddNorRemove);
 
 
         try (LogCaptor logCaptor = LogCaptor.forClass(TaskSetGrpcServiceUpdateProcessor.class)) {
@@ -232,7 +237,7 @@ class TaskSetGrpcServiceUpdateProcessorTest {
             TaskSet.newBuilder()
                 .addTaskDefinition(testTaskDefinition1)
                 .build();
-        var target = new TaskSetGrpcServiceUpdateProcessor("x-tenant-id-x", testRequestAddAnother1);
+        var target = new TaskSetGrpcServiceUpdateProcessor(testRequestAddAnother1);
 
         //
         // Execute

--- a/minion/minion-taskset/taskset-ipc/src/main/java/org/opennms/horizon/minion/taskset/ipc/internal/TaskSetResultsSinkModule.java
+++ b/minion/minion-taskset/taskset-ipc/src/main/java/org/opennms/horizon/minion/taskset/ipc/internal/TaskSetResultsSinkModule.java
@@ -8,6 +8,10 @@ import org.opennms.taskset.contract.TaskSetResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Sink Module for processing TaskSetResults.  Note this is used in the communication between the Minion and
+ * Minion Gateway, so Tenant IDs are not explicitly handled here.
+ */
 public class TaskSetResultsSinkModule implements SinkModule<TaskSetResults, TaskSetResults> {
 
   public static final String MODULE_ID = "task-set-result";

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
@@ -1,7 +1,6 @@
 package org.opennms.horizon.minion.taskset.worker.impl;
 
 import com.google.protobuf.Any;
-import com.google.protobuf.Message;
 import org.opennms.horizon.minion.plugin.api.CollectionSet;
 import org.opennms.horizon.minion.plugin.api.ScanResultsResponse;
 import org.opennms.horizon.minion.plugin.api.ServiceDetectorResponse;

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -536,6 +536,18 @@
                 <version>${junit.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
                 <version>${jna.version}</version>
@@ -941,6 +953,11 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>

--- a/shared-lib/inventory/pom.xml
+++ b/shared-lib/inventory/pom.xml
@@ -52,6 +52,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/shared-lib/protobuf/src/main/java/org/opennms/horizon/shared/protobuf/mapper/TenantedTaskSetResultsMapper.java
+++ b/shared-lib/protobuf/src/main/java/org/opennms/horizon/shared/protobuf/mapper/TenantedTaskSetResultsMapper.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *
+ */
+
+package org.opennms.horizon.shared.protobuf.mapper;
+
+import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
+
+public interface TenantedTaskSetResultsMapper {
+    TenantedTaskSetResults mapBareToTenanted(String tenantId, TaskSetResults bare);
+    TaskSetResults mapTenantedToBare(TenantedTaskSetResults tenanted);
+}

--- a/shared-lib/protobuf/src/main/java/org/opennms/horizon/shared/protobuf/mapper/impl/TenantedTaskSetResultsMapperImpl.java
+++ b/shared-lib/protobuf/src/main/java/org/opennms/horizon/shared/protobuf/mapper/impl/TenantedTaskSetResultsMapperImpl.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *
+ */
+
+package org.opennms.horizon.shared.protobuf.mapper.impl;
+
+import org.opennms.horizon.shared.protobuf.mapper.TenantedTaskSetResultsMapper;
+import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
+
+public class TenantedTaskSetResultsMapperImpl implements TenantedTaskSetResultsMapper {
+    @Override
+    public TenantedTaskSetResults mapBareToTenanted(String tenantId, TaskSetResults bare) {
+        TenantedTaskSetResults result =
+            TenantedTaskSetResults.newBuilder()
+                .setTenantId(tenantId)
+                .addAllResults(bare.getResultsList())
+                .build();
+
+        return result;
+    }
+
+    @Override
+    public TaskSetResults mapTenantedToBare(TenantedTaskSetResults tenanted) {
+        TaskSetResults result =
+            TaskSetResults.newBuilder()
+                .addAllResults(tenanted.getResultsList())
+                .build();
+
+        return result;
+    }
+}

--- a/shared-lib/protobuf/src/main/proto/tenatedTaskSet.proto
+++ b/shared-lib/protobuf/src/main/proto/tenatedTaskSet.proto
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+//
+// MAINTAINER WARNING: make sure to keep the structures in this file aligned with the ones in taskSet.proto!
+//
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+import "taskSet.proto";
+
+package opennms.taskset;
+option java_multiple_files = true;
+option java_package = "org.opennms.taskset.contract";
+
+message TenantedTaskSetResults {
+  string tenantId = 100;
+
+  repeated TaskResult results = 1;
+}

--- a/shared-lib/protobuf/src/test/java/org/opennms/horizon/shared/protobuf/mapper/impl/TenantedTaskSetResultsMapperImplTest.java
+++ b/shared-lib/protobuf/src/test/java/org/opennms/horizon/shared/protobuf/mapper/impl/TenantedTaskSetResultsMapperImplTest.java
@@ -1,0 +1,182 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *
+ */
+
+package org.opennms.horizon.shared.protobuf.mapper.impl;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennms.taskset.contract.TaskResult;
+import org.opennms.taskset.contract.TaskSetResults;
+import org.opennms.taskset.contract.TenantedTaskSetResults;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Verify the mapper for TaskSetResults <===> TenantedTaskSetResults
+ */
+public class TenantedTaskSetResultsMapperImplTest {
+
+    private TenantedTaskSetResultsMapperImpl target;
+
+    private TaskResult testTaskResult;
+
+    @Before
+    public void setUp() throws Exception {
+        target = new TenantedTaskSetResultsMapperImpl();
+
+        // Don't need to fully hydrate this one, it does not get mapped
+        testTaskResult =
+            TaskResult.newBuilder()
+                .setId("x-task-id-x")
+                .build();
+    }
+
+    @Test
+    public void testMapBareToTenanted() {
+        //
+        // Setup Test Data and Interactions
+        //
+        TaskSetResults taskSetResults =
+            TaskSetResults.newBuilder()
+                .addResults(testTaskResult)
+                .build();
+
+        //
+        // Execute
+        //
+        TenantedTaskSetResults tenantedTaskSetResults =
+            target.mapBareToTenanted("x-tenant-id-x", taskSetResults);
+
+        //
+        // Verify the Results
+        //
+        verifyAllFieldsSet(taskSetResults, true);
+        verifyAllFieldsSet(tenantedTaskSetResults, true);
+
+        assertEquals(1, tenantedTaskSetResults.getResultsCount());
+        assertSame(testTaskResult, tenantedTaskSetResults.getResults(0));
+    }
+
+    @Test
+    public void testMapTenantedToBare() {
+        //
+        // Setup Test Data and Interactions
+        //
+        TenantedTaskSetResults tenantedTaskSetResults =
+            TenantedTaskSetResults.newBuilder()
+                .setTenantId("x-tenant-id-x")
+                .addResults(testTaskResult)
+                .build();
+
+        //
+        // Execute
+        //
+        TaskSetResults taskSetResults =
+            target.mapTenantedToBare(tenantedTaskSetResults);
+
+        //
+        // Verify the Results
+        //
+        verifyAllFieldsSet(taskSetResults, true);
+        verifyAllFieldsSet(tenantedTaskSetResults, true);
+
+        assertEquals(1, tenantedTaskSetResults.getResultsCount());
+        assertSame(testTaskResult, tenantedTaskSetResults.getResults(0));
+    }
+
+    /**
+     * Check for difference in the named fields between the types.
+     */
+    @Test
+    public void testDefinitionsMatch() {
+        verifyAllFieldsExceptTenantIdMatch(
+            TaskSetResults.getDefaultInstance(), TenantedTaskSetResults.getDefaultInstance());
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    /**
+     * Verify all of the fields in the given message have been set to help ensure completeness of the test.
+     *
+     * @param message the message for which fields will be verified.
+     * @param repeatedMustNotBeEmpty true => verify repeated fields have at least one element; false => ignore repeated
+     *                               fields.  Unfortunately there is no concept of "not set" for repeated fields - they
+     *                               are always "non-null".
+     */
+    private void verifyAllFieldsSet(Message message, boolean repeatedMustNotBeEmpty) {
+        Descriptors.Descriptor typeDescriptor = message.getDescriptorForType();
+
+        List<Descriptors.FieldDescriptor> fieldDescriptorList = typeDescriptor.getFields();
+
+        //
+        // IF YOU SEE FAILURE HERE, MAKE SURE BOTH THE TEST AND THE MAPPER ARE INCLUDING ALL FIELDS
+        //
+        for (var fieldDescriptor : fieldDescriptorList) {
+            if (fieldDescriptor.isRepeated()) {
+                if (repeatedMustNotBeEmpty) {
+                    assertTrue(
+                        "message " + typeDescriptor.getFullName() + " has 0 repeated field values for field " + fieldDescriptor.getName() + " (" + fieldDescriptor.getNumber() + ")",
+                        message.getRepeatedFieldCount(fieldDescriptor) > 0);
+                }
+            } else {
+                if (!message.hasField(fieldDescriptor)) {
+                    fail("message " + typeDescriptor.getFullName() + " is missing field " + fieldDescriptor.getName() + " (" + fieldDescriptor.getNumber() + ")");
+                }
+            }
+        }
+    }
+
+    /**
+     * Verify both message types have the same fields except for tenant id.
+     *
+     * @param messageWithoutTenant
+     * @param messageWithTenant
+     */
+    private void verifyAllFieldsExceptTenantIdMatch(Message messageWithoutTenant, Message messageWithTenant) {
+        Descriptors.Descriptor withoutTenantTypeDescriptor = messageWithoutTenant.getDescriptorForType();
+        Descriptors.Descriptor withTenantTypeDescriptor = messageWithTenant.getDescriptorForType();
+
+        Set<String> withoutTenantTypeFields =
+            withoutTenantTypeDescriptor.getFields().stream().map(Descriptors.FieldDescriptor::getName).collect(Collectors.toSet());
+        Set<String> withTenantTypeFields =
+            withTenantTypeDescriptor.getFields().stream().map(Descriptors.FieldDescriptor::getName).collect(Collectors.toSet());
+
+        withTenantTypeFields.remove("tenantId");
+
+        assertEquals(withTenantTypeFields, withoutTenantTypeFields);
+    }
+}

--- a/shared-lib/task-set-service/api/src/main/proto/taskset-service.proto
+++ b/shared-lib/task-set-service/api/src/main/proto/taskset-service.proto
@@ -30,8 +30,9 @@ message UpdateTasksRequestList {
 // UPDATE TASKS
 //
 message UpdateTasksRequest {
-  string location = 1;
-  repeated UpdateSingleTaskOp update = 2;
+  string tenantId = 1;
+  string location = 2;
+  repeated UpdateSingleTaskOp update = 3;
 }
 
 message UpdateTasksResponse {


### PR DESCRIPTION
Mapper between tenanted and bare added with test ensuring the two structure are in-sync.

## Description
WORK IN PROGRESS.  Posting the PR early to share the incoming pattern.
NOTE the first iteration adds TenantedTaskSetResults and a mapper, and changes the Minion Gateway to push it onto the Kafka topic consumed by Metrics Processor.  Metrics Processor will BREAK with the current state of the code because Tenant ID is no longer set on the Kafka header, and it has not YET been updated to use TenantedTaskSetResults.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1258

## Flagged for review
- tenantedTaskSetProto in shared-lib/protobuf/src/main/proto
- TenantedTaskSetResultMapperImpl in shared-lib/protobuf sources.
- TenantedTaskSetResultMapperImplTest in shared-lib/protobuf sources.  Notice the verification of field parity between TenantedTaskSetResults and TaskSetResults.



## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
