### PR TITLE
HS-1619: Fix failed Minion build in Tilt caused by incorrect property

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -299,7 +299,7 @@ jib_project(
 ### Minion ###
 custom_build(
     'opennms/horizon-stream-minion',
-    'mvn install -f minion -Dapplication.docker.image=$EXPECTED_REF -DfailIfNoTests=false -DskipUTs=true -DskipITs=true -DskipTests=true -Dfeatures.verify.skip=true',
+    'mvn install -f minion -Dapplication.docker.image=$EXPECTED_REF -DskipUTs=true -DskipITs=true -DskipTests=true -Dfeatures.verify.skip=true',
     deps=['./minion'],
     ignore=['**/target', '**/dependency-reduced-pom.xml'],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -299,7 +299,7 @@ jib_project(
 ### Minion ###
 custom_build(
     'opennms/horizon-stream-minion',
-    'mvn install -f minion -Dapplication.docker.image=$EXPECTED_REF -Dtest=false -DfailIfNoTests=false -DskipITs=true -DskipTests=true -Dfeatures.verify.skip=true',
+    'mvn install -f minion -Dapplication.docker.image=$EXPECTED_REF -DfailIfNoTests=false -DskipUTs=true -DskipITs=true -DskipTests=true -Dfeatures.verify.skip=true',
     deps=['./minion'],
     ignore=['**/target', '**/dependency-reduced-pom.xml'],
 )


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
The 'test' property is used to specify what tests to run in surefire, not disable tests. This removes that property and replaces it with `skipUTs`.

## Jira link(s)
- https://issues.opennms.org/browse/HS-1619

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
* [x] Notify devops of changes to the Charts
