### PR TITLE
HS-1556: Add graphs for interfaces

### DIFF
--- a/ui/src/components/Appliances/AppliancesMinionsTable.vue
+++ b/ui/src/components/Appliances/AppliancesMinionsTable.vue
@@ -104,7 +104,6 @@
   >
     <template #content>
       <p>{{ modal.content }}</p>
-      <!-- <LineGraph :graph="graphProps" /> -->
     </template>
     <template #footer>
       <FeatherButton

--- a/ui/src/components/Graphs/LineGraph.vue
+++ b/ui/src/components/Graphs/LineGraph.vue
@@ -108,7 +108,7 @@ const dataSets = computed(() => {
   const bgColor = ['green', 'blue'] // TODO: find solution to set bg color, in regards to FeatherDS theme switching
   emits('has-data', graphs.dataSets.value.length)
   return graphs.dataSets.value.map((data: any, i) => ({
-    label: data.metric.__name__,
+    label: props.graph.metrics[i],
     data: data.values.map((val: any) => val[1]),
     backgroundColor: bgColor[i],
     borderColor: bgColor[i],

--- a/ui/src/composables/useGraphs.ts
+++ b/ui/src/composables/useGraphs.ts
@@ -26,7 +26,7 @@ export const useGraphs = () => {
         const { metric, values } = result
 
         if (values?.length) {
-          dataSetsObject[metric.__name__] = {
+          dataSetsObject[metricStr] = {
             metric,
             values: values.filter((val) => {
               const [timestamp, value] = val

--- a/ui/tests/fixture/metrics.ts
+++ b/ui/tests/fixture/metrics.ts
@@ -2,7 +2,6 @@ import { TsResult, TimeSeriesQueryResult } from '@/types/graphql'
 
 const mockMinionLatency: TsResult = {
   metric: {
-    __name__: 'response_time_msec',
     instance: 'opennms-minion-8d6f5f64f-4l4wh',
     job: 'horizon-core',
     location: 'Default',
@@ -21,7 +20,6 @@ const minionLatencyFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryRes
 
 const mockMinionUptime: TsResult = {
   metric: {
-    __name__: 'minion_uptime_sec',
     instance: 'minion-01',
     job: 'horizon-core',
     location: 'Default',
@@ -37,7 +35,6 @@ const minionUptimeFixture = (props: Partial<TsResult> = {}): TimeSeriesQueryResu
 
 const mockDeviceLatency: TsResult = {
   metric: {
-    __name__: 'icmp_round_trip_time_msec',
     instance: '127.0.0.1',
     job: 'horizon-core',
     location: 'Default',


### PR DESCRIPTION
## Description
Fixes some minor issues with graph name / multiple metrics on one graph.
Adds more graphs to the node status page, for each interface (bandwidth, latency, errors).

## Jira link(s)
- https://issues.opennms.org/browse/HS-1556

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
