### PR TITLE
HS-1310 Make sure runInPlace.sh works with tilt

### DIFF
--- a/minion/assembly/runInPlace.sh
+++ b/minion/assembly/runInPlace.sh
@@ -5,12 +5,12 @@ set -e
 MINION_ID='minion-standalone'
 MINION_LOCATION='minion-standalone-loc'
 IGNITE_SERVER_ADDRESSES=localhost
-MINION_GATEWAY_HOST=localhost
+MINION_GATEWAY_HOST=minion.onmshs.local
 # TODO - port 9443 for TLS?
-MINION_GATEWAY_PORT=8990
-MINION_GATEWAY_TLS="false"
+MINION_GATEWAY_PORT=1443
+MINION_GATEWAY_TLS="true"
 
-CERT_ROOTDIR="$(cd ../../tools/SSL; pwd)"
+CERT_ROOTDIR="$(pwd)/target"
 CA_CERT_FILE="${CERT_ROOTDIR}/CA.cert"
 CLIENT_KEY_FILE="${CERT_ROOTDIR}/client.key"
 CLIENT_CERT_FILE="${CERT_ROOTDIR}/client.signed.cert"
@@ -28,7 +28,7 @@ CLIENT_KEY_IS_PKCS12="false"
 CLIENT_PRIVATE_KEY_PASSWORD=""
 
 # Prevent hostname verification failures by setting the expected cert "hostname"
-OVERRIDE_AUTHORITY="opennms-minion-ssl-gateway"
+OVERRIDE_AUTHORITY="minion.onmshs.local"
 
 USAGE()
 {
@@ -37,6 +37,7 @@ USAGE()
 
 		    -a[ADDRESS]	use ADDRESS (IGNITE_SERVER_ADDRESSES) configure the Ignite cluster addresses? (warning - this currently may not have any effect)
 		    -f[FLAG]	use client private key PKCS12 FLAG (true => PKCS12; false => other)
+		    -g[AUTHORITY]	use this to override HOST entry HTTP/2 server authority
 		    -h[HOST]	use HOST (MINION_GATEWAY_HOST) as the hostname when connecting to the cloud
 		    -i[ID]	use ID (MINION_ID) as the system identifier for this minion instance
 		    -k[PATH]	use PATH to the client private key file
@@ -45,14 +46,16 @@ USAGE()
 		    -p[PORT]	use GATEWAY (MINION_GATEWAY_HOST) as the hostname when connecting to the cloud
 		    -d		enable jvm debug
 		    -t		enable TLS
+		    -T		generate minion mTLS from secrets available in local tilt setup (kubectl + openssl)
 !
 }
 
-while getopts a:f:h:i:k:l:P:p:Ddtx FLAG 
+while getopts a:f:g:h:i:k:l:P:p:DdtxT FLAG
 do
     case "${FLAG}" in
         a) IGNITE_SERVER_ADDRESSES="${OPTARG}" ;;
         f) CLIENT_KEY_IS_PKCS12="${OPTARG}" ;;
+        g) OVERRIDE_AUTHORITY="${OPTARG}";;
         h) MINION_GATEWAY_HOST="${OPTARG}" ;;
         i) MINION_ID="${OPTARG}" ;;
         k) CLIENT_KEY_FILE="${OPTARG}" ;;
@@ -64,11 +67,25 @@ do
         d) DEBUG=debug ;;
         t) MINION_GATEWAY_TLS="true" ;;
         x) MINION_GATEWAY_TLS="false" ;;
+        T) EXTRACT_TILT_CERTS="true" ;;
         ?) USAGE >&2 ; exit 1 ;;
     esac
 done
 
+if [ "${EXTRACT_TILT_CERTS}" == "true" ]; then
+  mkdir -p $CERT_ROOTDIR || (echo "Could not create $CERT_ROOTDIR" && exit 1)
 
+  # extract client mtls ca certificate
+  kubectl get secret client-root-ca-certificate -ogo-template='{{index .data "tls.crt" }}' | base64 --decode > "$CERT_ROOTDIR/client-ca.crt"
+  kubectl get secret client-root-ca-certificate -ogo-template='{{index .data "tls.key" }}' | base64 --decode > "$CERT_ROOTDIR/client-ca.key"
+
+  openssl genrsa -out "$CERT_ROOTDIR/client.key.pkcs1" 2048
+  openssl pkcs8 -topk8 -in "$CERT_ROOTDIR/client.key.pkcs1" -out "$CLIENT_KEY_FILE" -nocrypt
+  openssl req -new -key "$CLIENT_KEY_FILE" -out "$CERT_ROOTDIR/client.unsigned.cert" -subj "/C=CA/ST=TBD/L=TBD/O=OpenNMS/CN=local-minion/OU=L:${MINION_LOCATION}/OU=T:opennms-prime"
+  openssl x509 -req -in "$CERT_ROOTDIR/client.unsigned.cert" -days 14 -CA "$CERT_ROOTDIR/client-ca.crt" -CAkey "$CERT_ROOTDIR/client-ca.key" -out "$CLIENT_CERT_FILE" -CAcreateserial
+
+  kubectl get secret root-ca-certificate -ogo-template='{{index .data "ca.crt" }}' | base64 --decode > $CA_CERT_FILE
+fi
 
 ###
 ###


### PR DESCRIPTION
I've introduced two new switches:

- `-g AUTHORITY` - assigns custom authority to server, can be used with -h if host is an IP address which shows certificate for specific domain.
- `-T` - extract secrets via kubectl from development tilt setup. -s

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-1310

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
