### PR TITLE
HS-1284: Add JdbcInitComponent for Ignite

### DIFF
--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/ignite/IgniteConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/ignite/IgniteConfig.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.ImportResource;
 
 @Configuration
@@ -39,6 +40,7 @@ public class IgniteConfig {
 // Beans
 //----------------------------------------
 
+    @DependsOn("igniteJdbcConnectionStartupGate")
     @Bean
     public Ignite ignite(@Autowired(required=false) IgniteConfiguration cfg) {
         if (cfg == null) {

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/jdbc/JdbcInitComponent.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/jdbc/JdbcInitComponent.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *
+ */
+
+package org.opennms.miniongateway.jdbc;
+
+import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * HS-1284
+ *
+ * The main purpose of this class is to wait for the connection to the JDBC database used by Ignite at bean-init-time,
+ *  in a bean that the Ignite bean depends on, so that Ignite does not start until the database is available.
+ *
+ * This works-around the fact that Ignite only attempts to connect to the database one time at startup in order to
+ *  initialize the schema, and if that fails, ignite's cache persistence will never recover.
+ */
+@Component("igniteJdbcConnectionStartupGate")
+public class JdbcInitComponent {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcInitComponent.class);
+
+    public static final int DEFAULT_TIMEOUT = 60_000;
+    public static final int DEFAULT_RETRY_PERIOD = 500;
+
+    @Value("${ignite-jdbc.connection.startup-gate.timeout:" + DEFAULT_TIMEOUT + "}")
+    @Setter
+    private int timeout;
+
+    @Value("${ignite-jdbc.connection.startup-gate.retry-period:" + DEFAULT_RETRY_PERIOD + "}")
+    @Setter
+    private long retryPeriod;
+
+    @Setter
+    private Supplier<Long> timestampClockSource = System::nanoTime;
+    @Setter
+    private Consumer<Long> delayOperation = this::delay;
+
+    private final DataSource dataSource;
+
+    private Exception lastException;
+
+//========================================
+// Constructor
+//----------------------------------------
+
+    public JdbcInitComponent(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+//========================================
+// Initialization
+//----------------------------------------
+
+    @PostConstruct
+    public void init() {
+        long startTimestamp = timestampClockSource.get();
+        long now = startTimestamp;
+        boolean connected = false;
+        boolean first = true;
+        int count = 0;
+
+        while (
+            (! connected) &&
+            (! isTimedOut(startTimestamp, now, timeout))
+        ) {
+            if (first) {
+                first = false;
+            } else {
+                delayOperation.accept(retryPeriod);
+            }
+
+            count++;
+            connected = attemptConnect();
+            now = timestampClockSource.get();
+        }
+
+        if (!connected) {
+            LOG.error("Timed out attempting to connect to the database; aborting startup: connection-attempt-count={}; timeout={}", count, timeout);
+            throw new RuntimeException("Timed out attempting to connect to the database; aborting startup", lastException);
+        }
+    }
+
+//========================================
+// Internals
+//----------------------------------------
+
+    private boolean attemptConnect() {
+        try {
+            Connection connection = this.dataSource.getConnection();
+            connection.close();
+
+            return true;
+        } catch (Exception exc) {
+            LOG.info("Failed to connect to database", exc);
+            lastException = exc;
+        }
+
+        return false;
+    }
+
+    private void delay(long period) {
+        try {
+            Thread.sleep(period);
+        } catch (InterruptedException intExc) {
+            LOG.debug("Interrupted during delay", intExc);
+        }
+    }
+
+    /**
+     * Check for timeout.
+     *
+     * @param startupTimestamp time at startup in nanoseconds
+     * @param now current time in nanoseconds
+     * @param timeoutMs timeout period in milliseconds
+     *
+     * @return true => timeout exceeded; false => timeout not yet exceeded.
+     */
+    private boolean isTimedOut(long startupTimestamp, long now, long timeoutMs) {
+        long delta = now - startupTimestamp;
+        return (delta > (timeoutMs * 1_000_000L));
+    }
+}

--- a/minion-gateway/main/src/test/java/org/opennms/miniongateway/jdbc/JdbcInitComponentTest.java
+++ b/minion-gateway/main/src/test/java/org/opennms/miniongateway/jdbc/JdbcInitComponentTest.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *
+ */
+
+package org.opennms.miniongateway.jdbc;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+public class JdbcInitComponentTest {
+
+    private JdbcInitComponent target;
+
+    private DataSource mockDataSource;
+    private Connection mockConnection;
+
+    @Before
+    public void setUp() throws Exception {
+        mockDataSource = Mockito.mock(DataSource.class);
+        mockConnection = Mockito.mock(Connection.class);
+
+        target = new JdbcInitComponent(mockDataSource);
+    }
+
+    @Test
+    public void testInitSuccessFirstTry() throws SQLException {
+        //
+        // Setup Test Data and Interactions
+        //
+        Mockito.when(mockDataSource.getConnection()).thenReturn(mockConnection);
+
+        //
+        // Execute
+        //
+        target.init();
+
+        //
+        // Verify the Results
+        //
+        // NOTE: a lack of exception indicates success
+        Mockito.verify(mockConnection).close();
+    }
+
+    @Test
+    public void testInitSuccessThirdTry() throws SQLException {
+        //
+        // Setup Test Data and Interactions
+        //
+        SQLException testException = new SQLException("x-test-sql-exception-x");
+        Mockito.when(mockDataSource.getConnection())
+            .thenThrow(testException)
+            .thenThrow(testException)
+            .thenThrow(testException)
+            .thenReturn(mockConnection);
+
+        //
+        // Execute
+        //
+        List<Long> delayPeriods = new LinkedList<>();
+        target.setTimestampClockSource(
+            prepareClockSource(1_000_000_000L, 1_000_000_000L, 2_000_000_000L, 3_000_000_000L, 4_000_000_000L)
+        );
+        target.setDelayOperation(delay -> delayPeriods.add(delay));
+        target.setTimeout(JdbcInitComponent.DEFAULT_TIMEOUT);
+        target.init();
+
+        //
+        // Verify the Results
+        //
+        // NOTE: a lack of exception indicates success
+        assertEquals(3, delayPeriods.size());
+        Mockito.verify(mockConnection).close();
+    }
+
+    @Test
+    public void testInitFailForthTry() throws SQLException {
+        //
+        // Setup Test Data and Interactions
+        //
+        SQLException testException = new SQLException("x-test-sql-exception-x");
+        Mockito.when(mockDataSource.getConnection())
+            .thenThrow(testException)
+            .thenThrow(testException)
+            .thenThrow(testException)
+            .thenThrow(testException);
+
+        //
+        // Execute
+        //
+        List<Long> delayPeriods = new LinkedList<>();
+        target.setTimestampClockSource(
+            prepareClockSource(1_000_000_000L, 1_000_000_000L)
+        );
+        target.setDelayOperation(delay -> delayPeriods.add(delay));
+        target.setTimeout(4_000);
+
+        Exception caught = null;
+        try {
+            target.init();
+            fail("Missing expected exception");
+        } catch (Exception thrown) {
+            caught = thrown;
+        }
+
+        //
+        // Verify the Results
+        //
+        // NOTE: a lack of exception indicates success
+        assertSame(testException, caught.getCause());
+        assertEquals(4, delayPeriods.size());
+    }
+
+//========================================
+//
+//----------------------------------------
+
+    private Supplier<Long> prepareClockSource(long defaultTickLength, long... ticks) {
+        return new Supplier<Long>() {
+            private int cur = 0;
+            @Override
+            public Long get() {
+                if (cur >= ticks.length) {
+                    cur++;
+                    return ticks[ticks.length - 1] + ( defaultTickLength * ( cur - ticks.length ) );
+                }
+
+                return ticks[cur++];
+            }
+        };
+    }
+
+}

--- a/minion/docker-it/src/test/java/org/opennms/horizon/dockerit/testcontainers/TestContainerRunnerClassRule.java
+++ b/minion/docker-it/src/test/java/org/opennms/horizon/dockerit/testcontainers/TestContainerRunnerClassRule.java
@@ -117,8 +117,8 @@ public class TestContainerRunnerClassRule extends ExternalResource {
             .withEnv("USE_KUBERNETES", "false")
             .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("APPLICATION"));
 
-        // DEBUGGING: uncomment to force local port 5005
-        applicationContainer.getPortBindings().add("5005:5005");
+        // DEBUGGING: uncomment to force local port 5005 (NOTE: MAKE SURE IT IS COMMENTED-OUT AT CODE COMMIT-TIME - i.e. on "git commit")
+        // applicationContainer.getPortBindings().add("5005:5005");
         applicationContainer.getPortBindings().addAll(List.of(ExposedPort.udp(UDP_NETFLOW5_PORT).toString(), ExposedPort.udp(UDP_NETFLOW9_PORT).toString()));
         applicationContainer.start();
 


### PR DESCRIPTION
Add JdbcInitComponent that waits - up to a timeout - for the database to be accessible, and make the ignite bean depend on it.

This works-around the problem that Ignite only tries one time to get connected to the database for cache JDBC storage, thereby making the service not resilient to slowness, or temporary DB outage, during startup.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-1284
## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
