### PR TITLE
HS-1140: Persist Monitoring Policy for Notifications in Postgres

### DIFF
--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -117,6 +117,11 @@
         </dependency>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>alert-dto</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>notifications</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/MonitoringPolicyKafkaConsumer.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/MonitoringPolicyKafkaConsumer.java
@@ -1,0 +1,40 @@
+package org.opennms.horizon.notifications.kafka;
+
+import com.google.common.base.Strings;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.opennms.horizon.notifications.service.MonitoringPolicyService;
+import org.opennms.horizon.notifications.tenant.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+
+import java.util.Arrays;
+
+@Service
+public class MonitoringPolicyKafkaConsumer {
+    private final Logger LOG = LoggerFactory.getLogger(MonitoringPolicyKafkaConsumer.class);
+
+    @Autowired
+    private MonitoringPolicyService monitoringPolicyService;
+
+    @KafkaListener(
+        topics = "${horizon.kafka.monitoring-policy.topic}",
+        concurrency = "${horizon.kafka.monitoring-policy.concurrency}"
+    )
+    public void consume(@Payload byte[] data) {
+        try {
+            MonitorPolicyProto monitoringPolicyProto = MonitorPolicyProto.parseFrom(data);
+            if (Strings.isNullOrEmpty(monitoringPolicyProto.getTenantId())) {
+                LOG.warn("TenantId is empty, dropping alert {}", monitoringPolicyProto);
+                return;
+            }
+            monitoringPolicyService.saveMonitoringPolicy(monitoringPolicyProto);
+        } catch (InvalidProtocolBufferException e) {
+            LOG.error("Error while parsing Monitoring Policy. Payload: {}", Arrays.toString(data), e);
+        }
+    }
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/MonitoringPolicyKafkaConsumer.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/MonitoringPolicyKafkaConsumer.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.horizon.notifications.kafka;
 
 import com.google.common.base.Strings;

--- a/notifications/src/main/java/org/opennms/horizon/notifications/mapper/MonitoringPolicyMapper.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/mapper/MonitoringPolicyMapper.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.mapper;
+
+import org.mapstruct.Mapper;
+import org.opennms.horizon.notifications.model.MonitoringPolicy;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+
+@Mapper(componentModel = "spring")
+public interface MonitoringPolicyMapper {
+    MonitoringPolicy dtoToModel(MonitorPolicyProto dto);
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/model/MonitoringPolicy.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/model/MonitoringPolicy.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.horizon.notifications.model;
 
 import jakarta.persistence.Column;

--- a/notifications/src/main/java/org/opennms/horizon/notifications/model/MonitoringPolicy.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/model/MonitoringPolicy.java
@@ -1,0 +1,29 @@
+package org.opennms.horizon.notifications.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@Entity
+public class MonitoringPolicy extends TenantAwareEntity {
+    @Id
+    private long id;
+
+    @Column(name = "notify_email")
+    private boolean notifyByEmail;
+
+    @Column(name = "notify_pagerduty")
+    private boolean notifyByPagerDuty;
+
+    @Column(name = "notify_webhooks")
+    private boolean notifyByWebhooks;
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/repository/MonitoringPolicyRepository.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/repository/MonitoringPolicyRepository.java
@@ -1,0 +1,13 @@
+package org.opennms.horizon.notifications.repository;
+
+import org.opennms.horizon.notifications.model.MonitoringPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MonitoringPolicyRepository extends JpaRepository<MonitoringPolicy, Long> {
+    Optional<MonitoringPolicy> findByTenantIdAndId(String tenantId, long id);
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/repository/MonitoringPolicyRepository.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/repository/MonitoringPolicyRepository.java
@@ -1,3 +1,31 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
 package org.opennms.horizon.notifications.repository;
 
 import org.opennms.horizon.notifications.model.MonitoringPolicy;

--- a/notifications/src/main/java/org/opennms/horizon/notifications/service/MonitoringPolicyService.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/service/MonitoringPolicyService.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.notifications.service;
+
+import org.opennms.horizon.notifications.mapper.MonitoringPolicyMapper;
+import org.opennms.horizon.notifications.model.MonitoringPolicy;
+import org.opennms.horizon.notifications.repository.MonitoringPolicyRepository;
+import org.opennms.horizon.notifications.tenant.WithTenant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+
+@Service
+public class MonitoringPolicyService {
+
+    @Autowired
+    private MonitoringPolicyMapper monitoringPolicyMapper;
+
+    @Autowired
+    private MonitoringPolicyRepository monitoringPolicyRepository;
+
+    @WithTenant(tenantIdArg = 0, tenantIdArgInternalMethod = "getTenantId", tenantIdArgInternalClass = "org.opennms.horizon.shared.alert.policy.MonitorPolicyProto")
+    public void saveMonitoringPolicy(MonitorPolicyProto monitoringPolicyProto ) {
+        // Assuming updates always arrive in order on Kafka...
+        MonitoringPolicy policy = monitoringPolicyMapper.dtoToModel(monitoringPolicyProto);
+        monitoringPolicyRepository.save(policy);
+    }
+}

--- a/notifications/src/main/resources/db/changelog/changelog.xml
+++ b/notifications/src/main/resources/db/changelog/changelog.xml
@@ -9,5 +9,6 @@
     <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfig.xml" />
     <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfigUpdate.xml" />
     <include file="db/changelog/hs-0.1.0/tables/pagerDutyConfigTenantUpdate.xml" />
+    <include file="db/changelog/hs-0.1.0/tables/monitoringPolicy.xml" />
 
 </databaseChangeLog>

--- a/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/monitoringPolicy.xml
+++ b/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/monitoringPolicy.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet author="jhutc" id="monitoring_policy">
+        <validCheckSum>ANY</validCheckSum>
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="monitoring_policy"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="monitoring_policy">
+            <column name="id" type="bigint">
+                <constraints
+                    nullable="false"
+                    primaryKey="true"
+                    primaryKeyName="pk_monitoring_policy_id"
+                />
+            </column>
+            <column name="tenant_id" type="text">
+                <constraints nullable="false"/>
+            </column>
+            <column name="notify_email" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+            <column name="notify_pagerduty" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+            <column name="notify_webhooks" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
@@ -1,5 +1,6 @@
 package org.opennms.horizon.notifications;
 
+import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.spring.CucumberContextConfiguration;
@@ -7,19 +8,26 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.stub.MetadataUtils;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.keycloak.common.VerificationException;
 import org.opennms.horizon.alerts.proto.Alert;
 import org.opennms.horizon.notifications.api.PagerDutyDao;
 import org.opennms.horizon.notifications.dto.NotificationServiceGrpc;
 import org.opennms.horizon.notifications.dto.PagerDutyConfigDTO;
-import org.opennms.horizon.notifications.exceptions.NotificationAPIRetryableException;
 import org.opennms.horizon.notifications.exceptions.NotificationConfigUninitializedException;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
+import org.opennms.horizon.notifications.model.MonitoringPolicy;
+import org.opennms.horizon.notifications.repository.MonitoringPolicyRepository;
 import org.opennms.horizon.notifications.service.NotificationService;
 import org.opennms.horizon.notifications.tenant.WithTenant;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -29,13 +37,25 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -46,6 +66,8 @@ import static org.mockito.Mockito.when;
 @CucumberContextConfiguration
 @SpringBootTest
 @EnableAutoConfiguration
+@EmbeddedKafka(partitions = 1)
+@TestPropertySource(properties = "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}", locations = "classpath:application.yml")
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 public class NotificationCucumberTestSteps extends GrpcTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(NotificationCucumberTestSteps.class);
@@ -66,6 +88,17 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
     @SpyBean
     public RestTemplate restTemplate;
 
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired
+    MonitoringPolicyRepository monitoringPolicyRepository;
+
+    @Value("${horizon.kafka.monitoring-policy.topic}")
+    private String monitoringPolicyTopic;
+
+    private Producer<String, byte[]> kafkaProducer;
+
     private Exception caught;
 
     @Then("tear down grpc setup")
@@ -77,6 +110,7 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
     @Given("clean setup")
     public void clean(){
         jdbcTemplate.execute("delete from pager_duty_config");
+        jdbcTemplate.execute("delete from monitoring_policy");
         caught = null;
     }
 
@@ -84,6 +118,14 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
     public void cleanGrpc() throws VerificationException {
         prepareServer();
         serviceStub = NotificationServiceGrpc.newBlockingStub(channel);
+    }
+    @Given("kafka setup")
+    public void setupKafka() {
+        Map<String, Object> producerConfig = new HashMap<>(KafkaTestUtils.producerProps(embeddedKafkaBroker));
+
+        DefaultKafkaProducerFactory<String, byte[]> kafkaProducerFactory
+            = new DefaultKafkaProducerFactory<>(producerConfig, new StringSerializer(), new ByteArraySerializer());
+        kafkaProducer = kafkaProducerFactory.createProducer();
     }
 
     @Given("Integration {string} key set to {string} via grpc")
@@ -224,5 +266,35 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
         when(restTemplate.exchange(any(), any(), any(), any(Class.class)))
             .thenThrow(new RestClientResponseException("Failed", HttpStatus.BAD_GATEWAY, "Failed", null, null, null))
             .thenReturn(ResponseEntity.ok(null));
+    }
+
+    @Given("the following monitoring policies sent via Kafka")
+    public void addMonitoringPolicies(DataTable table) {
+        table.asLists().forEach((row) -> {
+            MonitorPolicyProto proto = MonitorPolicyProto.newBuilder()
+                .setId(Long.parseLong(row.get(0)))
+                .setTenantId(row.get(1))
+                .setNotifyByPagerDuty(Boolean.parseBoolean(row.get(2)))
+                .setNotifyByEmail(Boolean.parseBoolean(row.get(3)))
+                .setNotifyByWebhooks(Boolean.parseBoolean(row.get(4)))
+                .build();
+            ProducerRecord<String, byte[]> record = new ProducerRecord<>(monitoringPolicyTopic, proto.toByteArray());
+            kafkaProducer.send(record);
+        });
+        kafkaProducer.flush();
+    }
+
+
+    @Then("verify {string} has a monitoring policy with ID {long} and the following enabled")
+    @WithTenant(tenantIdArg = 0)
+    public void verifyMonitoringPolicy(String tenant, long id, List<String> enabledNotifications) {
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            Optional<MonitoringPolicy> monitoringPolicy = monitoringPolicyRepository.findByTenantIdAndId(tenant, id);
+            assertTrue(monitoringPolicy.isPresent());
+
+            assertEquals(enabledNotifications.contains("PagerDuty"), monitoringPolicy.get().isNotifyByPagerDuty());
+            assertEquals(enabledNotifications.contains("email"), monitoringPolicy.get().isNotifyByEmail());
+            assertEquals(enabledNotifications.contains("webhooks"), monitoringPolicy.get().isNotifyByWebhooks());
+        });
     }
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/MonitoringPolicyKafkaConsumerTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/MonitoringPolicyKafkaConsumerTest.java
@@ -1,0 +1,46 @@
+package org.opennms.horizon.notifications.kafka;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.notifications.service.MonitoringPolicyService;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MonitoringPolicyKafkaConsumerTest {
+
+    @InjectMocks
+    MonitoringPolicyKafkaConsumer monitoringPolicyKafkaConsumer;
+
+    @Mock
+    MonitoringPolicyService monitoringPolicyService;
+
+    @Test
+    public void testDropsInvalidData() {
+        monitoringPolicyKafkaConsumer.consume(new byte[10]);
+        Mockito.verify(monitoringPolicyService, times(0)).saveMonitoringPolicy(any());
+    }
+
+    @Test
+    public void testDropsWithoutTenantId() {
+        MonitorPolicyProto proto = MonitorPolicyProto.newBuilder().build();
+
+        monitoringPolicyKafkaConsumer.consume(proto.toByteArray());
+        Mockito.verify(monitoringPolicyService, times(0)).saveMonitoringPolicy(any());
+    }
+
+    @Test
+    public void testConsume() {
+        MonitorPolicyProto proto = MonitorPolicyProto.newBuilder().setTenantId("tenant").build();
+
+        monitoringPolicyKafkaConsumer.consume(proto.toByteArray());
+        Mockito.verify(monitoringPolicyService, times(1)).saveMonitoringPolicy(eq(proto));
+    }
+}

--- a/notifications/src/test/java/org/opennms/horizon/notifications/service/MonitoringPolicyServiceImplTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/service/MonitoringPolicyServiceImplTest.java
@@ -1,0 +1,53 @@
+package org.opennms.horizon.notifications.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.notifications.mapper.MonitoringPolicyMapper;
+import org.opennms.horizon.notifications.repository.MonitoringPolicyRepository;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.argThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MonitoringPolicyServiceImplTest {
+
+    @InjectMocks
+    MonitoringPolicyService monitoringPolicyService;
+
+    @Mock
+    MonitoringPolicyRepository monitoringPolicyRepository;
+
+    @Spy
+    MonitoringPolicyMapper monitoringPolicyMapper = Mappers.getMapper(MonitoringPolicyMapper.class);
+
+    @Test
+    public void savePolicy() {
+        MonitorPolicyProto proto = MonitorPolicyProto.newBuilder()
+            .setId(1)
+            .setTenantId("tenant")
+            .setNotifyByPagerDuty(true)
+            .setNotifyByEmail(false)
+            .setNotifyByWebhooks(false)
+            .build();
+        monitoringPolicyService.saveMonitoringPolicy(proto);
+
+        Mockito.verify(monitoringPolicyRepository, Mockito.times(1)).save(argThat((arg) -> {
+            assertEquals(1, arg.getId());
+            assertEquals("tenant", arg.getTenantId());
+            assertTrue(arg.isNotifyByPagerDuty());
+            assertFalse(arg.isNotifyByEmail());
+            assertFalse(arg.isNotifyByWebhooks());
+
+            return true;
+        }));
+    }
+}

--- a/notifications/src/test/resources/application.yml
+++ b/notifications/src/test/resources/application.yml
@@ -18,6 +18,9 @@ horizon:
     alerts:
       topic: alerts
       concurrency: 1
+    monitoring-policy:
+      topic: monitoring-policy
+      concurrency: 1
 
   pagerduty:
     client: OpenNMS

--- a/notifications/src/test/resources/org/opennms/horizon/notifications/monitoring-policy.feature
+++ b/notifications/src/test/resources/org/opennms/horizon/notifications/monitoring-policy.feature
@@ -1,0 +1,45 @@
+Feature: Monitoring Policy
+
+  Background:
+    Given clean setup
+    And kafka setup
+
+  Scenario: Can add new monitoring policy
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | JerrySeinfeld | true | false | false |
+    Then verify "JerrySeinfeld" has a monitoring policy with ID 1 and the following enabled
+      | PagerDuty |
+
+
+  Scenario: Can update existing monitoring policy
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | JerrySeinfeld | false | true  | false |
+      | 1 | JerrySeinfeld | true  | false | true  |
+    Then verify "JerrySeinfeld" has a monitoring policy with ID 1 and the following enabled
+      | PagerDuty |
+      | webhooks  |
+
+  Scenario: Can add multiple monitoring policies for a tenant
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | JerrySeinfeld | false | false | false |
+      | 2 | JerrySeinfeld | true  | true  | true  |
+    Then verify "JerrySeinfeld" has a monitoring policy with ID 1 and the following enabled
+      |  |
+    And verify "JerrySeinfeld" has a monitoring policy with ID 2 and the following enabled
+      | PagerDuty |
+      | email     |
+      | webhooks  |
+
+  Scenario: Can add multiple monitoring policies for different tenants
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | CosmoKramer   | false | false | true |
+      | 2 | JerrySeinfeld | false | true  | true |
+    Then verify "CosmoKramer" has a monitoring policy with ID 1 and the following enabled
+      | webhooks |
+    And verify "JerrySeinfeld" has a monitoring policy with ID 2 and the following enabled
+      | email    |
+      | webhooks |


### PR DESCRIPTION
## Description
Receives a monitoring policy over a Kafka topic, and we pull out the bits relative to notifications. These policies will then be used to enable configuration in the notifications processing flow.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1140

## Flagged for review
Should think about refactoring the Cucumber steps file, it looks large but lots is related to tests.

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
