### PR TITLE
HS-1140: Use monitoring policy to send notifications

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlertKafkaConsumer.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/kafka/AlertKafkaConsumer.java
@@ -32,18 +32,9 @@ public class AlertKafkaConsumer {
                 LOG.warn("TenantId is empty, dropping alert {}", alert);
                 return;
             }
-            consumeAlert(alert);
+            notificationService.postNotification(alert);
         } catch (InvalidProtocolBufferException e) {
             LOG.error("Error while parsing Alert. Payload: {}", Arrays.toString(data), e);
-        }
-    }
-
-    public void consumeAlert(Alert alert){
-        try {
-            notificationService.postNotification(alert);
-        } catch (NotificationException e) {
-            // TODO: We need better resiliency. If a notification fails, do we want to retry? do we want to try another method?
-            LOG.error("Exception sending alert to notification service: {}", alert, e);
         }
     }
 }

--- a/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationService.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationService.java
@@ -28,23 +28,47 @@
 
 package org.opennms.horizon.notifications.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opennms.horizon.alerts.proto.Alert;
 import org.opennms.horizon.notifications.api.PagerDutyAPI;
 import org.opennms.horizon.notifications.dto.PagerDutyConfigDTO;
 import org.opennms.horizon.notifications.exceptions.NotificationException;
+import org.opennms.horizon.notifications.model.MonitoringPolicy;
+import org.opennms.horizon.notifications.repository.MonitoringPolicyRepository;
 import org.opennms.horizon.notifications.tenant.WithTenant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
+@Slf4j
 public class NotificationService {
 
     @Autowired
     private PagerDutyAPI pagerDutyAPI;
 
+    @Autowired
+    private MonitoringPolicyRepository monitoringPolicyRepository;
+
     @WithTenant(tenantIdArg = 0, tenantIdArgInternalMethod = "getTenantId", tenantIdArgInternalClass = "org.opennms.horizon.alerts.proto.Alert")
-    public void postNotification(Alert alert) throws NotificationException {
-        pagerDutyAPI.postNotification(alert);
+    public void postNotification(Alert alert) {
+        Optional<MonitoringPolicy> dbPolicy = monitoringPolicyRepository.findByTenantIdAndId(
+            alert.getTenantId(),
+            alert.getMonitoringPolicyId()
+        );
+
+        dbPolicy.ifPresentOrElse(policy -> {
+            if (policy.isNotifyByPagerDuty()) {
+                // Wrap in a try/catch, we don't want a failure to notify via PagerDuty to prevent us from sending an
+                // email notification, etc.
+                try {
+                    pagerDutyAPI.postNotification(alert);
+                } catch (NotificationException e) {
+                    log.warn("Unable to send alert to PagerDuty: {}", alert, e);
+                }
+            }
+        }, () -> log.debug("No monitoring policy found, dropping alert: {}", alert));
     }
 
     public void postPagerDutyConfig(PagerDutyConfigDTO config) {

--- a/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/NotificationCucumberTestSteps.java
@@ -204,13 +204,13 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
         }
     }
 
-    @Given("Alert posted via service with tenant {string}")
-    public void postAlertViaService(String tenantId) throws Exception{
-        postAlert(tenantId);
+    @Given("Alert posted via service with tenant {string} with monitoring policy ID {long}")
+    public void postAlertViaService(String tenantId, long monitoringPolicyId) {
+        postAlert(tenantId, monitoringPolicyId);
     }
 
-    private void postAlert(String tenantId) throws NotificationException {
-        Alert alert = Alert.newBuilder().setLogMessage("Hello").setTenantId(tenantId).build();
+    private void postAlert(String tenantId, long monitoringPolicyId) {
+        Alert alert = Alert.newBuilder().setLogMessage("Hello").setTenantId(tenantId).setMonitoringPolicyId(monitoringPolicyId).build();
         notificationService.postNotification(alert);
     }
 
@@ -241,11 +241,11 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
         verify(restTemplate, times(count)).exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
     }
 
-    @Given("Alert posted via service with no config with tenant {string}")
-    public void postNotificationWithNoConfig(String tenantId) {
+    @Given("Alert posted via service with no config with tenant {string} with monitoring policy ID {long}")
+    public void postNotificationWithNoConfig(String tenantId, long monitoringPolicyId) {
         caught = null;
         try {
-            postAlert(tenantId);
+            postAlert(tenantId, monitoringPolicyId);
         } catch (Exception ex) {
             caught = ex;
         }
@@ -297,4 +297,11 @@ public class NotificationCucumberTestSteps extends GrpcTestBase {
             assertEquals(enabledNotifications.contains("webhooks"), monitoringPolicy.get().isNotifyByWebhooks());
         });
     }
+
+    @Given("{string} has a monitoring policy with ID {long}")
+    @WithTenant(tenantIdArg = 0)
+    public void waitForMonitoringPolicy(String tenant, long id) {
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> monitoringPolicyRepository.findByTenantIdAndId(tenant, id).isPresent());
+    }
+
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlertKafkaConsumerUnitTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlertKafkaConsumerUnitTest.java
@@ -53,11 +53,4 @@ public class AlertKafkaConsumerUnitTest {
     public void testConsume() {
         alertKafkaConsumer.consume(Alert.newBuilder().build().toByteArray());
     }
-
-    @Test
-    public void testConsumeSwallowsNotificationException() throws NotificationException {
-        doThrow(NotificationInternalException.class)
-            .when(notificationService).postNotification(any());
-        alertKafkaConsumer.consumeAlert(Alert.newBuilder().build());
-    }
 }

--- a/notifications/src/test/resources/org/opennms/horizon/notifications/notification-processing.feature
+++ b/notifications/src/test/resources/org/opennms/horizon/notifications/notification-processing.feature
@@ -3,6 +3,7 @@ Feature: Notification Processing
   Background: Common Test Setup
     Given clean setup
     Given grpc setup
+    And kafka setup
 
   # Throws org.springframework.dao.DataIntegrityViolationException: assigned tenant id differs from current tenant id: test-tenant!=other-tenant : org.opennms.horizon.notifications.model.PagerDutyConfig.tenantId
   # which is then wrapped by the grpc
@@ -31,17 +32,35 @@ Feature: Notification Processing
     Given Integration key set to "abc" without tenantId
     Then verify exception "JpaSystemException" thrown with message "SessionFactory configured for multi-tenancy, but no tenant identifier specified"
 
-  Scenario: Post notification
-    Given Integration "test-tenant" key set to "abc" via grpc
-    Given Alert posted via service with tenant "test-tenant"
+  Scenario: Post PagerDuty notification
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | test-tenant    | true            | false       | false          |
+    And Integration "test-tenant" key set to "abc" via grpc
+    And "test-tenant" has a monitoring policy with ID 1
+    And Alert posted via service with tenant "test-tenant" with monitoring policy ID 1
     Then verify pager duty rest method is called 1 times
 
-  Scenario: Try to post notification with no config
-    Given Alert posted via service with no config with tenant "test-tenant"
-    Then verify exception "NotificationConfigUninitializedException" thrown with message "PagerDuty config not initialized. Row count=0"
-
   Scenario: Will retry on failure to post notification to PagerDuty
-    Given Integration "test-tenant" key set to "abc" via grpc
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | test-tenant    | true            | false       | false          |
     And first attempt to post to PagerDuty will fail but should retry
-    And Alert posted via service with tenant "test-tenant"
+    And Integration "test-tenant" key set to "abc" via grpc
+    And "test-tenant" has a monitoring policy with ID 1
+    And Alert posted via service with tenant "test-tenant" with monitoring policy ID 1
     Then verify pager duty rest method is called 2 times
+
+  Scenario: Notification without monitoring policy is dropped
+    Given Integration "test-tenant" key set to "abc" via grpc
+    And Alert posted via service with tenant "test-tenant" with monitoring policy ID 1
+    Then verify pager duty rest method is called 0 times
+
+  Scenario: Notification not sent to PagerDuty if disabled in monitoring policy
+    Given the following monitoring policies sent via Kafka
+      #| id | tenant        | enablePagerDuty | enableEmail | enableWebhooks |
+      | 1 | test-tenant    | false            | false       | false          |
+    And Integration "test-tenant" key set to "abc" via grpc
+    And "test-tenant" has a monitoring policy with ID 1
+    And Alert posted via service with tenant "test-tenant" with monitoring policy ID 1
+    Then verify pager duty rest method is called 0 times

--- a/shared-lib/events/src/main/proto/alerts.proto
+++ b/shared-lib/events/src/main/proto/alerts.proto
@@ -70,6 +70,7 @@ message Alert {
   string ack_user = 17;
   // Acknowledged when?
   uint64 ack_time_ms = 18;
+  uint64 monitoring_policy_id = 19;
 }
 
 message AlertList {


### PR DESCRIPTION
## Description
Now that monitoring policies are persisted in the notification service, we can reference them when processing notifications for alerts, choosing the destination of the notification based on the policy.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1140

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
