### PR TITLE
HS-1476 Prevent creating multiple nodes when receiving trap events

### DIFF
--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
@@ -28,10 +28,8 @@
 
 package org.opennms.horizon.inventory.component;
 
-import com.google.common.base.Strings;
-import com.google.protobuf.InvalidProtocolBufferException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Arrays;
+
 import org.opennms.horizon.events.proto.Event;
 import org.opennms.horizon.inventory.dto.MonitoredState;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
@@ -46,7 +44,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
+import com.google.common.base.Strings;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -76,7 +77,7 @@ public class NodeMonitoringManager {
                 Node node = nodeService.createNode(createDTO, ScanType.NODE_SCAN, tenantId);
                 passiveDiscoveryService.sendNodeScan(node);
             }
-        } catch (InvalidProtocolBufferException e) {
+        } catch (Exception e) {
             log.error("Error while parsing Event. Payload: {}", Arrays.toString(data), e);
         }
     }

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
@@ -33,12 +33,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.opennms.horizon.events.proto.Event;
-import org.opennms.horizon.inventory.dto.IpInterfaceDTO;
 import org.opennms.horizon.inventory.dto.MonitoredState;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.model.Node;
-import org.opennms.horizon.inventory.service.IpInterfaceService;
 import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.discovery.PassiveDiscoveryService;
 import org.opennms.horizon.shared.events.EventConstants;
@@ -49,7 +47,6 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -57,7 +54,6 @@ import java.util.Optional;
 @PropertySource("classpath:application.yml")
 public class NodeMonitoringManager {
     private final NodeService nodeService;
-    private final IpInterfaceService ipInterfaceService;
     private final PassiveDiscoveryService passiveDiscoveryService;
 
     @KafkaListener(topics = "${kafka.topics.internal-events}", concurrency = "1")
@@ -71,20 +67,14 @@ public class NodeMonitoringManager {
                 var tenantId = event.getTenantId();
                 log.debug("Create new node from event with interface: {}, location: {} and tenant: {}", event.getIpAddress(), event.getLocation(), tenantId);
 
-                Optional<IpInterfaceDTO> ipInterfaceOp = ipInterfaceService.findByIpAddressAndLocationAndTenantId(event.getIpAddress(), event.getLocation(), event.getTenantId());
-                if(ipInterfaceOp.isPresent()) {
-                    IpInterfaceDTO ipInterface = ipInterfaceOp.get();
-                    log.warn("IP address {} already exists in the system and belong to device with ID {}", event.getIpAddress(), ipInterface.getNodeId());
-                } else {
-                    NodeCreateDTO createDTO = NodeCreateDTO.newBuilder()
-                        .setLocation(event.getLocation())
-                        .setManagementIp(event.getIpAddress())
-                        .setLabel("trap-" + event.getIpAddress())
-                        .setMonitoredState(MonitoredState.DETECTED)
-                        .build();
-                    Node node = nodeService.createNode(createDTO, ScanType.NODE_SCAN, tenantId);
-                    passiveDiscoveryService.sendNodeScan(node);
-                }
+                NodeCreateDTO createDTO = NodeCreateDTO.newBuilder()
+                    .setLocation(event.getLocation())
+                    .setManagementIp(event.getIpAddress())
+                    .setLabel("trap-" + event.getIpAddress())
+                    .setMonitoredState(MonitoredState.DETECTED)
+                    .build();
+                Node node = nodeService.createNode(createDTO, ScanType.NODE_SCAN, tenantId);
+                passiveDiscoveryService.sendNodeScan(node);
             }
         } catch (InvalidProtocolBufferException e) {
             log.error("Error while parsing Event. Payload: {}", Arrays.toString(data), e);

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/component/NodeMonitoringManager.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import org.opennms.horizon.events.proto.Event;
 import org.opennms.horizon.inventory.dto.MonitoredState;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
+import org.opennms.horizon.inventory.exception.EntityExistException;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.service.NodeService;
@@ -45,6 +46,7 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
+import com.google.protobuf.InvalidProtocolBufferException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,8 +79,10 @@ public class NodeMonitoringManager {
                 Node node = nodeService.createNode(createDTO, ScanType.NODE_SCAN, tenantId);
                 passiveDiscoveryService.sendNodeScan(node);
             }
-        } catch (Exception e) {
+        } catch (InvalidProtocolBufferException e) {
             log.error("Error while parsing Event. Payload: {}", Arrays.toString(data), e);
+        } catch (EntityExistException e) {
+            log.error("Duplicated device error.", e);
         }
     }
 }

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/exception/EntityExistException.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/exception/EntityExistException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2023 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2023 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.exception;
+
+public class EntityExistException extends Exception {
+    public EntityExistException(String message) {
+        super(message);
+    }
+}

--- a/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/NodeGrpcService.java
+++ b/inventory/main/src/main/java/org/opennms/horizon/inventory/grpc/NodeGrpcService.java
@@ -102,18 +102,19 @@ public class NodeGrpcService extends NodeServiceGrpc.NodeServiceImplBase {
     public void createNode(NodeCreateDTO request, StreamObserver<NodeDTO> responseObserver) {
         String tenantId = tenantLookup.lookupTenantId(Context.current()).orElseThrow();
         boolean valid = validateInput(request, tenantId, responseObserver);
-
         if (valid) {
             try {
                 Node node = nodeService.createNode(request, ScanType.NODE_SCAN, tenantId);
                 responseObserver.onNext(nodeMapper.modelToDTO(node));
                 responseObserver.onCompleted();
-
-
                 // Asynchronously send task sets to Minion
                 executorService.execute(() -> sendNodeScanTaskToMinion(node));
             } catch (EntityExistException e) {
-                responseObserver.onError(e);
+                Status status = Status.newBuilder()
+                    .setCode(Code.ALREADY_EXISTS_VALUE)
+                    .setMessage(IP_ADDRESS_ALREADY_EXISTS_FOR_LOCATION_MSG)
+                    .build();
+                responseObserver.onError(StatusProto.toStatusRuntimeException(status));
             }
         }
     }
@@ -344,16 +345,6 @@ public class NodeGrpcService extends NodeServiceGrpc.NodeServiceImplBase {
                     .setMessage("Bad management_ip: " + request.getManagementIp())
                     .build();
                 responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-            } else {
-                Optional<IpInterfaceDTO> optionalIpInterface = ipInterfaceService.findByIpAddressAndLocationAndTenantId(request.getManagementIp(), request.getLocation(), tenantId);
-                if (optionalIpInterface.isPresent()) {
-                    valid = false;
-                    Status status = Status.newBuilder()
-                        .setCode(Code.ALREADY_EXISTS_VALUE)
-                        .setMessage(IP_ADDRESS_ALREADY_EXISTS_FOR_LOCATION_MSG)
-                        .build();
-                    responseObserver.onError(StatusProto.toStatusRuntimeException(status));
-                }
             }
         }
 

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/component/NodeMonitoringManagerTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/component/NodeMonitoringManagerTest.java
@@ -29,9 +29,11 @@
 package org.opennms.horizon.inventory.component;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -47,6 +49,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.opennms.horizon.events.proto.Event;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
 import org.opennms.horizon.inventory.exception.EntityExistException;
+import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
 import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.discovery.PassiveDiscoveryService;
@@ -104,5 +107,25 @@ class NodeMonitoringManagerTest {
         consumer.receiveTrapEvent(anotherEvent.toByteArray());
         verifyNoInteractions(passiveDiscoveryService);
         verifyNoInteractions(nodeService);
+    }
+
+    @Test
+    void testMissingTenantID() {
+        Event testEvent = Event.newBuilder().setUei(EventConstants.NEW_SUSPECT_INTERFACE_EVENT_UEI).build();
+        assertThatThrownBy(() ->consumer.receiveTrapEvent(testEvent.toByteArray())).isInstanceOf(InventoryRuntimeException.class);
+    }
+
+    @Test
+    void testEntityExistException() throws EntityExistException {
+        doThrow(new EntityExistException("bad request")).when(nodeService).createNode(any(NodeCreateDTO.class), eq(ScanType.NODE_SCAN), eq(tenantId));
+        ArgumentCaptor<NodeCreateDTO> argumentCaptor = ArgumentCaptor.forClass(NodeCreateDTO.class);
+        consumer.receiveTrapEvent(event.toByteArray());
+        verify(nodeService).createNode(argumentCaptor.capture(), eq(ScanType.NODE_SCAN), eq(tenantId));
+        NodeCreateDTO createDTO = argumentCaptor.getValue();
+        assertThat(createDTO.getLocation()).isEqualTo(event.getLocation());
+        assertThat(createDTO.getManagementIp()).isEqualTo(event.getIpAddress());
+        assertThat(createDTO.getLabel()).endsWith(event.getIpAddress());
+        verifyNoInteractions(passiveDiscoveryService);
+
     }
 }

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/component/NodeMonitoringManagerTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/component/NodeMonitoringManagerTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opennms.horizon.events.proto.Event;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
+import org.opennms.horizon.inventory.exception.EntityExistException;
 import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.discovery.PassiveDiscoveryService;
@@ -84,7 +85,7 @@ class NodeMonitoringManagerTest {
     }
 
     @Test
-    void testReceiveEventAndCreateNewNode() {
+    void testReceiveEventAndCreateNewNode() throws EntityExistException {
         doReturn(node).when(nodeService).createNode(any(NodeCreateDTO.class), eq(ScanType.NODE_SCAN), eq(tenantId));
         ArgumentCaptor<NodeCreateDTO> argumentCaptor = ArgumentCaptor.forClass(NodeCreateDTO.class);
         consumer.receiveTrapEvent(event.toByteArray());

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcServiceTest.java
@@ -49,6 +49,7 @@ import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.inventory.dto.NodeIdList;
 import org.opennms.horizon.inventory.dto.NodeIdQuery;
 import org.opennms.horizon.inventory.dto.NodeList;
+import org.opennms.horizon.inventory.exception.EntityExistException;
 import org.opennms.horizon.inventory.mapper.NodeMapper;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.model.Node;
@@ -76,7 +77,6 @@ public class NodeGrpcServiceTest {
     private StreamObserver<Int64Value> mockInt64ValueStreamObserver;
     private StreamObserver<BoolValue> mockBoolValueStreamObserver;
     private ExecutorService mockExecutorService;
-    private Logger mockLogger;
 
     private NodeGrpcService target;
 
@@ -125,7 +125,6 @@ public class NodeGrpcServiceTest {
         mockInt64ValueStreamObserver = Mockito.mock(StreamObserver.class);
         mockBoolValueStreamObserver = Mockito.mock(StreamObserver.class);
         mockExecutorService = Mockito.mock(ExecutorService.class);
-        mockLogger = Mockito.mock(Logger.class);
 
         target =
             new NodeGrpcService(
@@ -145,7 +144,7 @@ public class NodeGrpcServiceTest {
      * Verify the creation of a new node, and successful send of task updates.
      */
     @Test
-    void testCreateNodeNewValidManagementIpSuccessfulSendTasks() {
+    void testCreateNodeNewValidManagementIpSuccessfulSendTasks() throws EntityExistException {
         Runnable runnable = commonTestCreateNode();
 
         // Verify the lambda execution
@@ -157,7 +156,7 @@ public class NodeGrpcServiceTest {
      * Verify the creation of a new node with no management IP address
      */
     @Test
-    void testCreateNodeNoManagementIp() {
+    void testCreateNodeNoManagementIp() throws EntityExistException {
         //
         // Setup test data and interactions
         //
@@ -683,7 +682,7 @@ public class NodeGrpcServiceTest {
 // Internals
 //----------------------------------------
 
-    private Runnable commonTestCreateNode() {
+    private Runnable commonTestCreateNode() throws EntityExistException {
         //
         // Setup test data and interactions
         //

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
@@ -28,6 +28,24 @@
 
 package org.opennms.horizon.inventory.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,23 +69,6 @@ import org.opennms.horizon.inventory.service.taskset.ScannerTaskSetService;
 import org.opennms.horizon.inventory.service.taskset.publisher.TaskSetPublisher;
 import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.taskset.contract.ScanType;
-
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 public class NodeServiceTest {
     private NodeService nodeService;
@@ -126,6 +127,7 @@ public class NodeServiceTest {
             .setManagementIp("127.0.0.1")
             .addTags(TagCreateDTO.newBuilder().setName("tag-name").build())
             .build();
+        doReturn(Optional.empty()).when(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreateDTO.getLocation()), eq(tenant));
 
         nodeService.createNode(nodeCreateDTO, ScanType.NODE_SCAN, tenant);
         verify(mockNodeRepository).save(any(Node.class));
@@ -134,6 +136,7 @@ public class NodeServiceTest {
         verify(mockMonitoringLocationRepository).findByLocationAndTenantId(location, tenant);
         verify(tagService).addTags(eq(tenant), any(TagCreateListDTO.class));
         verify(mockConfigUpdateService, timeout(5000)).sendConfigUpdate(tenant, location);
+        verify(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreateDTO.getLocation()), eq(tenant));
     }
 
     @Test
@@ -149,11 +152,14 @@ public class NodeServiceTest {
 
         doReturn(Optional.of(new MonitoringLocation())).when(mockMonitoringLocationRepository).findByLocationAndTenantId(location, tenantId);
 
+        doReturn(Optional.empty()).when(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreateDTO.getLocation()), eq(tenantId));
+
         nodeService.createNode(nodeCreateDTO, ScanType.NODE_SCAN, tenantId);
         verify(mockNodeRepository).save(any(Node.class));
         verify(mockIpInterfaceRepository).save(any(IpInterface.class));
         verify(mockMonitoringLocationRepository).findByLocationAndTenantId(location, tenantId);
         verify(mockConfigUpdateService, timeout(5000).times(0)).sendConfigUpdate(eq(tenantId), any());
+        verify(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreateDTO.getLocation()), eq(tenantId));
     }
 
     @Test
@@ -185,10 +191,12 @@ public class NodeServiceTest {
             .setManagementIp("127.0.0.1").build();
         MonitoringLocation location = new MonitoringLocation();
         doReturn(Optional.of(location)).when(mockMonitoringLocationRepository).findByLocationAndTenantId(GrpcConstants.DEFAULT_LOCATION, tenantID);
+        doReturn(Optional.empty()).when(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
         nodeService.createNode(nodeCreate, ScanType.NODE_SCAN, tenantID);
         verify(mockMonitoringLocationRepository).findByLocationAndTenantId(GrpcConstants.DEFAULT_LOCATION, tenantID);
         verify(mockNodeRepository).save(any(Node.class));
         verify(mockIpInterfaceRepository).save(any(IpInterface.class));
+        verify(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
     }
 
     @Test
@@ -198,6 +206,7 @@ public class NodeServiceTest {
             .setManagementIp("127.0.0.1").build();
         doReturn(Optional.empty()).when(mockMonitoringLocationRepository).findByLocationAndTenantId(GrpcConstants.DEFAULT_LOCATION, tenantID);
         doReturn(new MonitoringLocation()).when(mockMonitoringLocationRepository).save(any(MonitoringLocation.class));
+        doReturn(Optional.empty()).when(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
         ArgumentCaptor<MonitoringLocation> captor = ArgumentCaptor.forClass(MonitoringLocation.class);
         nodeService.createNode(nodeCreate, ScanType.NODE_SCAN, tenantID);
         verify(mockMonitoringLocationRepository).findByLocationAndTenantId(GrpcConstants.DEFAULT_LOCATION, tenantID);
@@ -205,6 +214,7 @@ public class NodeServiceTest {
         assertThat(captor.getValue().getLocation()).isEqualTo(GrpcConstants.DEFAULT_LOCATION);
         verify(mockNodeRepository).save(any(Node.class));
         verify(mockIpInterfaceRepository).save(any(IpInterface.class));
+        verify(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
     }
 
     @Test
@@ -248,5 +258,19 @@ public class NodeServiceTest {
         Map<String, List<NodeDTO>> result = nodeService.listNodeByIds(List.of(1L, 2L, 3L), tenantID);
         assertThat(result.isEmpty()).isTrue();
         verify(mockNodeRepository).findByIdInAndTenantId(List.of(1L, 2L, 3L), tenantID);
+    }
+
+    @Test
+    public void testCreateNodeIPExists() {
+        Node node = new Node();
+        IpInterface ipInterface = new IpInterface();
+        ipInterface.setNode(node);
+        NodeCreateDTO nodeCreate = NodeCreateDTO.newBuilder()
+            .setLabel("test-node")
+            .setManagementIp("127.0.0.1").build();
+        doReturn(Optional.of(ipInterface)).when(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
+        Node result = nodeService.createNode(nodeCreate, ScanType.NODE_SCAN, tenantID);
+        assertThat(result).isEqualTo(node);
+        verify(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
     }
 }

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
@@ -272,5 +272,9 @@ public class NodeServiceTest {
         Node result = nodeService.createNode(nodeCreate, ScanType.NODE_SCAN, tenantID);
         assertThat(result).isEqualTo(node);
         verify(mockIpInterfaceRepository).findByIpAddressAndLocationAndTenantId(any(InetAddress.class), eq(nodeCreate.getLocation()), eq(tenantID));
+        verifyNoInteractions(mockNodeRepository);
+        verifyNoInteractions(mockMonitoringLocationRepository);
+        verifyNoInteractions(tagService);
+        verifyNoInteractions(mockConfigUpdateService);
     }
 }

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseServiceIntTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/service/taskset/response/ScannerResponseServiceIntTest.java
@@ -38,6 +38,7 @@ import org.opennms.horizon.azure.api.AzureScanItem;
 import org.opennms.horizon.azure.api.AzureScanResponse;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
 import org.opennms.horizon.inventory.dto.NodeCreateDTO;
+import org.opennms.horizon.inventory.exception.EntityExistException;
 import org.opennms.horizon.inventory.grpc.GrpcTestBase;
 import org.opennms.horizon.inventory.model.IpInterface;
 import org.opennms.horizon.inventory.model.Node;
@@ -169,7 +170,7 @@ class ScannerResponseServiceIntTest extends GrpcTestBase {
     }
 
     @Test
-    void testAcceptNodeScanResult() throws InvalidProtocolBufferException {
+    void testAcceptNodeScanResult() throws InvalidProtocolBufferException, EntityExistException {
         String managedIp = "127.0.0.1";
         Node node = createNode(managedIp);
         int ifIndex = 1;
@@ -197,7 +198,7 @@ class ScannerResponseServiceIntTest extends GrpcTestBase {
 
     }
 
-    private Node createNode(String ipAddress) {
+    private Node createNode(String ipAddress) throws EntityExistException {
         NodeCreateDTO createDTO = NodeCreateDTO.newBuilder()
             .setLabel("test-node")
             .setManagementIp(ipAddress)


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- Prevent creating multiple nodes with the trap events from the same tenant, same location, and same IP address
- Prevent triggering an alert before a node is created.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1476

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
