### PR TITLE
BTO-255: add changet to avoid liquibase validation error

### DIFF
--- a/alert/src/main/resources/db/changelog/changelog.xml
+++ b/alert/src/main/resources/db/changelog/changelog.xml
@@ -14,4 +14,5 @@
 
     <!-- FIXME: Find a way to only load this data for tests.. not simple as they run in a container -->
     <include file="/db/changelog/hs-0.1.0/data/alert_definition_test_data.xml" />
+    <include file="/db/changelog/hs-0.1.0/tables/update_alert_enum_type.xml" />
 </databaseChangeLog>

--- a/alert/src/main/resources/db/changelog/hs-0.1.0/tables/alert.xml
+++ b/alert/src/main/resources/db/changelog/hs-0.1.0/tables/alert.xml
@@ -23,13 +23,13 @@
 
             <column name="reduction_key" type="text"/>
 
-            <column name="type" type="text"/>
+            <column name="type" type="integer"/>
 
             <column name="counter" type="bigint">
                 <constraints nullable="false"/>
             </column>
 
-            <column name="severity" type="text">
+            <column name="severity" type="integer">
                 <constraints nullable="false"/>
             </column>
 
@@ -56,7 +56,7 @@
             <!-- the key that will match an event to clear the alert -->
             <column name="clear_key" type="text"/>
 
-            <column name="managed_object_type" type="text"/>
+            <column name="managed_object_type" type="integer"/>
 
             <column name="managed_object_instance" type="text"/>
         </createTable>

--- a/alert/src/main/resources/db/changelog/hs-0.1.0/tables/update_alert_enum_type.xml
+++ b/alert/src/main/resources/db/changelog/hs-0.1.0/tables/update_alert_enum_type.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="hs-0.1.0-update_enum_type_to_text" author="benjaminJ">
+        <modifyDataType tableName="alert" columnName="type" newDataType="text" />
+        <modifyDataType tableName="alert" columnName="severity" newDataType="text" />
+        <modifyDataType tableName="alert" columnName="managed_object_type" newDataType="text" />
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Description
Revert enum type change for table alert and put those changes into another changset to avoid liquibase validation error in dev en

## Jira link(s)
- https://issues.opennms.org/browse/BTO-255

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
