### PR TITLE
[HS-1429] Disabled shallow clones for operator and ui workflows

### DIFF
--- a/.github/workflows/base-image-update.yml
+++ b/.github/workflows/base-image-update.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Log in to the Container registry
         # Need to pull images from github container registry first.

--- a/.github/workflows/feature-alert.yml
+++ b/.github/workflows/feature-alert.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-datachoices.yml
+++ b/.github/workflows/feature-datachoices.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-events.yml
+++ b/.github/workflows/feature-events.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-inventory.yml
+++ b/.github/workflows/feature-inventory.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-metrics-processor.yml
+++ b/.github/workflows/feature-metrics-processor.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-minion-gateway-grpc-proxy.yml
+++ b/.github/workflows/feature-minion-gateway-grpc-proxy.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-minion-gateway.yml
+++ b/.github/workflows/feature-minion-gateway.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-minion.yml
+++ b/.github/workflows/feature-minion.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-notifications.yml
+++ b/.github/workflows/feature-notifications.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-operator.yml
+++ b/.github/workflows/feature-operator.yml
@@ -31,7 +31,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-        # Is required to call actions.
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/feature-parent-pom.yml
+++ b/.github/workflows/feature-parent-pom.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/feature-rest-server.yml
+++ b/.github/workflows/feature-rest-server.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/feature-shared-lib.yml
+++ b/.github/workflows/feature-shared-lib.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/feature-ui.yml
+++ b/.github/workflows/feature-ui.yml
@@ -33,7 +33,8 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-        # Is required to call actions.
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarCloud analysis
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

This makes SonarCloud happy. Also enabled shallow clone for base-image-update, which does not do any SonarCloud scanning

## Jira link(s)
- https://issues.opennms.org/browse/HS-1429

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
