### PR TITLE
Only call pagerDuty once if there are multiple monitoring policies for an alert that have the pager duty flag set

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationService.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationService.java
@@ -59,17 +59,23 @@ public class NotificationService {
             alert.getMonitoringPolicyIdList()
         );
 
-        dbPolicies.forEach(policy -> {
+        boolean notifyPagerDuty = false;
+
+        for (MonitoringPolicy policy : dbPolicies) {
             if (policy.isNotifyByPagerDuty()) {
-                // Wrap in a try/catch, we don't want a failure to notify via PagerDuty to prevent us from sending an
-                // email notification, etc.
-                try {
-                    pagerDutyAPI.postNotification(alert);
-                } catch (NotificationException e) {
-                    log.warn("Unable to send alert to PagerDuty: {}", alert, e);
-                }
+                notifyPagerDuty = true;
             }
-        });
+        }
+
+        if (notifyPagerDuty) {
+            // Wrap in a try/catch, we don't want a failure to notify via PagerDuty to prevent us from sending an
+            // email notification, etc.
+            try {
+                pagerDutyAPI.postNotification(alert);
+            } catch (NotificationException e) {
+                log.warn("Unable to send alert to PagerDuty: {}", alert, e);
+            }
+        }
 
         if (dbPolicies.isEmpty()) {
             log.debug("No monitoring policy found, dropping alert: {}", alert);

--- a/notifications/src/test/java/org/opennms/horizon/notifications/service/NotificationServiceImplTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/service/NotificationServiceImplTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 
 @RunWith(MockitoJUnitRunner.class)
-public class NotificationsServiceImplTest {
+public class NotificationServiceImplTest {
 
     @InjectMocks
     NotificationService notificationService;
@@ -140,7 +140,7 @@ public class NotificationsServiceImplTest {
 
         notificationService.postNotification(alert);
 
-        Mockito.verify(pagerDutyAPI, times(2)).postNotification(alert);
+        Mockito.verify(pagerDutyAPI, times(1)).postNotification(alert);
     }
 
     @Test


### PR DESCRIPTION
## Description
Fix a defect where pager duty will be called multiple times for a single alert if there are multiple policies that have the pager duty flag set.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1389

## Flagged for review
n/a

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
