### PR TITLE
[HS-1480] Add Udpgen container that sends flows traffic to test minion

### DIFF
--- a/external-it/hs-system-tests/pom.xml
+++ b/external-it/hs-system-tests/pom.xml
@@ -26,7 +26,7 @@
         <azure.identity.version>1.8.2</azure.identity.version>
         <lombok.version>1.18.26</lombok.version>
         <jna.version>5.12.1</jna.version>
-        <testcontainers.version>1.15.3</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
 
     <build>

--- a/external-it/hs-system-tests/src/test/java/org/opennms/horizon/systemtests/CucumberHooks.java
+++ b/external-it/hs-system-tests/src/test/java/org/opennms/horizon/systemtests/CucumberHooks.java
@@ -26,7 +26,6 @@ public class CucumberHooks {
             return;
         }
 
-        System.out.println("CLOUD BEFORE STEP");
         Selenide.open(SecretsStorage.portalHost);
         PortalLoginPage.closeCookieHeader();
         PortalLoginPage.setUsername(SecretsStorage.adminUserEmail);
@@ -37,7 +36,7 @@ public class CucumberHooks {
         PortalCloudPage.verifyThatUserLoggedIn();
 
         long timeCode = Instant.now().toEpochMilli();
-        ;
+
         String instanceName = "Cloud-env" + timeCode;
         PortalCloudPage.clickAddInstance();
         AddNewInstancePopup.setInstanceName(instanceName);

--- a/external-it/hs-system-tests/src/test/java/org/opennms/horizon/systemtests/steps/cloud/UdpGenSteps.java
+++ b/external-it/hs-system-tests/src/test/java/org/opennms/horizon/systemtests/steps/cloud/UdpGenSteps.java
@@ -1,0 +1,27 @@
+package org.opennms.horizon.systemtests.steps.cloud;
+
+import io.cucumber.java.en.Then;
+import lombok.SneakyThrows;
+import org.opennms.horizon.systemtests.CucumberHooks;
+import testcontainers.UpdGenContainer;
+
+import java.util.Arrays;
+
+public class UdpGenSteps {
+    @SneakyThrows
+    @Then("send {int} packets of {string} traffic to {int} port")
+    public void generateNetflow9(Integer number, String flowType, Integer port) {
+        if (!Arrays.asList("netflow9", "netflow5", "ipfix").contains(flowType)) {
+            throw new RuntimeException("Do not support this type");
+        }
+
+        try (
+            UpdGenContainer updGenContainer = new UpdGenContainer(
+                CucumberHooks.MINIONS.get(0).getUdpPortBinding(port),
+                flowType,
+                number)
+        ) {
+            updGenContainer.start();
+        }
+    }
+}

--- a/external-it/hs-system-tests/src/test/java/testcontainers/UpdGenContainer.java
+++ b/external-it/hs-system-tests/src/test/java/testcontainers/UpdGenContainer.java
@@ -1,0 +1,33 @@
+package testcontainers;
+
+import lombok.SneakyThrows;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.net.InetAddress;
+import java.time.Duration;
+
+public class UpdGenContainer extends GenericContainer<UpdGenContainer> {
+    @SneakyThrows
+    public UpdGenContainer(Object port, String flowType, Object numberOfPackages) {
+        super("opennms/udpgen:latest");
+        withNetwork(Network.SHARED)
+            .withNetworkAliases("horizon-stream")
+            .withCommand("/udpgen",
+                "-h", InetAddress.getLocalHost().getHostAddress(),
+                "-p", port.toString(),
+                "-x", flowType,
+                "-r", "10", // packages per second
+                "-s", numberOfPackages.toString()
+            ).withLogConsumer(
+                new Slf4jLogConsumer(LoggerFactory.getLogger(UpdGenContainer.class))
+            )
+            .waitingFor(
+                Wait.forLogMessage(".*Sent " + numberOfPackages + " packets.*", 1)
+                    .withStartupTimeout(Duration.ofSeconds(Integer.parseInt(numberOfPackages.toString()) / 10 + 60))
+            );
+    }
+}


### PR DESCRIPTION
- `Update` testcontainers version to the latest one (to expose udp ports)
- `Add` UdpGen container 
- `Update` MinionContainer (expose UDP ports + method to obtain mapped UDP port)
- `Add` steps for UdpGen to send flows data to test minion


Overall: now we can check cases with Flows graphs.
