### PR TITLE
AR-72: Add ADR for new Monitoring Policy service

### DIFF
--- a/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
+++ b/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
@@ -4,7 +4,7 @@ Date: 2023-05-01
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
+++ b/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
@@ -8,10 +8,7 @@ Proposed
 
 ## Context
 
-Monitoring policies are a feature that
-allow the user to configure how alerts are produced. 
-
-A monitoring policy contains the following:
+Monitoring policies are a feature that allow the user to configure how alerts are produced. A monitoring policy contains the following:
 
 - The node tags that the monitoring policy should create alerts for.
 - How network operators are notified about the monitoring policy's alerts.

--- a/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
+++ b/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
@@ -52,6 +52,7 @@ The Alert service, Notification service, and upcoming Threshold service will con
 - The Alert service will be more focused on managing alerts and the alert engine, increasing its cohesion.
 - The alert engine and API will be capable of scaling independently of monitoring policies.
 - It becomes very obvious where monitoring policies exist.
+- Alerts are coupled with monitoring policies. Moving them to another service couples the Alert service with an additional microservice, but it also makes it consistent with the way the Notification and Threshold service are coupled.
 - Monitoring policies, tags, rules, and the events configured within monitoring policies or produced for thresholds will need to be communicated to the alert service.
 - The alert engine will lose high consistency in favour of eventual consistency.
 - The Alert service will still need the UEIs and reduction/clear keys for each event it uses to produce or clear alerts. This needs to be designed.

--- a/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
+++ b/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
@@ -35,7 +35,7 @@ Monitoring policies are currently implemented in the Alert service. This has the
   - Monitoring policies need knowledge of internal events, SNMP traps, individual metric names, and flows.
   - Synthetic transactions may be implemented alongside monitoring policies, bringing in even more information.
 
-Synthetic transactions are very similar to monitoring policies, but contain more Inventory knowledge and will directly trigger data collection tasks for Minions. The current requirements for alert-related configuration like rules and notifications are currently very similar or the same. The similarity of synthetic transactions to monitoring policies means we may want to include the two in the same microservice. The added responsibilities would likely be inappropriate to add to the Alert service.
+Synthetic transactions are very similar to monitoring policies, but contain more Inventory knowledge and will trigger data collection tasks for Minions. The current requirements for alert-related configuration like rules and notifications are currently very similar or the same. We may want to include the two in the same microservice. This might be too much responsibility for the Alert service if monitoring policies remained.
 
 ## Decision
 
@@ -54,6 +54,7 @@ The Alert service, Notification service, and upcoming Threshold service will con
 - It becomes very obvious where monitoring policies exist.
 - Alerts are coupled with monitoring policies. Moving them to another service couples the Alert service with an additional microservice, but it also makes it consistent with the way the Notification and Threshold service are coupled.
 - Monitoring policies, tags, rules, and the events configured within monitoring policies or produced for thresholds will need to be communicated to the alert service.
-- The alert engine will lose high consistency in favour of eventual consistency.
+- The alert engine's configuration will lose high consistency in favour of eventual consistency.
+- Monitoring policies and the alert engine/API will be more resilient. One service will still operate if the other is unavailable, e.g. alerts will still function while the monitoring policy service is down.
 - The Alert service will still need the UEIs and reduction/clear keys for each event it uses to produce or clear alerts. This needs to be designed.
 - A new microservice needs to be developed, deployed, and maintained. This includes new devops pipelines, a SonarCloud project, Kubernetes objects, local development configuration, a database, etc.

--- a/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
+++ b/doc/architecture/decisions/0004-create-new-monitoring-policy-service.md
@@ -1,0 +1,61 @@
+# 4. Create new monitoring policy service
+
+Date: 2023-05-01
+
+## Status
+
+Proposed
+
+## Context
+
+Monitoring policies are a feature that
+allow the user to configure how alerts are produced. 
+
+A monitoring policy contains the following:
+
+- The node tags that the monitoring policy should create alerts for.
+- How network operators are notified about the monitoring policy's alerts.
+- Rules to create alerts for single SNMP traps or internal events.
+- Rules to create alerts based on thresholds for occurrences of an SNMP trap or internal event over a time window.
+- Rules to create alerts based on thresholds for metrics or flows.
+- How alerts are cleared.
+- The severity level of alerts.
+- Multiple levels of conditions for thresholds.
+- Severity level for each condition.
+
+There are multiple components that use parts of monitoring policies:
+
+- The alert engine is configured using rules, conditions, thresholds, events, and severities from the policy.
+- Alerts contain references to the monitoring policy and the rule that it was created from.
+- The upcoming thresholding service will use threshold conditions from monitoring policies.
+- The Notification service uses notification configuration from monitoring policies.
+
+Monitoring policies are currently implemented in the Alert service. This has the following concerns:
+
+- The alert engine cannot scale independently of monitoring policy configuration.
+- The alert engine only needs event UEIs and associated reduction/clear keys. Monitoring policies are associated with many different features across the system, so there are issues with cohesiveness:
+  - Notification and threshold configuration are used by other services.
+  - Monitoring policies need knowledge of internal events, SNMP traps, individual metric names, and flows.
+  - Synthetic transactions may be implemented alongside monitoring policies, bringing in even more information.
+
+Synthetic transactions are very similar to monitoring policies, but contain more Inventory knowledge and will directly trigger data collection tasks for Minions. The current requirements for alert-related configuration like rules and notifications are currently very similar or the same. The similarity of synthetic transactions to monitoring policies means we may want to include the two in the same microservice. The added responsibilities would likely be inappropriate to add to the Alert service.
+
+## Decision
+
+We will create a new "Monitoring Policy" microservice, and move monitoring policies to it from the Alert service.
+
+Monitoring policy configuration will be communicated to other microservices asynchronously with Kafka.
+
+Asynchronous communication will be done using system events that express domain events, e.g. "MetricThresholdConfigured".
+
+The Alert service, Notification service, and upcoming Threshold service will consume the domain events produced by the Monitoring Policy service.
+
+## Consequences
+
+- The Alert service will be more focused on managing alerts and the alert engine, increasing its cohesion.
+- The alert engine and API will be capable of scaling independently of monitoring policies.
+- It becomes very obvious where monitoring policies exist.
+- Monitoring policies, tags, rules, and the events configured within monitoring policies or produced for thresholds will need to be communicated to the alert service.
+- The alert engine will lose high consistency in favour of eventual consistency.
+- The Alert service will still need the UEIs and reduction/clear keys for each event it uses to produce or clear alerts. This needs to be designed.
+- A new microservice needs to be developed, deployed, and maintained. This includes new devops pipelines, a SonarCloud project, Kubernetes objects, local development configuration, a database, etc.


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Proposed ADR for moving monitoring policies out of the alert service and creating a new microservice for them.

## Jira link(s)
- https://issues.opennms.org/browse/AR-72

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->
Would like some input on context and consequences.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
