### PR TITLE
HS-1532 Include trap description and log message in event

### DIFF
--- a/alert/src/main/java/org/opennms/horizon/alertservice/service/AlertEventProcessor.java
+++ b/alert/src/main/java/org/opennms/horizon/alertservice/service/AlertEventProcessor.java
@@ -248,6 +248,8 @@ public class AlertEventProcessor {
         alert.setReductionKey(alertData.reductionKey());
         alert.setClearKey(alertData.clearKey());
         alert.setCounter(1L);
+        alert.setDescription(event.getDescription());
+        alert.setLogMessage(event.getLogMessage());
         if (event.getNodeId() > 0) {
             alert.setManagedObjectType(ManagedObjectType.NODE);
             alert.setManagedObjectInstance(Long.toString(event.getNodeId()));

--- a/events/traps/src/main/java/org/opennms/horizon/events/traps/TrapsConsumer.java
+++ b/events/traps/src/main/java/org/opennms/horizon/events/traps/TrapsConsumer.java
@@ -156,6 +156,12 @@ public class TrapsConsumer {
             .setNodeId(event.getNodeid())
             .setLocation(event.getDistPoller())
             .setIpAddress(event.getInterface());
+        if (event.getDescr() != null) {
+            eventBuilder.setDescription(event.getDescr());
+        }
+        if (event.getLogmsg() != null) {
+            eventBuilder.setLogMessage(event.getLogmsg().getContent());
+        }
         mapEventInfo(event, eventBuilder);
 
         List<EventParameter> eventParameters = mapEventParams(event);

--- a/events/traps/src/test/java/org/opennms/horizon/events/traps/EventFactoryTest.java
+++ b/events/traps/src/test/java/org/opennms/horizon/events/traps/EventFactoryTest.java
@@ -1,0 +1,83 @@
+package org.opennms.horizon.events.traps;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opennms.horizon.events.api.EventConfDao;
+import org.opennms.horizon.events.conf.xml.LogDestType;
+import org.opennms.horizon.events.grpc.client.InventoryClient;
+import org.opennms.horizon.grpc.traps.contract.TrapDTO;
+import org.opennms.horizon.shared.snmp.SnmpHelper;
+import  org.opennms.horizon.events.xml.Event;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class EventFactoryTest {
+
+    @InjectMocks
+    EventFactory eventFactory;
+
+    @Mock
+    EventConfDao eventConfDao;
+
+    @Mock
+    SnmpHelper snmpHelper;
+
+    @Mock
+    InventoryClient inventoryClient;
+
+    @Test
+    public void testEventWithNoConfig() throws Exception {
+        Event e = eventFactory.createEventFrom(
+            TrapDTO.newBuilder().build(),
+            "systemId",
+            "location",
+            InetAddress.getByName("127.0.0.1"),
+            "tid"
+        );
+
+        assertEquals("uei.opennms.org/default/trap", e.getUei());
+        assertNull(e.getDescr());
+        assertNull(e.getLogmsg());
+    }
+
+    @Test
+    public void testEventWithConfig() throws Exception {
+        org.opennms.horizon.events.conf.xml.Logmsg eventLogmsg = new org.opennms.horizon.events.conf.xml.Logmsg();
+        eventLogmsg.setContent("A real event log message");
+        eventLogmsg.setNotify(true);
+        eventLogmsg.setDest(LogDestType.LOGNDISPLAY);
+
+        org.opennms.horizon.events.conf.xml.Event eventConf = new org.opennms.horizon.events.conf.xml.Event();
+        eventConf.setUei("uei.opennms.org/generic/traps/realone");
+        eventConf.setDescr("A real event configuration");
+        eventConf.setLogmsg(eventLogmsg);
+
+        Mockito.when(eventConfDao.findByEvent(any())).thenReturn(eventConf);
+        Event e = eventFactory.createEventFrom(
+            TrapDTO.newBuilder().build(),
+            "systemId",
+            "location",
+            InetAddress.getByName("127.0.0.1"),
+            "tid"
+        );
+
+        assertEquals("uei.opennms.org/generic/traps/realone", e.getUei());
+        assertEquals("A real event configuration", e.getDescr());
+        assertEquals("A real event log message", e.getLogmsg().getContent());
+        assertEquals(LogDestType.LOGNDISPLAY.name(), e.getLogmsg().getDest());
+        assertTrue(e.getLogmsg().getNotify());
+    }
+
+
+}

--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPI.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPI.java
@@ -55,6 +55,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.ResourceAccessException;

--- a/notifications/src/main/resources/alert.html.vm
+++ b/notifications/src/main/resources/alert.html.vm
@@ -25,9 +25,9 @@
     <tr>
         <td align="left" valign="top">
             <h2 style="margin:0;font-family:'Inter', Helvetica, Arial, sans-serif;">
-                ${alert.getDescription()}
+                ${alert.getLogMessage()}
             </h2>
-            <p style="font-family: 'Open Sans', Georgia, sans-serif;">${alert.getLogMessage()}</p>
+            <p style="font-family: 'Open Sans', Georgia, sans-serif;">${alert.getDescription()}</p>
         </td>
     </tr>
 </table>

--- a/shared-lib/events/src/main/proto/events.proto
+++ b/shared-lib/events/src/main/proto/events.proto
@@ -50,6 +50,8 @@ message Event {
   uint64 produced_time_ms = 7;
   repeated EventParameter parameters = 8;
   optional EventInfo info = 9;
+  string description = 10;
+  string log_message = 11;
 }
 
 message EventInfo {


### PR DESCRIPTION
## Description
When an alert is recieved by the Notification service, it doesn't have any real detail about what the trap means. This PR adds the description and log message to the event, which will also be added to the alert to provide some context for the notification.

Sending a trap matching a monitoring policy that has PagerDuty and email enabled will trigger both of those notifications:
![image](https://user-images.githubusercontent.com/6621243/234693123-bbb8b8fa-6105-46e4-b30f-a1c4a4d60a66.png)
![image](https://user-images.githubusercontent.com/6621243/234693265-10502019-999a-437e-bf3b-df9be952c822.png)

There is probably some more tweaking to those notifications to highlight which node the alert applies to, etc.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1532

## Flagged for review


## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
