### PR TITLE
HS-1353 - Added yaml for postgres keycloak testing

### DIFF
--- a/install-local/postgres-for_testing_keycloak_realm_update.yaml
+++ b/install-local/postgres-for_testing_keycloak_realm_update.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-keycloak-v3
+  namespace: hs-instance
+  labels:
+    app: postgres-keycloak-v3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-keycloak-v3
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: postgres-keycloak-v3
+        role: master
+    spec:
+      volumes:
+        - name: postgres-volume
+          emptyDir: {}
+        - name: postgres-initial-script
+          secret:
+            secretName: postgres-initial-sql
+            defaultMode: 420
+      containers:
+        - name: postgres
+          image: postgres:14.5-alpine
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: adminUser
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: adminPwd
+          resources:
+            limits:
+              cpu: '2'
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: postgres-volume
+              mountPath: /var/lib/postgresql/data
+            - name: postgres-initial-script
+              mountPath: /docker-entrypoint-initdb.d/postgres.initial.script.sql
+              subPath: postgres.initial.script.sql
+            - name: postgres-initial-script
+              mountPath: /docker-entrypoint-initdb.d/postgres.keycloak.initial.script.sql
+              subPath: postgres.keycloak.initial.script.sql
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - '-h'
+                - localhost
+                - '-U'
+                - postgres
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 60
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - '-h'
+                - localhost
+                - '-U'
+                - postgres
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-keycloak-v3
+  namespace: hs-instance
+  labels:
+    app: postgres-keycloak-v3
+spec:
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres-keycloak-v3
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster
+


### PR DESCRIPTION
## Description
Added a testing yaml for postgres on testing keycloak. Rather than rebuild. Because configmaps for keycloak only update on db init not after it has been created.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1353

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
