### PR TITLE
HS-1614: Update failsafe and surefire plugins to latest 3.1.0 version

### DIFF
--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -329,7 +329,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.vintage</groupId>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -315,7 +315,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <!-- Without these dependencies, all tests don't run with maven, either locally or in github Actions -->
                 <dependencies>
                     <dependency>
@@ -333,7 +332,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${failsafe.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -59,7 +59,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <!-- Without these dependencies, all tests don't run with maven, either locally or in github Actions -->
                 <dependencies>
                     <dependency>

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -388,7 +388,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <!-- Without these dependencies, all tests don't run with maven, either locally or in github Actions -->
                 <dependencies>
                     <dependency>
@@ -406,7 +405,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${failsafe.version}</version>
                 <executions>
                     <execution>
                         <id>horizon-integration-test</id>

--- a/minion-gateway/task-set-service/pom.xml
+++ b/minion-gateway/task-set-service/pom.xml
@@ -84,7 +84,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <!-- Without these dependencies, all tests don't run with maven, either locally or in github Actions -->
                 <dependencies>
                     <dependency>

--- a/minion/docker-it/pom.xml
+++ b/minion/docker-it/pom.xml
@@ -165,7 +165,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
                 <executions>
                     <execution>
                         <id>horizon-integration-test</id>

--- a/minion/pom.xml
+++ b/minion/pom.xml
@@ -199,16 +199,6 @@
                     <version>3.2.4</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.0.0-M5</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
                     <version>${karaf.version}</version>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -391,7 +391,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <!-- Without these dependencies, all tests don't run with maven, either locally or in github Actions -->
                 <dependencies>
                     <dependency>
@@ -409,7 +408,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${failsafe.version}</version>
                 <executions>
                     <execution>
                         <id>horizon-integration-test</id>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -138,8 +138,8 @@
         <mockito.version>4.8.0</mockito.version>
         <jupiter.version>5.9.0</jupiter.version>
         <jib.version>3.3.1</jib.version>
-        <surefire.version>3.0.0-M7</surefire.version>
-        <failsafe.version>3.0.0-M7</failsafe.version>
+        <surefire.version>3.1.0</surefire.version>
+        <failsafe.version>3.1.0</failsafe.version>
         <zjsonpatch.version>0.4.12</zjsonpatch.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <cron-utils.version>9.1.6</cron-utils.version>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -204,7 +204,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION


## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Fixes warnings from Maven about a deprecated 'localRepository' parameter. Uses pluginManagement in the parent-pom to define the versions.

Minion was using version 2.22.2 of surefire, this is a big bump so tests might not pass.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1614

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
