### PR TITLE
HS-1330: Add default tag for discovery forms

### DIFF
--- a/ui/src/components/Common/BasicAutocomplete.vue
+++ b/ui/src/components/Common/BasicAutocomplete.vue
@@ -177,7 +177,8 @@ const reset = () => {
 }
 
 defineExpose({
-  reset
+  reset,
+  addValue
 })
 </script>
 

--- a/ui/src/components/Discovery/DiscoveryAzureForm.vue
+++ b/ui/src/components/Discovery/DiscoveryAzureForm.vue
@@ -111,6 +111,9 @@ const tags = computed(() => (props.discovery?.id ? discoveryQueries.tagsByActive
 onMounted(() => {
   if (props.discovery?.id) {
     discoveryQueries.getTagsByActiveDiscoveryId(props.discovery.id)
+  } else {
+    // add default tag to azure form
+    tagsAutocompleteRef.value.addValue('default')
   }
 })
 

--- a/ui/src/components/Discovery/DiscoverySnmpForm.vue
+++ b/ui/src/components/Discovery/DiscoverySnmpForm.vue
@@ -128,6 +128,9 @@ const tagsAutocompleteRef = ref()
 onMounted(() => {
   if (props.discovery?.id) {
     discoveryQueries.getTagsByActiveDiscoveryId(props.discovery.id)
+  } else {
+    // add default tag to snmp form
+    tagsAutocompleteRef.value.addValue('default')
   }
 })
 

--- a/ui/src/components/Discovery/DiscoverySyslogSNMPTrapsForm.vue
+++ b/ui/src/components/Discovery/DiscoverySyslogSNMPTrapsForm.vue
@@ -118,6 +118,9 @@ const tags = computed(() => (props.discovery?.id ? discoveryQueries.tagsByPassiv
 onMounted(() => {
   if (props.discovery?.id) {
     discoveryQueries.getTagsByPassiveDiscoveryId(props.discovery.id)
+  } else {
+    // add default tag to syslog form
+    tagsAutocompleteRef.value.addValue('default')
   }
 })
 

--- a/ui/tests/Discovery/discoveryAzureForm.test.ts
+++ b/ui/tests/Discovery/discoveryAzureForm.test.ts
@@ -12,7 +12,7 @@ const azureTestPayload: AzureActiveDiscoveryCreateInput = {
   directoryId: 'dir1',
   subscriptionId: 'sub1',
   location: 'Default',
-  tags: []
+  tags: [{ name: 'default' }]
 }
 
 const wrapper = mount({

--- a/ui/tests/Discovery/discoverySyslogSNMPTrapsForm.test.ts
+++ b/ui/tests/Discovery/discoverySyslogSNMPTrapsForm.test.ts
@@ -8,7 +8,7 @@ describe('DiscoverySyslogSNMPTrapsForm', () => {
   beforeAll(() => {
     wrapper = mountWithPiniaVillus({
       component: DiscoverySyslogSNMPTrapsForm,
-      shallow: true,
+      shallow: false,
       props: { successCallback: () => ({}), cancel: () => ({}) },
       global: {
         directives: {


### PR DESCRIPTION
## Description
For azure, snmp, syslog discovery forms, we now automatically add a 'default' tag.
Tag can be removed by user.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1330

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
