### PR TITLE
HS-1380 Send monitoring policy to Notification service over Kafka

### DIFF
--- a/alert/src/main/java/org/opennms/horizon/alertservice/db/entity/MonitorPolicy.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/db/entity/MonitorPolicy.java
@@ -31,6 +31,7 @@ package org.opennms.horizon.alertservice.db.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.EntityListeners;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -46,8 +47,10 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import org.opennms.horizon.alertservice.service.routing.MonitoringPolicyKafkaProducer;
 
 @Entity
+@EntityListeners(MonitoringPolicyKafkaProducer.class)
 @Table(name = "monitoring_policy")
 @Getter
 @Setter

--- a/alert/src/main/java/org/opennms/horizon/alertservice/service/routing/KafkaProducer.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/service/routing/KafkaProducer.java
@@ -28,7 +28,7 @@ public class KafkaProducer implements AlertLifecyleListener {
     private String kafkaTopic;
 
     @Autowired
-    public KafkaProducer(@Qualifier("kafkaAlertProducerTemplate") KafkaTemplate<String, byte[]> kafkaTemplate, AlertService alertService) {
+    public KafkaProducer(@Qualifier("kafkaProducerTemplate") KafkaTemplate<String, byte[]> kafkaTemplate, AlertService alertService) {
         this.kafkaTemplate = kafkaTemplate;
         this.alertService = Objects.requireNonNull(alertService);
     }

--- a/alert/src/main/java/org/opennms/horizon/alertservice/service/routing/MonitoringPolicyKafkaProducer.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/service/routing/MonitoringPolicyKafkaProducer.java
@@ -1,0 +1,39 @@
+package org.opennms.horizon.alertservice.service.routing;
+
+import jakarta.persistence.PostUpdate;
+import jakarta.persistence.PostPersist;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.opennms.horizon.alertservice.db.entity.MonitorPolicy;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MonitoringPolicyKafkaProducer {
+    @Value("${kafka.topics.monitoring-policy}")
+    private String topic;
+
+    @Autowired
+    @Qualifier("kafkaProducerTemplate")
+    private KafkaTemplate<String, byte[]> kafkaTemplate;
+
+    @PostUpdate
+    @PostPersist
+    public void sendMonitoringPolicy(MonitorPolicy monitorPolicy) {
+        // Not all fields are included in this proto, since the Notification service doesn't care about all of them.
+        MonitorPolicyProto proto = MonitorPolicyProto.newBuilder()
+            .setId(monitorPolicy.getId())
+            .setTenantId(monitorPolicy.getTenantId())
+            .setNotifyByEmail(monitorPolicy.getNotifyByEmail())
+            .setNotifyByWebhooks(monitorPolicy.getNotifyByWebhooks())
+            .setNotifyByPagerDuty(monitorPolicy.getNotifyByPagerDuty())
+            .build();
+
+        var record = new ProducerRecord<String, byte[]>(topic, proto.toByteArray());
+        kafkaTemplate.send(record);
+    }
+}
+

--- a/alert/src/main/resources/application.yaml
+++ b/alert/src/main/resources/application.yaml
@@ -51,3 +51,4 @@ kafka:
   topics:
     alert-events: "events"
     new-alerts: "alerts"
+    monitoring-policy: "monitoring-policy"

--- a/alert/src/test/java/org/opennms/horizon/alertservice/service/routing/MonitoringPolicyKafkaProducerTest.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/service/routing/MonitoringPolicyKafkaProducerTest.java
@@ -1,0 +1,86 @@
+package org.opennms.horizon.alertservice.service.routing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.alertservice.db.entity.MonitorPolicy;
+import org.opennms.horizon.alertservice.db.entity.PolicyRule;
+import org.opennms.horizon.alertservice.mapper.MonitorPolicyMapper;
+import org.opennms.horizon.shared.alert.policy.MonitorPolicyProto;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MonitoringPolicyKafkaProducerTest {
+
+    @InjectMocks
+    MonitoringPolicyKafkaProducer producer;
+
+    @Mock
+    KafkaTemplate<String, byte[]> kafkaProducerTemplate;
+
+    @Captor
+    ArgumentCaptor<ProducerRecord<String, byte[]>> producerCaptor;
+
+    String topic = "some-monitoring-policy-topic";
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(producer, "topic", topic);
+    }
+
+    @Test
+    public void sendsUpdatedMonitoringPolicyToKafka() throws InvalidProtocolBufferException {
+        MonitorPolicy policy = new MonitorPolicy();
+        policy.setId(1L);
+        policy.setTenantId("T1");
+        policy.setNotifyByPagerDuty(true);
+        policy.setNotifyByEmail(false);
+        policy.setNotifyByWebhooks(false);
+
+        // These fields aren't needed by the notification service, so we should avoid sending them.
+        policy.setName("Testing Policy");
+        policy.setMemo("Some memo");
+        policy.setRules(List.of(mock(PolicyRule.class)));
+        policy.setTags(mock(JsonNode.class));
+        policy.setNotifyInstruction("Instructions");
+
+        producer.sendMonitoringPolicy(policy);
+
+        verify(kafkaProducerTemplate, times(1)).send(producerCaptor.capture());
+        assertEquals(topic, producerCaptor.getValue().topic());
+        MonitorPolicyProto sentProto = MonitorPolicyProto.parseFrom(producerCaptor.getValue().value());
+        assertEquals(1L, sentProto.getId());
+        assertEquals("T1", sentProto.getTenantId());
+        assertTrue(sentProto.getNotifyByPagerDuty());
+        assertFalse(sentProto.getNotifyByEmail());
+        assertFalse(sentProto.getNotifyByWebhooks());
+
+        // Check the unneeded fields are missing
+        assertTrue(sentProto.getName().isEmpty());
+        assertTrue(sentProto.getMemo().isEmpty());
+        assertTrue(sentProto.getRulesList().isEmpty());
+        assertTrue(sentProto.getTagsList().isEmpty());
+        assertTrue(sentProto.getNotifyInstruction().isEmpty());
+    }
+}

--- a/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/BackgroundSteps.java
+++ b/alert/src/test/java/org/opennms/horizon/alertservice/stepdefs/BackgroundSteps.java
@@ -41,6 +41,7 @@ public class BackgroundSteps {
     private String kafkaBootstrapUrl;
     private String eventTopic;
     private String alertTopic;
+    private String monitoringPolicyTopic;
 
 
     @Given("Kafka event topic {string}")
@@ -51,6 +52,11 @@ public class BackgroundSteps {
     @Given("Kafka alert topic {string}")
     public void createKafkaTopicForAlerts(String alertTopic) {
         this.alertTopic = alertTopic;
+    }
+
+    @Given("Kafka monitoring policy topic {string}")
+    public void createKafkaTopicForMonitoringPolicy(String monitoringPolicyTopic) {
+        this.monitoringPolicyTopic = monitoringPolicyTopic;
     }
 
     @Given("Application base HTTP URL in system property {string}")

--- a/alert/src/test/resources/org/opennms/horizon/alertservice/monitor-policy.feature
+++ b/alert/src/test/resources/org/opennms/horizon/alertservice/monitor-policy.feature
@@ -7,6 +7,8 @@ Feature: Monitor policy gRPC Functionality
     Given Kafka bootstrap URL in system property "kafka.bootstrap-servers"
     Given Kafka event topic "events"
     Given Kafka alert topic "alerts"
+    Given Kafka monitoring policy topic "monitoring-policy"
+    Given Monitoring policy kafka consumer
 
   Scenario: The default monitoring policy should exist
     Given Tenant id "different-tenant"
@@ -30,3 +32,4 @@ Feature: Monitor policy gRPC Functionality
     Then Create a new policy with give parameters
     Then Verify the new policy has been created
     Then List policy should contain 1
+    Then Verify monitoring policy for tenant "test-tenant" is sent to Kafka


### PR DESCRIPTION
## Description
The BFF sends the full monitoring policy to the Alert service, but portions of it are used in the Notification service to route notifications for alerts. This commit will send a minimal version of the monitoring policy to the Notification service over Kafka.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1380

## Flagged for review


## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
