### PR TITLE
HS-1576: Let code-gen make request to GQL playground

### DIFF
--- a/ui/codegen.yml
+++ b/ui/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "http://localhost:8123/api/graphql"
+schema: "https://onmshs.local:1443/api/graphql"
 documents: './src/graphql/**/*'
 generates:
   src/types/graphql.ts:

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --ignore-path ./.gitignore --ext .ts,.vue .",
     "lint:fix": "eslint --ignore-path ./.gitignore --ext .ts,.vue . --fix",
     "format": "prettier --ignore-path ./.gitignore --write \"**/*.+(ts)\"",
-    "generate": "graphql-codegen --config codegen.yml"
+    "generate": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 graphql-codegen --config codegen.yml"
   },
   "dependencies": {
     "@dsb-norge/vue-keycloak-js": "^2.2.0",
@@ -93,6 +93,7 @@
     "@vue/test-utils": "^2.2.7",
     "c8": "^7.11.3",
     "casual": "^1.6.2",
+    "cross-env": "^7.0.3",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-vue": "^9.9.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3058,6 +3058,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
@@ -3065,7 +3072,7 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "2.6.7"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Description
Now that the GQL playground is under https, generating types will fail - but we can get around this by setting NODE_TLS_REJECT_UNAUTHORIZED=0 for the gen cmd. Added cross-env do to this on mac/windows.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1576

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
