### PR TITLE
HS-1496 Make sure trust manager is configured only if custom CA file exists

### DIFF
--- a/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
+++ b/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
@@ -4,9 +4,9 @@ grpc.tls.enabled=${env:MINION_GATEWAY_TLS:-false}
 grpc.max.message.size=${env:MINION_GATEWAY_MAX_MESSAGE_SIZE:-104857600}
 
 # The following only apply when TLS is enabled
-grpc.client.cert.filepath=${env:CERT_PKG_CLIENT_CERT_PATH:-certs/client.signed.cert}
-grpc.client.private.key.filepath=${env:CERT_PKG_CLIENT_KEY_PATH:-certs/client.key}
-grpc.client.private.key.password=${env:CLIENT_PRIVATE_KEY_PASSWORD:-}
+grpc.client.cert.filepath=${env:CERT_PKG_CLIENT_CERT_PATH}
+grpc.client.private.key.filepath=${env:CERT_PKG_CLIENT_KEY_PATH}
+grpc.client.private.key.password=${env:CLIENT_PRIVATE_KEY_PASSWORD}
 grpc.client.private.key.is-pkcs12=${env:CLIENT_PRIVATE_KEY_IS_PKCS12:-false}
-grpc.trust.cert.filepath=${env:CERT_PKG_CA_CERT_PATH:-certs/CA.cert}
-grpc.override.authority=${env:GRPC_CERT_OVERRIDE_AUTHORITY:-opennms-minion-ssl-gateway}
+grpc.trust.cert.filepath=${env:CERT_PKG_CA_CERT_PATH}
+grpc.override.authority=${env:GRPC_CERT_OVERRIDE_AUTHORITY}

--- a/minion/docker-it/src/test/java/org/opennms/horizon/dockerit/testcontainers/TestContainerRunnerClassRule.java
+++ b/minion/docker-it/src/test/java/org/opennms/horizon/dockerit/testcontainers/TestContainerRunnerClassRule.java
@@ -111,7 +111,7 @@ public class TestContainerRunnerClassRule extends ExternalResource {
     private void startSslGatewayContainer() {
         sslGatewayContainer
             .withNetwork(network)
-            .withNetworkAliases("ssl-gateway")
+            .withNetworkAliases("opennms-minion-ssl-gateway")
             .withExposedPorts(443)
             .withCopyFileToContainer(
                 MountableFile.forClasspathResource("ssl-gateway/nginx.conf"), "/etc/nginx/nginx.conf"
@@ -146,12 +146,14 @@ public class TestContainerRunnerClassRule extends ExternalResource {
             .withEnv("JAVA_TOOL_OPTIONS", "-Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005")
             .withEnv("MINION_LOCATION", "Default")
             .withEnv("USE_KUBERNETES", "false")
-            .withEnv("MINION_GATEWAY_HOST", "ssl-gateway")
+            .withEnv("MINION_GATEWAY_HOST", "opennms-minion-ssl-gateway")
             .withEnv("MINION_GATEWAY_PORT", "443")
             .withEnv("MINION_GATEWAY_TLS", "true")
+            .withEnv("CERT_PKG_CLIENT_CERT_PATH", "/opt/karaf/certs/client.cert")
             .withEnv("CERT_PKG_CLIENT_KEY_PATH", "/opt/karaf/certs/client.key")
-            .withEnv("CLIENT_PRIVATE_KEY_IS_PKCS12", "false")
+            .withEnv("CERT_PKG_CA_CERT_PATH", "/opt/karaf/certs/CA.cert")
             .withEnv("CERT_PKG_PASSWORD", "passw0rd")
+            .withEnv("CLIENT_PRIVATE_KEY_IS_PKCS12", "false")
             .withCopyFileToContainer(
                 MountableFile.forClasspathResource("minion-cert.insecure.zip"), "/opt/karaf/certs.in/minion-cert.zip"
             )


### PR DESCRIPTION
## Description
This PR bring back previous behavior and allows to connect minion to cloud instances.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1496
- 
## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
