### PR TITLE
HS-1303 Add retries for posting notifications to PagerDuty

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/config/NotificationsConfig.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/config/NotificationsConfig.java
@@ -28,16 +28,42 @@
 
 package org.opennms.horizon.notifications.config;
 
+import org.opennms.horizon.notifications.exceptions.NotificationAPIRetryableException;
+import org.opennms.horizon.notifications.exceptions.NotificationException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class NotificationsConfig {
+    @Value("${horizon.pagerduty.retry.delay:1000}")
+    private int retryDelay;
+
+    @Value("${horizon.pagerduty.retry.maxDelay:60000}")
+    private int maxRetryDelay;
+
+    @Value("${horizon.pagerduty.retry.multiplier:2}")
+    private int retryMultiplier;
+
+    @Value("${horizon.pagerduty.retry.max:10}")
+    private int maxNumberOfRetries;
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         return builder.build();
+    }
+
+    @Bean
+    public RetryTemplate retryTemplate() {
+        // Default exponential backoff, retries after 1s, 3s, 7s, 15s.. At most 60s delay by default.
+        return RetryTemplate.builder()
+            .retryOn(NotificationAPIRetryableException.class)
+            .maxAttempts(maxNumberOfRetries)
+            .exponentialBackoff(retryDelay, retryMultiplier, maxRetryDelay)
+            .build();
     }
 }

--- a/notifications/src/main/java/org/opennms/horizon/notifications/exceptions/NotificationAPIRetryableException.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/exceptions/NotificationAPIRetryableException.java
@@ -1,0 +1,9 @@
+package org.opennms.horizon.notifications.exceptions;
+
+import org.springframework.web.client.ResourceAccessException;
+
+public class NotificationAPIRetryableException extends NotificationAPIException {
+    public NotificationAPIRetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/notifications/src/test/resources/org/opennms/horizon/notifications/notification-processing.feature
+++ b/notifications/src/test/resources/org/opennms/horizon/notifications/notification-processing.feature
@@ -34,8 +34,14 @@ Feature: Notification Processing
   Scenario: Post notification
     Given Integration "test-tenant" key set to "abc" via grpc
     Given Alert posted via service with tenant "test-tenant"
-    Then verify pager duty rest method is called
+    Then verify pager duty rest method is called 1 times
 
   Scenario: Try to post notification with no config
     Given Alert posted via service with no config with tenant "test-tenant"
     Then verify exception "NotificationConfigUninitializedException" thrown with message "PagerDuty config not initialized. Row count=0"
+
+  Scenario: Will retry on failure to post notification to PagerDuty
+    Given Integration "test-tenant" key set to "abc" via grpc
+    And first attempt to post to PagerDuty will fail but should retry
+    And Alert posted via service with tenant "test-tenant"
+    Then verify pager duty rest method is called 2 times


### PR DESCRIPTION
## Description
If PagerDuty was down or returned a non-successful response code, the notification would be lost. This commit add some configuration to retry and give a best effort for delivering the notification.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1303

## Flagged for review
null

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
