### PR TITLE
HS-1609: Fix bean validation

### DIFF
--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -84,7 +84,6 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${jakarta.validation.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -89,7 +89,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/events/conf/pom.xml
+++ b/events/conf/pom.xml
@@ -38,7 +38,10 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${jakarta.validation.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/events/persistence/pom.xml
+++ b/events/persistence/pom.xml
@@ -66,7 +66,10 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${jakarta.validation.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -148,6 +148,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>horizon-common-tag</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
         </dependency>
@@ -168,12 +173,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opennms.horizon.shared</groupId>
-            <artifactId>horizon-common-tag</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -107,7 +107,10 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${jakarta.validation.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
@@ -169,10 +172,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/grpc/TagGrpcItTest.java
@@ -52,6 +52,7 @@ import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.opennms.horizon.inventory.repository.TagRepository;
 import org.opennms.horizon.inventory.repository.discovery.active.AzureActiveDiscoveryRepository;
+import org.opennms.taskset.contract.ScanType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
@@ -237,6 +238,7 @@ class TagGrpcItTest extends GrpcTestBase {
         node1.setTenantId(tenantId);
         node1.setMonitoringLocation(location);
         node1.setMonitoringLocationId(location.getId());
+        node1.setScanType(ScanType.NODE_SCAN);
         node1 = nodeRepository.saveAndFlush(node1);
 
         Node node2 = new Node();
@@ -245,6 +247,7 @@ class TagGrpcItTest extends GrpcTestBase {
         node2.setTenantId(tenantId);
         node2.setMonitoringLocation(location);
         node2.setMonitoringLocationId(location.getId());
+        node2.setScanType(ScanType.NODE_SCAN);
         node2 = nodeRepository.saveAndFlush(node2);
 
         TagCreateDTO createDTO1 = TagCreateDTO.newBuilder()
@@ -638,6 +641,7 @@ class TagGrpcItTest extends GrpcTestBase {
         node.setTenantId(tenantId);
         node.setMonitoringLocation(location);
         node.setMonitoringLocationId(location.getId());
+        node.setScanType(ScanType.NODE_SCAN);
         node = nodeRepository.saveAndFlush(node);
         return node.getId();
     }

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/repository/IpInterfaceRepositoryTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/repository/IpInterfaceRepositoryTest.java
@@ -48,6 +48,7 @@ import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.model.SnmpInterface;
 import org.opennms.horizon.shared.constants.GrpcConstants;
+import org.opennms.taskset.contract.ScanType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
@@ -177,6 +178,7 @@ class IpInterfaceRepositoryTest {
             node.setNodeLabel("node" + i);
             node.setCreateTime(LocalDateTime.now());
             node.setTenantId("tenant" + i);
+            node.setScanType(ScanType.NODE_SCAN);
             var location = new MonitoringLocation();
             location.setLocation("location" + i);
             location.setTenantId("tenant" + i);

--- a/inventory/main/src/test/java/org/opennms/horizon/inventory/repository/NodeRepositoryTest.java
+++ b/inventory/main/src/test/java/org/opennms/horizon/inventory/repository/NodeRepositoryTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.model.Node;
+import org.opennms.taskset.contract.ScanType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
@@ -81,6 +82,7 @@ class NodeRepositoryTest {
         node1.setTenantId(tenantId1);
         node1.setCreateTime(LocalDateTime.now());
         node1.setMonitoringLocation(location1);
+        node1.setScanType(ScanType.NODE_SCAN);
         nodeRepo.save(node1);
 
         node2 = new Node();
@@ -88,6 +90,7 @@ class NodeRepositoryTest {
         node2.setTenantId(tenantId1);
         node2.setCreateTime(LocalDateTime.now());
         node2.setMonitoringLocation(location1);
+        node2.setScanType(ScanType.NODE_SCAN);
         nodeRepo.save(node2);
 
         node3 = new Node();
@@ -95,6 +98,7 @@ class NodeRepositoryTest {
         node3.setTenantId(tenantId2);
         node3.setCreateTime(LocalDateTime.now());
         node3.setMonitoringLocation(location2);
+        node3.setScanType(ScanType.NODE_SCAN);
         nodeRepo.save(node3);
     }
 

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -234,7 +234,6 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${jakarta.validation.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -239,7 +239,6 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -65,8 +65,7 @@
         <guava.version>31.0.1-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
         <hibernate.version>6.1.6.Final</hibernate.version>
-<!--        //TODO:MMF Need new hibernate for @TenantId annotation-->
-<!--        <hibernate.version>6.1.5.Final</hibernate.version>-->
+        <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
 
         <httpcore.version>4.4.4</httpcore.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -560,6 +559,11 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${javax.validation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator.version}</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -66,7 +66,6 @@
         <hamcrest.version>1.3</hamcrest.version>
         <hibernate.version>6.1.6.Final</hibernate.version>
         <hibernate-validator.version>8.0.0.Final</hibernate-validator.version>
-
         <httpcore.version>4.4.4</httpcore.version>
         <httpclient.version>4.5.13</httpclient.version>
         <ignite.version>2.14.0</ignite.version>
@@ -80,7 +79,6 @@
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
         <javax.annotation.version>1.2</javax.annotation.version>
-        <javax.validation.version>2.0.1.Final</javax.validation.version>
         <jaxrs.version>2.1</jaxrs.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <jcifs.version>2.1.6</jcifs.version>
@@ -556,9 +554,9 @@
                 <version>${jakarta.activation.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${javax.validation.version}</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Several services had a missing or incorrect dependency on hibernate-validator, which broke bean validation and caused errors to show in the logs when these services ran.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1609

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->
Now that validation is re-enabled these services might start throwing new validation exceptions if we have missing test cases. I ran into some of these in the inventory service - we could have other places if missing or invalid parameters are being used and that isn't being tested.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
