### PR TITLE
HS-1331: Derive SNMP sysName as Node Label after node scan if available

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
@@ -246,6 +246,11 @@ public class NodeService {
 
     public void updateNodeInfo(Node node, NodeInfoResult nodeInfo) {
         mapper.updateFromNodeInfo(nodeInfo, node);
+
+        if (StringUtils.isNotEmpty(nodeInfo.getSystemName())) {
+            node.setNodeLabel(nodeInfo.getSystemName());
+        }
+
         nodeRepository.save(node);
     }
 

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseServiceIntTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseServiceIntTest.java
@@ -299,6 +299,7 @@ class ScannerResponseServiceIntTest extends GrpcTestBase {
                     nodeInfo.getSystemDescr(),
                     nodeInfo.getSystemLocation(),
                     nodeInfo.getSystemContact());
+            assertEquals(nodeInfo.getSystemName(), node.getNodeLabel());
         } else {
             assertThat(node)
                 .extracting(Node::getObjectId,


### PR DESCRIPTION
## Description
HS-1331: Derive SNMP sysName as Node Label after node scan if available

![image](https://user-images.githubusercontent.com/8379423/228287790-47dbce9d-8851-482a-a37b-a7df9b36ed20.png)


## Jira link(s)
- https://issues.opennms.org/browse/HS-1331

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
