### PR TITLE
HS-1266 - add clear errors for form

### DIFF
--- a/ui/src/components/Discovery/DiscoveryAzureForm.vue
+++ b/ui/src/components/Discovery/DiscoveryAzureForm.vue
@@ -142,6 +142,7 @@ const dirIdV = string().required('Directory ID is required.')
 
 watchEffect(() => {
   if (props.discovery) {
+    form.clearErrors()
     store.azure = { ...store.azure, ...props.discovery }
   }
 })

--- a/ui/src/components/Discovery/DiscoverySnmpForm.vue
+++ b/ui/src/components/Discovery/DiscoverySnmpForm.vue
@@ -122,6 +122,7 @@ onMounted(() => {
 
 watch(props, () => {
   if (props.discovery?.id) {
+    form.clearErrors()
     discoveryQueries.getTagsByActiveDiscoveryId(props.discovery.id)
   }
   discoveryInfo.value = props.discovery || ({} as IcmpActiveDiscoveryCreateInput)

--- a/ui/src/components/Discovery/DiscoverySyslogSNMPTrapsForm.vue
+++ b/ui/src/components/Discovery/DiscoverySyslogSNMPTrapsForm.vue
@@ -120,6 +120,7 @@ onMounted(() => {
 
 watch(props, () => {
   if (props.discovery?.id) {
+    form.clearErrors()
     discoveryQueries.getTagsByPassiveDiscoveryId(props.discovery.id)
   }
   discoveryInfo.value = props.discovery || ({} as PassiveDiscoveryUpsertInput)


### PR DESCRIPTION
## Description
Fixing a bug for discovery forms
if new discovery form shows the errors for empty forms, then on selecting a created discovery, it would keep showing the errors, even if the fields are not empty.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1266

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
