### PR TITLE
HS-1082 Support for propagation of metric collection time.

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumer.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/component/MinionHeartbeatConsumer.java
@@ -155,6 +155,7 @@ public class MinionHeartbeatConsumer {
             .setResponseTimeMs(responseTime)
             .setMonitorType(MonitorType.ECHO)
             .setIpAddress(systemId) //for minion only
+            .setTimestamp(System.currentTimeMillis())
             .build();
         TaskResult result = TaskResult.newBuilder()
             .setId("monitor-"+systemId)

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutionResultProcessorImpl.java
@@ -1,6 +1,7 @@
 package org.opennms.horizon.minion.taskset.worker.impl;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.Timestamp;
 import org.opennms.horizon.minion.plugin.api.CollectionSet;
 import org.opennms.horizon.minion.plugin.api.ScanResultsResponse;
 import org.opennms.horizon.minion.plugin.api.ServiceDetectorResponse;
@@ -162,6 +163,7 @@ public class TaskExecutionResultProcessorImpl implements TaskExecutionResultProc
                 .setReason(Optional.of(smr).map(ServiceMonitorResponse::getReason).orElse(MonitorResponse.getDefaultInstance().getReason()))
                 .putAllMetrics(Optional.of(smr).map(ServiceMonitorResponse::getProperties).orElse(Collections.EMPTY_MAP))
                 .setNodeId(smr.getNodeId())
+                .setTimestamp(smr.getTimestamp())
                 .build();
 
         return result;

--- a/minion/plugins/icmp-plugin/src/main/java/org/opennms/horizon/minion/icmp/IcmpMonitor.java
+++ b/minion/plugins/icmp-plugin/src/main/java/org/opennms/horizon/minion/icmp/IcmpMonitor.java
@@ -139,6 +139,7 @@ public class IcmpMonitor extends AbstractServiceMonitor {
                     .status(Status.Up)
                     .responseTime(responseTimeMillis)
                     .nodeId(nodeId)
+                    .timestamp(System.currentTimeMillis())
                     .ipAddress(inetAddress.getHostAddress())
                     .build()
             );

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponse.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponse.java
@@ -47,6 +47,13 @@ public interface ServiceMonitorResponse {
      */
     DeviceConfig getDeviceConfig();
 
+    /**
+     * Returns timestamp when response time was actually generated.
+     *
+     * @return Timestamp of a response.
+     */
+    long getTimestamp();
+
     interface DeviceConfig {
 
         byte[] getContent();

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponseImpl.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceMonitorResponseImpl.java
@@ -18,6 +18,8 @@ public class ServiceMonitorResponseImpl implements ServiceMonitorResponse {
     private MonitorType monitorType;
     private long nodeId;
 
+    private long timestamp;
+
     public static ServiceMonitorResponse unknown() { return builder().status(Status.Unknown).build();}
     public static ServiceMonitorResponse down() { return builder().status(Status.Down).build();}
 

--- a/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/SnmpMonitor.java
+++ b/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/SnmpMonitor.java
@@ -209,6 +209,7 @@ public class SnmpMonitor extends AbstractServiceMonitor {
             .status(Status.Unknown)
             .responseTime(elapsedTimeMs)
             .ipAddress(hostAddress)
+            .timestamp(System.currentTimeMillis())
             .nodeId(nodeId);
 
         Map<String, Number> metrics = new HashMap<>();

--- a/shared-lib/protobuf/src/main/proto/taskSet.proto
+++ b/shared-lib/protobuf/src/main/proto/taskSet.proto
@@ -28,6 +28,7 @@
 syntax = "proto3";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "icmp.proto";
 import "snmp.proto";
 import "traps-config.proto";
@@ -109,6 +110,7 @@ message MonitorResponse {
   MonitorType monitor_type = 5;
   map<string, double> metrics = 6;
   uint64 node_id = 7;
+  uint64 timestamp = 8;
 }
 
 message DetectorResponse {


### PR DESCRIPTION
## Description
Propagation of metric collection timestamp from minion to opennms backend.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1082

## Flagged for review
I am not clear on timezone handling. Minions will span across different zones hence I think we should go with UTC times, but then there is a question of how cortex/prometheus is interpreting timestamp attached to metric.

Finally there is a question of out-of-order samples received with a significant delay.

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
