### PR TITLE
opentelemetry support for Java containers

### DIFF
--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -276,6 +276,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -364,6 +364,31 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -267,6 +267,9 @@
                             <jvmFlag>--add-opens=java.base/java.text=ALL-UNNAMED</jvmFlag>
                             <jvmFlag>--add-opens=java.desktop/java.awt.font=ALL-UNNAMED</jvmFlag>
                         </jvmFlags>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
                     </container>
                 </configuration>
                 <executions>

--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -41,6 +41,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>grpc-common-constants</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/build-tools/basic/mk-docker-images.sh
+++ b/build-tools/basic/mk-docker-images.sh
@@ -72,7 +72,7 @@ time {
 	echo "==="
 	echo "=== DATACHOICES IMAGE"
 	echo "==="
-	mvn -f events install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-datachoices:local-basic
+	mvn -f datachoices install -Djib.container.creationTime=USE_CURRENT_TIMESTAMP -Dapplication.docker.image=opennms/horizon-stream-datachoices:local-basic
 
 	echo ""
 	echo "==="

--- a/charts/opennms-operator/.helmignore
+++ b/charts/opennms-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/opennms/.helmignore
+++ b/charts/opennms/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/opennms/templates/cortex/cortex-deployment.yaml
+++ b/charts/opennms/templates/cortex/cortex-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         - name: cortex-config-volume
           configMap:
             name: cortex-config-map
+        - name: cortex-rules-volume
+          emptyDir: {}
       containers:
         - name: {{ .Values.Cortex.ServiceName }}
           image: {{ .Values.Cortex.Image }}
@@ -56,4 +58,6 @@ spec:
             - name: cortex-config-volume
               mountPath: "/etc/cortex.yml"
               subPath: "cortex.yml"
+            - name: cortex-rules-volume
+              mountPath: /tmp/cortex/rules
 {{ end }}

--- a/charts/opennms/templates/cortex/cortex-deployment.yaml
+++ b/charts/opennms/templates/cortex/cortex-deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
         app: {{ .Values.Cortex.ServiceName }}
+      annotations:
+        # roll the deployment when the cortex configmap changes
+        checksum/cortex-configmap: {{ include (print $.Template.BasePath "/cortex/cortex-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:

--- a/charts/opennms/templates/keycloak/keycloak-deployment.yaml
+++ b/charts/opennms/templates/keycloak/keycloak-deployment.yaml
@@ -49,6 +49,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.Keycloak.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.Keycloak.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:/opt/keycloak/agent/opentelemetry-javaagent.jar"
             {{- if .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint }}

--- a/charts/opennms/templates/keycloak/keycloak-deployment.yaml
+++ b/charts/opennms/templates/keycloak/keycloak-deployment.yaml
@@ -47,6 +47,19 @@ spec:
               memory: "{{ .Values.Keycloak.Resources.Requests.Memory }}"
           args: ['--import-realm']
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.Keycloak.ServiceName }}"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-javaagent:/opt/keycloak/agent/opentelemetry-javaagent.jar"
+            {{- if .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: {{ .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint | toYaml }}
+            {{- else }}
+            - name: OTEL_TRACES_EXPORTER
+              value: "none"
+            {{- end }}
+            - name: OTEL_METRICS_EXPORTER
+              value: "none"
             - name: KC_CACHE_STACK
               value: kubernetes
             - name: KC_CACHE

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.Alert.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.Alert.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # Permanent debug port in `skaffold dev`
             - name: SPRING_DATASOURCE_URL

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -35,6 +35,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Alert.ServiceName }}
           image: {{ .Values.OpenNMS.Alert.Image }}
@@ -61,6 +65,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.Alert.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Alert.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Alert.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -44,8 +44,10 @@ spec:
           image: {{ .Values.OpenNMS.Alert.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.Alert.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.Alert.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # Permanent debug port in `skaffold dev`
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # Permanent debug port in `skaffold dev`
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://postgres:5432/alert"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         appdomain: opennms
         app: {{ .Values.OpenNMS.Alert.ServiceName }}
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    

--- a/charts/opennms/templates/opennms/alert/alert-deployment.yaml
+++ b/charts/opennms/templates/opennms/alert/alert-deployment.yaml
@@ -60,6 +60,9 @@ spec:
                   key: alertPwd
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Alert.Port }}

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.API.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.API.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_CACHE_CAFFEINE_SPEC

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         appdomain: opennms
         app: {{ .Values.OpenNMS.API.ServiceName }}
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{ if .Values.NodeRestrictions.Enabled }}
       nodeSelector:

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -68,6 +68,9 @@ spec:
               value: "{{ .Values.OpenNMS.Alert.ServiceName }}:{{ .Values.OpenNMS.Alert.GrpcPort }}"
             - name: GRPC_URL_MINION_CERTIFICATE_MANAGER
               value: "{{ .Values.OpenNMS.MinionCertificateManager.ServiceName }}:{{ .Values.OpenNMS.MinionCertificateManager.Port }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - containerPort: {{ .Values.OpenNMS.API.Port }}
           {{/*  TODO    livenessProbe:*/}}

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -48,8 +48,10 @@ spec:
           image: {{ .Values.OpenNMS.API.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.API.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.API.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_CACHE_CAFFEINE_SPEC
               value: "maximumSize=10000,expireAfterWrite=60s"
             - name: TSDB_URL

--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                       - {{ .Values.NodeRestrictions.Value }}
       {{ end }}
       terminationGracePeriodSeconds: 120
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.API.ServiceName }}
           image: {{ .Values.OpenNMS.API.Image }}
@@ -76,6 +80,9 @@ spec:
             requests:
               cpu: "{{ .Values.OpenNMS.API.Resources.Requests.Cpu }}"
               memory: "{{ .Values.OpenNMS.API.Resources.Requests.Memory }}"
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.API.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -35,6 +35,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.DataChoices.ServiceName }}
           image: {{ .Values.OpenNMS.DataChoices.Image }}
@@ -65,6 +69,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.DataChoices.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.DataChoices.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.DataChoices.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.DataChoices.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.DataChoices.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -44,8 +44,10 @@ spec:
           image: {{ .Values.OpenNMS.DataChoices.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.DataChoices.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.DataChoices.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://postgres:5432/datachoices"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -64,6 +64,9 @@ spec:
               value: "http://{{ .Values.Keycloak.ServiceName }}:8080/auth/"
             - name: KEYCLOAK_REALM
               value: "{{ .Values.Keycloak.RealmName }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.DataChoices.Port }}

--- a/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
+++ b/charts/opennms/templates/opennms/datachoices/datachoices-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         appdomain: opennms
         app: {{ .Values.OpenNMS.DataChoices.ServiceName }}
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.OpenNMS.Events.Port }}"
         prometheus.io/path: "/actuator/prometheus"
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.Events.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.Events.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -66,6 +66,9 @@ spec:
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: GRPC_URL_INVENTORY
               value: "{{ .Values.OpenNMS.Inventory.ServiceName }}:{{ .Values.OpenNMS.Inventory.GrpcPort }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Events.Port }}

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -48,8 +48,10 @@ spec:
           image: {{ .Values.OpenNMS.Events.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.Events.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.Events.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://postgres:5432/events"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/opennms/templates/opennms/events/events-deployment.yaml
+++ b/charts/opennms/templates/opennms/events/events-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Events.ServiceName }}
           image: {{ .Values.OpenNMS.Events.Image }}
@@ -67,6 +71,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.Events.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Events.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Events.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -73,6 +73,9 @@ spec:
                 secretKeyRef:
                   key: encryptionKey
                   name: {{ .Values.OpenNMS.Inventory.ServiceName }}-encryption-key
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Inventory.Port }}

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.OpenNMS.Inventory.Port }}"
         prometheus.io/path: "/actuator/prometheus"
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.Inventory.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.Inventory.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Inventory.ServiceName }}
           image: {{ .Values.OpenNMS.Inventory.Image }}
@@ -74,6 +78,9 @@ spec:
               containerPort: {{ .Values.OpenNMS.Inventory.Port }}
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Inventory.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Inventory.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
+++ b/charts/opennms/templates/opennms/inventory/inventory-deployment.yaml
@@ -48,8 +48,10 @@ spec:
           image: {{ .Values.OpenNMS.Inventory.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.Inventory.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.Inventory.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://postgres:5432/inventory"
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MetricsProcessor.ServiceName }}
           image: {{ .Values.OpenNMS.MetricsProcessor.Image }}
@@ -53,6 +57,9 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.MetricsProcessor.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: "/actuator/prometheus"
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -54,6 +54,9 @@ spec:
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: CORTEX_WRITE_URL
               value: {{ .Values.Cortex.Protocol }}://{{ .Values.Cortex.Host }}:{{ .Values.Cortex.Port }}{{ .Values.Cortex.PathWrite }}
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: 8080

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -48,8 +48,10 @@ spec:
           image: {{ .Values.OpenNMS.MetricsProcessor.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.MetricsProcessor.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.MetricsProcessor.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: CORTEX_WRITE_URL

--- a/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
+++ b/charts/opennms/templates/opennms/metricsprocessor/metricsprocessor-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.MetricsProcessor.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.MetricsProcessor.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.MinionGatewayGrpcProxy.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: KAFKA_BOOTSTRAP_SERVERS

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -56,6 +56,9 @@ spec:
               value: "{{ .Values.OpenNMS.MinionGateway.ServiceName }}"
             - name: GRPC_DOWNSTREAM_PORT
               value: "{{ .Values.OpenNMS.MinionGateway.GrpcPort }}"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.Port }}

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}
           image: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.Image }}
@@ -62,4 +66,7 @@ spec:
             requests:
               cpu: "{{ .Values.OpenNMS.MinionGatewayGrpcProxy.Resources.Requests.Cpu }}"
               memory: "{{ .Values.OpenNMS.MinionGatewayGrpcProxy.Resources.Requests.Memory }}"
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
 {{- end }}

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -18,6 +18,9 @@ spec:
         appdomain: opennms
         app: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}
         ignite-cluster: core
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}-sa
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-gateway-grpc-proxy/minion-gateway-grpc-proxy-deployment.yaml
@@ -48,8 +48,10 @@ spec:
           image: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.MinionGatewayGrpcProxy.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.MinionGatewayGrpcProxy.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: GRPC_DOWNSTREAM_HOST

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -54,6 +54,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.MinionGateway.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.MinionGateway.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_USERNAME

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -44,6 +44,9 @@ spec:
             name: minion-gateway-ignite-config
         - name: ignite-volume
           emptyDir: {}
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MinionGateway.ServiceName }}
           image: {{ .Values.OpenNMS.MinionGateway.Image }}
@@ -80,6 +83,8 @@ spec:
               mountPath: "/app/resources/ignite"
             - name: ignite-volume
               mountPath: /ignite
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
           resources:
             limits:
               cpu: "{{ .Values.OpenNMS.MinionGateway.Resources.Limits.Cpu }}"

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -52,8 +52,10 @@ spec:
           image: {{ .Values.OpenNMS.MinionGateway.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.Minion.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.MinionGateway.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y -XX:MaxDirectMemorySize=768m"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_DATASOURCE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         appdomain: opennms
         app: {{ .Values.OpenNMS.MinionGateway.ServiceName }}
         ignite-cluster: core
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Values.OpenNMS.Minion.ServiceName }}-sa
       {{- if .Values.NodeRestrictions.Enabled }}

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -69,6 +69,9 @@ spec:
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups
               value: "false"
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.MinionGateway.Port }}

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -72,6 +72,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.Keycloak.ServiceName }}-initial-admin
                   key: password
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Notification.GrpcPort }}

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -35,6 +35,10 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.Notification.ServiceName }}
           image: {{ .Values.OpenNMS.Notification.Image }}
@@ -71,6 +75,9 @@ spec:
           ports:
             - name: grpc
               containerPort: {{ .Values.OpenNMS.Notification.GrpcPort }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.Notification.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         appdomain: opennms
         app: {{ .Values.OpenNMS.Notification.ServiceName }}
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -44,8 +44,10 @@ spec:
           image: {{ .Values.OpenNMS.Notification.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.Notification.ImagePullPolicy }}
           env:
+            - name: OTEL_SERVICE_NAME
+              value: "{{ .Values.OpenNMS.Notification.ServiceName }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
             - name: SPRING_DATASOURCE_URL

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.Notification.ServiceName }}"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.version={{ .Values.OpenNMS.Notification.Image }}"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS

--- a/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
@@ -4,3 +4,33 @@ metadata:
   name: spring-boot-app-config
   namespace: {{ .Release.Namespace }}
 data:
+  logback-spring.xml: |
+    <?xml version="1.0" encoding="UTF-8"?>
+    <configuration>
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    
+        <springProfile name="json-logging">
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+                    <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+                        <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                            <prettyPrint>${CONSOLE_JSON_PRETTY:-false}</prettyPrint>
+                        </jsonFormatter>
+                        <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+                        <timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
+                        <appendLineSeparator>true</appendLineSeparator>
+                    </layout>
+                </encoder>
+            </appender>
+        </springProfile>
+    
+        <springProfile name="!json-logging">
+            <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        </springProfile>
+    
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </configuration>
+  application-json-logging.properties: |
+    spring.main.banner-mode=off

--- a/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-app-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spring-boot-app-config
+  namespace: {{ .Release.Namespace }}
+data:

--- a/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
@@ -7,3 +7,9 @@ data:
 {{- if .Values.OpenNMS.global.enableJsonLogging }}
   SPRING_PROFILES_ACTIVE: json-logging
 {{- end }}
+{{- if .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint }}
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: {{ .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint | toYaml }}
+{{- else }}
+  OTEL_TRACES_EXPORTER: "none"
+{{- end }}
+  OTEL_METRICS_EXPORTER: "none"

--- a/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spring-boot-env
+  namespace: {{ .Release.Namespace }}
+data:

--- a/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
+++ b/charts/opennms/templates/opennms/spring-boot-env-configmap.yaml
@@ -4,3 +4,6 @@ metadata:
   name: spring-boot-env
   namespace: {{ .Release.Namespace }}
 data:
+{{- if .Values.OpenNMS.global.enableJsonLogging }}
+  SPRING_PROFILES_ACTIVE: json-logging
+{{- end }}

--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -5,6 +5,8 @@ OpenShift: false
 OpenNMS:
   global:
     enableJsonLogging: false
+    openTelemetry:
+      otlpTracesEndpoint: null
   API:
     Path: /api
     ServiceName: opennms-rest-server

--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -3,6 +3,8 @@ Port: 443 #set depending on TLS.Enabled and the Ingress ports, do not change
 Protocol: https #set depending on TLS.Enabled, do not change
 OpenShift: false
 OpenNMS:
+  global:
+    enableJsonLogging: false
   API:
     Path: /api
     ServiceName: opennms-rest-server

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -268,6 +268,31 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -276,6 +276,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -265,6 +265,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -34,6 +34,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/datachoices/src/main/java/org/opennms/horizon/datachoices/service/DataChoicesService.java
+++ b/datachoices/src/main/java/org/opennms/horizon/datachoices/service/DataChoicesService.java
@@ -80,7 +80,7 @@ public class DataChoicesService {
         List<String> tenantIds = repository.findAll().stream()
             .map(DataChoices::getTenantId).distinct().collect(Collectors.toList());
 
-        System.out.println("tenantIds.size() = " + tenantIds.size());
+        log.info("tenantIds.size() = " + tenantIds.size());
 
 //        todo: perform queries and send HTTP request to usage-stats-handler
     }

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -143,6 +143,31 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -27,6 +27,11 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.horizon.events</groupId>
             <artifactId>persistence</artifactId>
             <version>${project.version}</version>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -151,6 +151,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -140,6 +140,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/inventory/docker-it/pom.xml
+++ b/inventory/docker-it/pom.xml
@@ -17,10 +17,6 @@
         Test Containers are used to spin up containers and exercise the public endpoints.
     </description>
 
-    <properties>
-        <application.docker.image.name>opennms/horizon-stream-inventory</application.docker.image.name>
-    </properties>
-
     <dependencies>
         <!-- Dependency to ensure the docker image is built before running the tests -->
         <dependency>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -23,6 +23,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -348,6 +348,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -340,6 +340,31 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -337,6 +337,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/keycloak-ui/Dockerfile
+++ b/keycloak-ui/Dockerfile
@@ -17,7 +17,9 @@ ENV KC_CACHE_STACK=kubernetes
 WORKDIR /opt/keycloak
 
 # Install custom providers
-RUN curl -sL https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.5.3/keycloak-metrics-spi-2.5.3.jar -o /opt/keycloak/providers/keycloak-metrics-spi-2.5.3.jar
+RUN curl -sSfL https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.5.3/keycloak-metrics-spi-2.5.3.jar -o /opt/keycloak/providers/keycloak-metrics-spi-2.5.3.jar
+RUN mkdir -p /opt/keycloak/agent
+RUN curl -sSfL https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.25.0/opentelemetry-javaagent.jar -o /opt/keycloak/agent/opentelemetry-javaagent.jar
 
 COPY --link --chown=1000 themes themes
 

--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -95,6 +95,31 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -97,6 +97,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -103,6 +103,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -83,6 +83,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -145,6 +145,31 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -153,6 +153,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -142,6 +142,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -58,6 +58,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>horizon-shaded-grpc-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -29,6 +29,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.horizon.minion.gateway</groupId>
             <artifactId>minion-gateway-ignite-detector-api</artifactId>
             <version>${project.version}</version>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -193,6 +193,9 @@
                             <jvmFlag>--add-opens=java.base/java.lang=ALL-UNNAMED</jvmFlag>
                             <jvmFlag>--add-opens=java.base/java.util.concurrent=ALL-UNNAMED</jvmFlag>
                         </jvmFlags>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
                     </container>
                 </configuration>
                 <executions>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -179,6 +179,31 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -202,6 +202,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/minion/docker-assembly/pom.xml
+++ b/minion/docker-assembly/pom.xml
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>copy</id>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -341,6 +341,13 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -344,6 +344,31 @@
 				</configuration>
 			</plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -352,6 +352,9 @@
                             <entry>${application.jib.app.config}</entry>
                         </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -39,6 +39,11 @@
     </dependencyManagement>
 	<dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${jupiter.version}</version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -101,6 +101,7 @@
         <keycloak.version>20.0.3</keycloak.version>
         <liquibaseVersion>4.17.0</liquibaseVersion>
         <log4j2.version>2.19.0</log4j2.version>
+        <logback.contrib.version>0.1.5</logback.contrib.version>
         <logcaptor.version>2.7.10</logcaptor.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
         <maven-resources.version>3.3.0</maven-resources.version>
@@ -964,7 +965,16 @@
                 <artifactId>kafka</artifactId>
                 <version>${testcontainers.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-json-classic</artifactId>
+                <version>${logback.contrib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback.contrib</groupId>
+                <artifactId>logback-jackson</artifactId>
+                <version>${logback.contrib.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -27,6 +27,8 @@
 
         <!-- Jib properties -->
         <application.jib.defaultGoal>dockerBuild</application.jib.defaultGoal> <!-- dockerBuild for local only; build to push also -->
+        <!-- agents will be extracted relative to this build location -->
+        <application.jib.extra.root>${project.build.directory}/jib</application.jib.extra.root>
         <application.jib.app.config>/app/config</application.jib.app.config>
         <application.docker.skip>false</application.docker.skip>
         <application.docker.image>${application.docker.image.name}:${application.docker.image.tag}</application.docker.image>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -106,6 +106,7 @@
         <logback.contrib.version>0.1.5</logback.contrib.version>
         <logcaptor.version>2.7.10</logcaptor.version>
         <mapstruct.version>1.5.3.Final</mapstruct.version>
+        <maven-dependency.version>3.3.0</maven-dependency.version>
         <maven-resources.version>3.3.0</maven-resources.version>
         <mina.version>2.1.5</mina.version>
         <netty3.version>3.10.6.Final</netty3.version>
@@ -987,6 +988,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -113,6 +113,7 @@
         <netty4.version>4.1.78.Final</netty4.version>
         <opennms.tracker.version>0.7</opennms.tracker.version>
         <opentracing.version>0.31.0</opentracing.version>
+        <opentelemetry.version>1.25.0</opentelemetry.version>
         <org.osgi.service.jdbc.version>1.0.0</org.osgi.service.jdbc.version>
         <osgi.version>7.0.0</osgi.version>
         <pax.jdbc.version>1.5.2</pax.jdbc.version>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -27,6 +27,7 @@
 
         <!-- Jib properties -->
         <application.jib.defaultGoal>dockerBuild</application.jib.defaultGoal> <!-- dockerBuild for local only; build to push also -->
+        <application.jib.app.config>/app/config</application.jib.app.config>
         <application.docker.skip>false</application.docker.skip>
         <application.docker.image>${application.docker.image.name}:${application.docker.image.tag}</application.docker.image>
         <!-- application.docker.image.name MUST be set by child modules that use jib-maven-plugin. -->

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -259,6 +259,31 @@
 					</excludes>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -40,6 +40,11 @@
 	<dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>horizon-shaded-grpc-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -268,6 +268,9 @@
 							<entry>${application.jib.app.config}</entry>
 						</extraClasspath>
 					</container>
+					<extraDirectories>
+						<paths>${application.jib.extra.root}</paths>
+					</extraDirectories>
 				</configuration>
 
 				<executions>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -257,6 +257,13 @@
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
+				<configuration>
+					<container>
+						<extraClasspath>
+							<entry>${application.jib.app.config}</entry>
+						</extraClasspath>
+					</container>
+				</configuration>
 
 				<executions>
 					<execution>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -43,6 +43,7 @@
         <module>shaded-grpc-core</module>
         <module>minion-certificate-manager-api</module>
         <module>horizon-common-tag</module>
+        <module>spring-boot-logback-json</module>
     </modules>
 
     <build>

--- a/shared-lib/spring-boot-logback-json/pom.xml
+++ b/shared-lib/spring-boot-logback-json/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms.horizon.shared</groupId>
+        <artifactId>shared-lib</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-boot-logback-json</artifactId>
+    <name>OpenNMS Horizon Stream :: Spring Boot Support :: Logback JSON</name>
+
+    <dependencies>
+        <!-- Since we need to support a few different versions of Spring Boot,
+             we don't include spring-boot-starter-logging since we can't specify
+             its version here. It is the default logger, anyway, so we should
+             be fine. -->
+        <!-- The same goes for logback-classic and logback-core. We don't add
+             these directly here so we don't conflict with what is in
+             spring-boot-starter-logging. Also avoiding this in rest-server tests:
+
+		java.lang.NoClassDefFoundError: org/slf4j/impl/StaticLoggerBinder
+			at org.springframework.boot.logging.logback.LogbackLoggingSystem.getLoggerContext(LogbackLoggingSystem.java:293)
+             -->
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/tooling/ignite-tool/pom.xml
+++ b/tooling/ignite-tool/pom.xml
@@ -36,6 +36,11 @@
     <dependencies>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
             <artifactId>task-set-service-api</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
To try:
- Install jaeger on your host system (the docker container works out well)
- Add this to your tilt values file:
```
--- tilt-helm-values.yaml
+++ tilt-helm-values.yaml
@@ -10,6 +10,10 @@ Keycloak:
   HostnameAdminUrl: http://localhost:8123/auth

 OpenNMS:
+  global:
+    enableJsonLogging: true
+    openTelemetry:
+      otlpTracesEndpoint: "http://host.docker.internal:4317"
   API:
     Resources:
       Limits:
```
- Go to http://localhost:16686/

- Add spring-boot-app-config ConfigMap that is mounted in /app/config
- Add spring-boot-env ConfigMap that adds env to all Spring Boot services
- HS-1419: Add spring-boot-logback-json to support JSON logging
- HS-1419: Add spring-boot-logback-json to our spring-boot services
- This looks like it accidentally had application.docker.image.name set
- Ooops, looks like we were building events and tagging it as datachoices
- Clean up a System.out.println
- Add .helmignore files so vim's .swp files don't mess up Tilt/Helm
- Jib: add extra directory target/jib to containers
- Add maven-dependency-plugin to pluginManagement
- Add OpenTelemetry agent to all Java containers
- Enable OpenTelemtry Java agent and conditionally send traces over OTLP
- XXX: hack: add otel support to keycloak

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
