### PR TITLE
Temporarily disable the otel javaagent for minion-gateway

### DIFF
--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -55,6 +55,8 @@ spec:
           image: {{ .Values.OpenNMS.MinionGateway.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.Minion.ImagePullPolicy }}
           env:
+            - name: OTEL_JAVAAGENT_ENABLED
+              value: "false"
             - name: OTEL_SERVICE_NAME
               value: "{{ .Values.OpenNMS.MinionGateway.ServiceName }}"
             - name: OTEL_RESOURCE_ATTRIBUTES


### PR DESCRIPTION
We've been crashes fairly often in the minion-gateway (OOMs). Let's
see if this fixes it, and if not, we'll just remove it from
JAVA_TOOL_OPTIONS.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
