### PR TITLE
HS-1140 Allow matching multiple monitoring policies for alerts

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/repository/MonitoringPolicyRepository.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/repository/MonitoringPolicyRepository.java
@@ -32,10 +32,10 @@ import org.opennms.horizon.notifications.model.MonitoringPolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface MonitoringPolicyRepository extends JpaRepository<MonitoringPolicy, Long> {
-    Optional<MonitoringPolicy> findByTenantIdAndId(String tenantId, long id);
+    List<MonitoringPolicy> findByTenantIdAndIdIn(String tenantId, Collection<Long> id);
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlertKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlertKafkaConsumerIntegrationTest.java
@@ -49,11 +49,13 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.timeout;
@@ -111,8 +113,8 @@ class AlertKafkaConsumerIntegrationTest {
         monitoringPolicy.setTenantId("opennms-prime");
         monitoringPolicy.setId(1);
         monitoringPolicy.setNotifyByPagerDuty(true);
-        Mockito.when(monitoringPolicyRepository.findByTenantIdAndId(anyString(), anyLong())).thenReturn(
-            Optional.of(monitoringPolicy)
+        Mockito.when(monitoringPolicyRepository.findByTenantIdAndIdIn(anyString(), anyList())).thenReturn(
+            List.of(monitoringPolicy)
         );
 
         String tenantId = "opennms-prime";
@@ -124,7 +126,7 @@ class AlertKafkaConsumerIntegrationTest {
             .setLogMessage("hello")
             .setDatabaseId(1234)
             .setTenantId("opennms-prime")
-            .setMonitoringPolicyId(1)
+            .addMonitoringPolicyId(1)
             .build();
         var producerRecord = new ProducerRecord<String,byte[]>(alertsTopic, alert.toByteArray());
         kafkaProducer.send(producerRecord);

--- a/shared-lib/events/src/main/proto/alerts.proto
+++ b/shared-lib/events/src/main/proto/alerts.proto
@@ -84,7 +84,7 @@ message Alert {
   string ack_user = 17;
   // Acknowledged when?
   uint64 ack_time_ms = 18;
-  uint64 monitoring_policy_id = 19;
+  repeated uint64 monitoring_policy_id = 19;
 }
 
 message AlertList {


### PR DESCRIPTION
## Description
Alerts may have multiple monitoring policies associated with them, so the notification service needs to honor that.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1140

## Flagged for review

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
