### PR TITLE
Add support for JSON logging for spring boot services

### DIFF
--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -267,6 +267,9 @@
                             <jvmFlag>--add-opens=java.base/java.text=ALL-UNNAMED</jvmFlag>
                             <jvmFlag>--add-opens=java.desktop/java.awt.font=ALL-UNNAMED</jvmFlag>
                         </jvmFlags>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
                     </container>
                 </configuration>
                 <executions>

--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -41,6 +41,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>grpc-common-constants</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/build-tools/basic/mk-docker-images.sh
+++ b/build-tools/basic/mk-docker-images.sh
@@ -72,7 +72,7 @@ time {
 	echo "==="
 	echo "=== DATACHOICES IMAGE"
 	echo "==="
-	mvn -f events install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-datachoices:local-basic
+	mvn -f datachoices install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-datachoices:local-basic
 
 	echo ""
 	echo "==="

--- a/charts/opennms-operator/.helmignore
+++ b/charts/opennms-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/opennms/.helmignore
+++ b/charts/opennms/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -35,6 +35,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Alert.ServiceName }}
           image: {{ .Values.OpenNMS.Alert.Image }}
@@ -61,6 +65,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.Alert.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Alert.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Alert.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -60,6 +60,9 @@ spec:
                   key: alertPwd
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Alert.Port }}

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -68,6 +68,9 @@ spec:
               value: "{{ .Values.OpenNMS.Alert.ServiceName }}:{{ .Values.OpenNMS.Alert.GrpcPort }}"
             - name: GRPC_URL_MINION_CERTIFICATE_MANAGER
               value: "{{ .Values.OpenNMS.MinionCertificateManager.ServiceName }}:{{ .Values.OpenNMS.MinionCertificateManager.Port }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - containerPort: {{ .Values.OpenNMS.API.Port }}
           {{/*  TODO    livenessProbe:*/}}

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                       - {{ .Values.NodeRestrictions.Value }}
       {{ end }}
       terminationGracePeriodSeconds: 120
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.API.ServiceName }}
           image: {{ .Values.OpenNMS.API.Image }}
@@ -76,6 +80,9 @@ spec:
             requests:
               cpu: "{{ .Values.OpenNMS.API.Resources.Requests.Cpu }}"
               memory: "{{ .Values.OpenNMS.API.Resources.Requests.Memory }}"
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.API.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -35,6 +35,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.DataChoices.ServiceName }}
           image: {{ .Values.OpenNMS.DataChoices.Image }}
@@ -65,6 +69,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.DataChoices.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.DataChoices.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.DataChoices.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -64,6 +64,9 @@ spec:
               value: "http://{{ .Values.Keycloak.ServiceName }}:8080/auth/"
             - name: KEYCLOAK_REALM
               value: "{{ .Values.Keycloak.RealmName }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.DataChoices.Port }}

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -66,6 +66,9 @@ spec:
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: GRPC_URL_INVENTORY
               value: "{{ .Values.OpenNMS.Inventory.ServiceName }}:{{ .Values.OpenNMS.Inventory.GrpcPort }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Events.Port }}

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Events.ServiceName }}
           image: {{ .Values.OpenNMS.Events.Image }}
@@ -67,6 +71,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.Events.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Events.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Events.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -73,6 +73,9 @@ spec:
                 secretKeyRef:
                   key: encryptionKey
                   name: {{ .Values.OpenNMS.Inventory.ServiceName }}-encryption-key
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Inventory.Port }}

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Inventory.ServiceName }}
           image: {{ .Values.OpenNMS.Inventory.Image }}
@@ -74,6 +78,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.Inventory.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Inventory.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Inventory.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MetricsProcessor.ServiceName }}
           image: {{ .Values.OpenNMS.MetricsProcessor.Image }}
@@ -53,6 +57,9 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.MetricsProcessor.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -54,6 +54,9 @@ spec:
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: CORTEX_WRITE_URL
               value: {{ .Values.Cortex.Protocol }}://{{ .Values.Cortex.Host }}:{{ .Values.Cortex.Port }}{{ .Values.Cortex.PathWrite }}
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: 8080

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -56,6 +56,9 @@ spec:
               value: "{{ .Values.OpenNMS.MinionGateway.ServiceName }}"
             - name: GRPC_DOWNSTREAM_PORT
               value: "{{ .Values.OpenNMS.MinionGateway.GrpcPort }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.Port }}

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}
           image: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.Image }}
@@ -62,4 +66,7 @@ spec:
             requests:
               cpu: "{{ .Values.OpenNMS.MinionGatewayGrpcProxy.Resources.Requests.Cpu }}"
               memory: "{{ .Values.OpenNMS.MinionGatewayGrpcProxy.Resources.Requests.Memory }}"
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
 {{- end }}

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -44,6 +44,9 @@ spec:
             name: minion-gateway-ignite-config
         - name: ignite-volume
           emptyDir: {}
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MinionGateway.ServiceName }}
           image: {{ .Values.OpenNMS.MinionGateway.Image }}
@@ -80,6 +83,8 @@ spec:
               mountPath: "/app/resources/ignite"
             - name: ignite-volume
               mountPath: /ignite
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
           resources:
             limits:
               cpu: "{{ .Values.OpenNMS.MinionGateway.Resources.Limits.Cpu }}"

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -69,6 +69,9 @@ spec:
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups
               value: "false"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.MinionGateway.Port }}

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -72,6 +72,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.Keycloak.ServiceName }}-initial-admin
                   key: password
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Notification.GrpcPort }}

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -35,6 +35,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Notification.ServiceName }}
           image: {{ .Values.OpenNMS.Notification.Image }}
@@ -71,6 +75,9 @@ spec:
           ports:
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Notification.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Notification.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
@@ -4,3 +4,33 @@ metadata:
   name: spring-boot-app-config
   namespace: {{ .Release.Namespace }}
 data:
+  logback-spring.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    
+        <springProfile name="json-logging">
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+                    <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                        <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                            <prettyPrint>${CONSOLE_JSON_PRETTY:-false}</prettyPrint>
+                        </jsonFormatter>
+                        <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                        <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                        <appendLineSeparator>true</appendLineSeparator>
+                    </layout>
+                </encoder>
+            </appender>
+        </springProfile>
+    
+        <springProfile name="!json-logging">
+            <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        </springProfile>
+    
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </configuration>
+  application-json-logging.properties: |
+    spring.main.banner-mode=off

--- a/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spring-boot-app-config
+  namespace: {{ .Release.Namespace }}
+data:

--- a/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spring-boot-env
+  namespace: {{ .Release.Namespace }}
+data:

--- a/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
@@ -4,3 +4,6 @@ metadata:
   name: spring-boot-env
   namespace: {{ .Release.Namespace }}
 data:
+{{- if .Values.OpenNMS.global.enableJsonLogging }}
+  SPRING_PROFILES_ACTIVE: json-logging
+{{- end }}

--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -3,6 +3,8 @@ Port: 443 #set depending on TLS.Enabled and the Ingress ports, do not change
 Protocol: https #set depending on TLS.Enabled, do not change
 OpenShift: false
 OpenNMS:
+  global:
+    enableJsonLogging: false
   API:
     Path: /api
     ServiceName: opennms-rest-server

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -265,6 +265,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -34,6 +34,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/datachoices/src/main/java/org/opennms/horizon/datachoices/service/DataChoicesService.java
+++ b/datachoices/src/main/java/org/opennms/horizon/datachoices/service/DataChoicesService.java
@@ -80,7 +80,7 @@ public class DataChoicesService {
         List<String> tenantIds = repository.findAll().stream()
             .map(DataChoices::getTenantId).distinct().collect(Collectors.toList());
 
-        System.out.println("tenantIds.size() = " + tenantIds.size());
+        log.info("tenantIds.size() = " + tenantIds.size());
 
 //        todo: perform queries and send HTTP request to usage-stats-handler
     }

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -27,6 +27,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.horizon.events</groupId>
             <artifactId>persistence</artifactId>
             <version>${project.version}</version>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -140,6 +140,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/inventory/docker-it/pom.xml
+++ b/inventory/docker-it/pom.xml
@@ -17,10 +17,6 @@
         Test Containers are used to spin up containers and exercise the public endpoints.
     </description>
 
-    <properties>
-        <application.docker.image.name>opennms/horizon-stream-inventory</application.docker.image.name>
-    </properties>
-
     <dependencies>
         <!-- Dependency to ensure the docker image is built before running the tests -->
         <dependency>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -23,6 +23,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -337,6 +337,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -97,6 +97,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -83,6 +83,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -142,6 +142,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -58,6 +58,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>horizon-shaded-grpc-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.horizon.minion.gateway</groupId>
             <artifactId>minion-gateway-ignite-detector-api</artifactId>
             <version>${project.version}</version>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -193,6 +193,9 @@
                             <jvmFlag>--add-opens=java.base/java.lang=ALL-UNNAMED</jvmFlag>
                             <jvmFlag>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED</jvmFlag>
                         </jvmFlags>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
                     </container>
                 </configuration>
                 <executions>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -341,6 +341,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -39,6 +39,11 @@
     </dependencyManagement>
 	<dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${jupiter.version}</version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -101,6 +101,7 @@
         <keycloak.version>20.0.3</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
         <log4j2.version>2.19.0</log4j2.version>
+        <logback.contrib.version>0.1.5</logback.contrib.version>
         <logcaptor.version>2.7.10</logcaptor.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <maven-resources.version>3.3.0</maven-resources.version>
@@ -964,7 +965,16 @@
                 <artifactId>kafka</artifactId>
                 <version>${testcontainers.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-json-classic</artifactId>
+                <version>${logback.contrib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-jackson</artifactId>
+                <version>${logback.contrib.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -27,6 +27,7 @@
 
         <!-- Jib properties -->
         <application.jib.defaultGoal>dockerBuild</application.jib.defaultGoal> <!-- dockerBuild for local only; build to push also -->
+        <application.jib.app.config>/app/config</application.jib.app.config>
         <application.docker.skip>false</application.docker.skip>
         <application.docker.image>${application.docker.image.name}:${application.docker.image.tag}</application.docker.image>
         <!-- application.docker.image.name MUST be set by child modules that use jib-maven-plugin. -->

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -40,6 +40,11 @@
 	<dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>horizon-shaded-grpc-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -257,6 +257,13 @@
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
+				<configuration>
+					<container>
+						<extraClasspath>
+							<entry>${application.jib.app.config}</entry>
+						</extraClasspath>
+					</container>
+				</configuration>
 
 				<executions>
 					<execution>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -43,6 +43,7 @@
         <module>shaded-grpc-core</module>
         <module>minion-certificate-manager-api</module>
         <module>horizon-common-tag</module>
+        <module>spring-boot-logback-json</module>
     </modules>
 
     <build>

--- a/shared-lib/spring-boot-logback-json/pom.xml
+++ b/shared-lib/spring-boot-logback-json/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms.horizon.shared</groupId>
+        <artifactId>shared-lib</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-boot-logback-json</artifactId>
+    <name>OpenNMS Horizon Stream :: Spring Boot Support :: Logback JSON</name>
+
+    <dependencies>
+        <!-- Since we need to support a few different versions of Spring Boot,
+             we don't include spring-boot-starter-logging since we can't specify
+             its version here. It is the default logger, anyway, so we should
+             be fine. -->
+        <!-- The same goes for logback-classic and logback-core. We don't add
+             these directly here so we don't conflict with what is in
+             spring-boot-starter-logging. Also avoiding this in rest-server tests:
+
+		java.lang.NoClassDefFoundError: org/slf4j/impl/StaticLoggerBinder
+			at org.springframework.boot.logging.logback.LogbackLoggingSystem.getLoggerContext(LogbackLoggingSystem.java:293)
+             -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/tooling/ignite-tool/pom.xml
+++ b/tooling/ignite-tool/pom.xml
@@ -36,6 +36,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>task-set-service-api</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
**I highly suggest reviewing commit by commit.** Please also see the questions section further down. This is my first PR for horizon-stream, so I'll be extremeley happy with any guidance/etc. that can be provided.

Supporting infrastructure:
- [Add spring-boot-app-config ConfigMap that is mounted in /app/config](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/1f7fc420074419342ad36f03b2273853d3e149a8) 
- [Add spring-boot-env ConfigMap that adds env to all Spring Boot services](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/bd9572ad9caa41f51d6352615e912666669fd1b7)

The parts that actually matter:
- [HS-1419](https://opennms.atlassian.net/browse/HS-1419)[: Add spring-boot-logback-json to support JSON logging](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/a8b72b15a0aba3c22f845c702d418b10c4ec2fc0) 
- [HS-1419](https://opennms.atlassian.net/browse/HS-1419)[: Add spring-boot-logback-json to our spring-boot services](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/c02c22bfb031ecaa97931bbf49d2ec1c3072239d)

Cleanups I did along the way: 
- [This looks like it accidentally had application.docker.image.name set](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/b17482a9ae93874e255624e091a3c44fbec8f166) 
- [Ooops, looks like we were building events and tagging it as datachoices](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/89cb11ae8406f966213f87eadf1956f105fe35f3)
- [Clean up a System.out.println](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/0d4d59c9307edeac0578d2c3059665cbe5439ba0)
- [Add .helmignore files so vim's .swp files don't mess up Tilt/Helm](https://github.com/OpenNMS-Cloud/horizon-stream/pull/971/commits/8a883fdffc28e5ea476e601315cd2267a67a2a7b)

A note on why `logback-spring.xml` is used instead of `logback.xml`: https://github.com/spring-projects/spring-boot/issues/15649

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Support an option to enable JSON logging for Spring Boot-based services and enable it by default in our Helm chart. This will make it easy for log aggregation tools to consume log output in our dev/stg/prod clusters, especially for multi-line log content, log messages with stack traces, etc..

Also cleaned up a bug or two along the way.

## Key questions for reviewers
- Are the two new global config maps for Spring Boot containers that I introduced a good structure? Names okay?
- Is `spring-boot-logback-json` a good name for the library? Actually, it's not even a library, just a reference to two JARs. Should it be a `pom` artifact instead?
- Are we okay with JSON logging being disabled by default? This seemed a bit more user-friendly for local development, in particular.
- Are we okay with the use of Spring profiles? This is activated with `SPRING_PROFILES_ACTIVE=json-logging` environment variable.
- Are we okay with global Helm values? Is `OpenNMS.global.enableJsonLogging` a good name? Note: I'm trying to fit into the existing naming structure, but also trying to adhere to the [Helm value naming conventions](https://helm.sh/docs/chart_best_practices/values/#naming-conventions) for anything new. We should come back and lowercase the initial character in our values before we get too far down the road, BTW.

## (near) future improvements
- Get JSON log support working in `rest-server`. It's running an older 2.x version of Spring Boot, so the solution as we have here doesn't work for it.
- Add JSON log support to the Minion
- Add things like the tenant ID, location, etc. to MDC

## Jira link(s)
- https://issues.opennms.org/browse/HS-1419

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts

## Other things that helped out
* https://dev.to/luafanti/spring-boot-logging-with-loki-promtail-and-grafana-loki-stack-aep
* https://vishnu-g.medium.com/creating-custom-spring-boot-starter-to-solve-cross-cutting-concerns-d76f555beb64
* https://medium.com/@asegu/build-your-own-spring-boot-starter-90ad1f426227
* https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin

## Other approaches
* https://github.com/blueswen/spring-boot-observability#loki-docker-driver
* https://spring.io/blog/2022/10/12/observability-with-spring-boot-3

## Interesting thing I stumbled across that we use
* https://github.com/Hakky54/log-captor -- to help capture logs for tests!

## For future minion work
* https://ops4j1.jira.com/wiki/spaces/paxlogging/pages/499286109/Configuration
* https://github.com/ops4j/org.ops4j.pax.logging/blob/main/pax-logging-logback/pom.xml
* https://stackoverflow.com/a/24685621
* https://ops4j1.jira.com/wiki/spaces/paxlogging/pages/499580944/Using+Pax+Logging+API+without+backend

[HS-1419]: https://opennms.atlassian.net/browse/HS-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HS-1419]: https://opennms.atlassian.net/browse/HS-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ