### PR TITLE
HS-1302: Move detectors to be part of NodeScan

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/ScannerTaskSetService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/ScannerTaskSetService.java
@@ -36,14 +36,15 @@ import org.opennms.horizon.inventory.dto.IpInterfaceDTO;
 import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.inventory.mapper.NodeMapper;
 import org.opennms.horizon.inventory.model.Node;
-import org.opennms.horizon.inventory.model.discovery.PassiveDiscovery;
 import org.opennms.horizon.inventory.model.discovery.active.AzureActiveDiscovery;
 import org.opennms.horizon.inventory.service.taskset.publisher.TaskSetPublisher;
 import org.opennms.horizon.shared.utils.InetAddressUtils;
 import org.opennms.horizon.snmp.api.SnmpConfiguration;
 import org.opennms.icmp.contract.IpRange;
 import org.opennms.icmp.contract.PingSweepRequest;
+import org.opennms.node.scan.contract.DetectRequest;
 import org.opennms.node.scan.contract.NodeScanRequest;
+import org.opennms.node.scan.contract.ServiceType;
 import org.opennms.taskset.contract.TaskDefinition;
 import org.opennms.taskset.contract.TaskType;
 import org.slf4j.Logger;
@@ -210,6 +211,8 @@ public class ScannerTaskSetService {
             Any taskConfig = Any.pack(NodeScanRequest.newBuilder()
                 .setNodeId(node.getId())
                 .setPrimaryIp(ip.getIpAddress())
+                .addDetector(DetectRequest.newBuilder().setService(ServiceType.SNMP).build())
+                .addDetector(DetectRequest.newBuilder().setService(ServiceType.ICMP).build())
                 .addAllSnmpConfigs(snmpConfigs).build());
 
             return TaskDefinition.newBuilder()

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseService.java
@@ -43,7 +43,6 @@ import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.model.SnmpInterface;
 import org.opennms.horizon.inventory.model.discovery.active.AzureActiveDiscovery;
 import org.opennms.horizon.inventory.repository.NodeRepository;
-import org.opennms.horizon.inventory.repository.discovery.PassiveDiscoveryRepository;
 import org.opennms.horizon.inventory.repository.discovery.active.AzureActiveDiscoveryRepository;
 import org.opennms.horizon.inventory.service.IpInterfaceService;
 import org.opennms.horizon.inventory.service.NodeService;
@@ -81,10 +80,10 @@ public class ScannerResponseService {
     private final IpInterfaceService ipInterfaceService;
     private final SnmpInterfaceService snmpInterfaceService;
     private final TagService tagService;
-    private final PassiveDiscoveryRepository passiveDiscoveryRepository;
     private final DetectorTaskSetService detectorTaskSetService;
     private final SnmpConfigService snmpConfigService;
     private final IcmpActiveDiscoveryService icmpActiveDiscoveryService;
+    private final DetectorResponseService detectorResponseService;
 
     @Transactional
     public void accept(String tenantId, String location, ScannerResponse response) throws InvalidProtocolBufferException {
@@ -214,8 +213,10 @@ public class ScannerResponseService {
             for (IpInterfaceResult ipIfResult : result.getIpInterfacesList()) {
                 ipInterfaceService.creatUpdateFromScanResult(tenantId, node, ipIfResult, ifIndexSNMPMap);
             }
+            result.getDetectorResultList().forEach(detectorResult -> {
+                detectorResponseService.processDetectorResults(tenantId, location, detectorResult);
+            });
 
-            detectorTaskSetService.sendDetectorTasks(node);
         } else {
             log.error("Error while process node scan results, node with id {} doesn't exist", result.getNodeId());
         }

--- a/minion/plugins/icmp-plugin/src/main/resources/OSGI-INF/blueprint/icmp-plugins.xml
+++ b/minion/plugins/icmp-plugin/src/main/resources/OSGI-INF/blueprint/icmp-plugins.xml
@@ -17,7 +17,7 @@
 
   <service ref="icmpDetectorManager" interface="org.opennms.horizon.minion.plugin.api.ServiceDetectorManager">
     <service-properties>
-      <entry key="detector.name" value="ICMPDetector"/>
+      <entry key="detector.name" value="ICMP"/>
     </service-properties>
   </service>
 

--- a/minion/plugins/nodescan-plugin/src/main/java/org/opennms/horizon/minion/nodescan/NodeScannerManager.java
+++ b/minion/plugins/nodescan-plugin/src/main/java/org/opennms/horizon/minion/nodescan/NodeScannerManager.java
@@ -30,17 +30,20 @@ package org.opennms.horizon.minion.nodescan;
 
 import org.opennms.horizon.minion.plugin.api.Scanner;
 import org.opennms.horizon.minion.plugin.api.ScannerManager;
+import org.opennms.horizon.minion.plugin.api.registries.DetectorRegistry;
 import org.opennms.horizon.shared.snmp.SnmpHelper;
 
 public class NodeScannerManager implements ScannerManager {
     private final SnmpHelper snmpHelper;
+    private final DetectorRegistry detectorRegistry;
 
-    public NodeScannerManager(SnmpHelper snmpHelper) {
+    public NodeScannerManager(SnmpHelper snmpHelper, DetectorRegistry detectorRegistry) {
         this.snmpHelper = snmpHelper;
+        this.detectorRegistry = detectorRegistry;
     }
 
     @Override
     public Scanner create() {
-        return new NodeScanner(snmpHelper);
+        return new NodeScanner(snmpHelper, detectorRegistry);
     }
 }

--- a/minion/plugins/nodescan-plugin/src/main/resources/OSGI-INF/blueprint/nodescanner-plugin.xml
+++ b/minion/plugins/nodescan-plugin/src/main/resources/OSGI-INF/blueprint/nodescanner-plugin.xml
@@ -4,8 +4,11 @@
 
     <reference availability="optional" id="snmpHelper" interface="org.opennms.horizon.shared.snmp.SnmpHelper" />
 
+    <reference availability="optional" id="detectorRegistry" interface="org.opennms.horizon.minion.plugin.api.registries.DetectorRegistry"/>
+
     <bean id="nodeScannerManager" class="org.opennms.horizon.minion.nodescan.NodeScannerManager">
         <argument ref="snmpHelper"/>
+        <argument ref="detectorRegistry"/>
     </bean>
 
     <service ref="nodeScannerManager" interface="org.opennms.horizon.minion.plugin.api.ScannerManager">
@@ -13,4 +16,6 @@
             <entry key="scanner.name" value="NodeScanner" />
         </service-properties>
     </service>
+
+
 </blueprint>

--- a/minion/plugins/nodescan-plugin/src/test/java/org/opennms/horizon/minion/nodescan/SnmpConfigMatrixTest.java
+++ b/minion/plugins/nodescan-plugin/src/test/java/org/opennms/horizon/minion/nodescan/SnmpConfigMatrixTest.java
@@ -31,6 +31,7 @@ package org.opennms.horizon.minion.nodescan;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.opennms.horizon.minion.plugin.api.registries.DetectorRegistry;
 import org.opennms.horizon.shared.snmp.SnmpHelper;
 import org.opennms.horizon.snmp.api.SnmpConfiguration;
 
@@ -43,7 +44,7 @@ public class SnmpConfigMatrixTest {
 
     @Test
     public void testConfigMatrix() {
-        NodeScanner nodeScanner = new NodeScanner(Mockito.mock(SnmpHelper.class));
+        NodeScanner nodeScanner = new NodeScanner(Mockito.mock(SnmpHelper.class), Mockito.mock(DetectorRegistry.class));
         List<SnmpConfiguration> configsFromRequest = new ArrayList<>();
         List<SnmpConfiguration> configurationsWithReadCommunity = new ArrayList<>();
         configurationsWithReadCommunity.add(SnmpConfiguration.newBuilder().setReadCommunity("snmp1").build());

--- a/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceDetector.java
+++ b/minion/plugins/plugins-api/src/main/java/org/opennms/horizon/minion/plugin/api/ServiceDetector.java
@@ -1,11 +1,14 @@
 package org.opennms.horizon.minion.plugin.api;
 
 import com.google.protobuf.Any;
+import org.opennms.node.scan.contract.ServiceResult;
 
 import java.util.concurrent.CompletableFuture;
 
 public interface ServiceDetector {
 
     CompletableFuture<ServiceDetectorResponse> detect(Any config, long nodeId);
+
+    CompletableFuture<ServiceResult> detect(String host, Any config);
 
 }

--- a/minion/plugins/snmp-plugin/src/main/resources/OSGI-INF/blueprint/snmp-plugins.xml
+++ b/minion/plugins/snmp-plugin/src/main/resources/OSGI-INF/blueprint/snmp-plugins.xml
@@ -16,7 +16,7 @@
 
   <service ref="snmpDetectorManager" interface="org.opennms.horizon.minion.plugin.api.ServiceDetectorManager">
     <service-properties>
-      <entry key="detector.name" value="SNMPDetector"/>
+      <entry key="detector.name" value="SNMP"/>
     </service-properties>
   </service>
 

--- a/shared-lib/protobuf/src/main/proto/nodescan.proto
+++ b/shared-lib/protobuf/src/main/proto/nodescan.proto
@@ -35,53 +35,53 @@ option java_multiple_files = true;
 option java_package = "org.opennms.node.scan.contract";
 
 message NodeScanRequest {
-  int64 nodeId = 1;
-  string primaryIp = 2;
-  repeated string ipAddresses = 3; //reserved for service scan
+  int64 node_id = 1;
+  string primary_ip = 2;
+  repeated string ip_addresses = 3; //reserved for service scan
   repeated opennms.snmp.api.SnmpConfiguration snmp_configs = 4;
 }
 
 //Scan Results
 message NodeInfoResult {
-  string objectId = 1;
-  string systemName = 2;
-  string systemDescr = 3;
-  string systemLocation = 4;
-  string systemContact = 5;
-  int64 systemUptime = 6;
+  string object_id = 1;
+  string system_name = 2;
+  string system_descr = 3;
+  string system_location = 4;
+  string system_contact = 5;
+  int64 system_uptime = 6;
 }
 
 //for service detector
 message ServiceResult {
-  string ipAddress = 1;
-  string serviceName = 2;
+  string ip_address = 1;
+  string service_name = 2;
   string status = 3;
 }
 
 message IpInterfaceResult {
-  string ipAddress = 1;
-  string ipHostName = 2;
+  string ip_address = 1;
+  string ip_host_name = 2;
   string netmask = 3;
-  int32 ifIndex = 4;
+  int32 if_index = 4;
 }
 
 message SnmpInterfaceResult {
-  string physicalAddr = 1;
-  int32 ifIndex = 2;
-  string ifDescr = 3;
-  int32 ifType = 4;
-  string ifName = 5;
-  int64 ifSpeed = 6;
-  int32 ifAdminStatus = 7;
-  int32 ifOperatorStatus = 8;
-  string ifAlias = 9;
+  string physical_addr = 1;
+  int32 if_index = 2;
+  string if_descr = 3;
+  int32 if_type = 4;
+  string if_name = 5;
+  int64 if_speed = 6;
+  int32 if_admin_status = 7;
+  int32 if_operator_status = 8;
+  string if_alias = 9;
 }
 
 message NodeScanResult {
-  int64 nodeId = 1;
-  NodeInfoResult nodeInfo = 2;
-  repeated IpInterfaceResult ipInterfaces = 3;
-  repeated SnmpInterfaceResult snmpInterfaces = 4;
+  int64 node_id = 1;
+  NodeInfoResult node_info = 2;
+  repeated IpInterfaceResult ip_interfaces = 3;
+  repeated SnmpInterfaceResult snmp_interfaces = 4;
   opennms.snmp.api.SnmpConfiguration snmp_config = 5;
 }
 

--- a/shared-lib/protobuf/src/main/proto/nodescan.proto
+++ b/shared-lib/protobuf/src/main/proto/nodescan.proto
@@ -37,8 +37,18 @@ option java_package = "org.opennms.node.scan.contract";
 message NodeScanRequest {
   int64 node_id = 1;
   string primary_ip = 2;
-  repeated string ip_addresses = 3; //reserved for service scan
+  repeated DetectRequest detector = 3;
   repeated opennms.snmp.api.SnmpConfiguration snmp_configs = 4;
+}
+
+enum ServiceType {
+  ICMP = 0;
+  SNMP = 1;
+}
+
+message DetectRequest {
+  ServiceType service = 1;
+  google.protobuf.Any config = 2;
 }
 
 //Scan Results
@@ -54,8 +64,8 @@ message NodeInfoResult {
 //for service detector
 message ServiceResult {
   string ip_address = 1;
-  string service_name = 2;
-  string status = 3;
+  ServiceType service = 2;
+  bool status = 3;
 }
 
 message IpInterfaceResult {
@@ -83,6 +93,7 @@ message NodeScanResult {
   repeated IpInterfaceResult ip_interfaces = 3;
   repeated SnmpInterfaceResult snmp_interfaces = 4;
   opennms.snmp.api.SnmpConfiguration snmp_config = 5;
+  repeated ServiceResult detector_result = 6;
 }
 
 


### PR DESCRIPTION
## Description
Currently Inventory service sends detectors request after NodeScan. We can combine both steps.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1302

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
