### PR TITLE
Add tracing and JSON logging to new minion certificate services

### DIFF
--- a/charts/opennms/templates/cortex/cortex-configmap.yaml
+++ b/charts/opennms/templates/cortex/cortex-configmap.yaml
@@ -76,4 +76,14 @@ data:
       backend: local
       local:
         directory: /tmp/cortex/rules
+
+  {{- if .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint }}
+    tracing:
+      type: otel
+      otel:
+        {{- $url := urlParse .Values.OpenNMS.global.openTelemetry.otlpTracesEndpoint }}
+        # this key is misnamed in 1.14 and is corrected in 1.15 in later to otlp_endpoint
+        oltp_endpoint: {{ $url.host }}
+        sample_ratio: 1
+  {{- end }}
 {{ end }}

--- a/charts/opennms/templates/opennms/minion-certificate-manager/minion-certificate-manager-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-certificate-manager/minion-certificate-manager-deployment.yaml
@@ -16,6 +16,9 @@ spec:
       labels:
         appdomain: opennms
         app: {{ .Values.OpenNMS.MinionCertificateManager.ServiceName }}
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    
@@ -43,19 +46,27 @@ spec:
         - name: minion-certificate-manager-secrets
           secret:
             secretName: {{ .Values.OpenNMS.MinionCertificateManager.MtlsSecretName }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MinionCertificateManager.ServiceName }}
           image: {{ .Values.OpenNMS.MinionCertificateManager.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.MinionCertificateManager.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: KEYCLOAK_BASE_URL
               value: "http://{{ .Values.Keycloak.ServiceName }}:8080/auth/"
             - name: KEYCLOAK_REALM
               value: "{{ .Values.Keycloak.RealmName }}"
             - name: GRPC_SERVER_PORT
               value: "{{ .Values.OpenNMS.MinionCertificateManager.Port }}"
+            {{- include "deployment.env" .Values.OpenNMS.MinionCertificateManager | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: grpc
               containerPort: {{ .Values.OpenNMS.MinionCertificateManager.Port }}
@@ -66,6 +77,9 @@ spec:
             - name: minion-certificate-manager-secrets
               mountPath: "/run/secrets/mtls"
               readOnly: true
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.MinionCertificateManager.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/charts/opennms/templates/opennms/minion-certificate-manager/minion-certificate-verifier-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion-certificate-manager/minion-certificate-verifier-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         appdomain: opennms
         app: {{ .Values.OpenNMS.MinionCertificateVerifier.ServiceName }}
+      annotations:
+        # roll the deployment when the Spring boot environment variable configmap changes
+        checksum/spring-boot-env-configmap: {{ include (print $.Template.BasePath "/opennms/spring-boot-env-configmap.yaml") . | sha256sum }}
     spec:
       {{- if .Values.NodeRestrictions.Enabled }}
       nodeSelector:                                                                                    
@@ -35,16 +38,27 @@ spec:
                 values:                                                                                
                 - {{ .Values.NodeRestrictions.Value }}                                                 
       {{- end }}
+      volumes:
+        - name: spring-boot-app-config-volume
+          configMap:
+            name: spring-boot-app-config
       containers:
         - name: {{ .Values.OpenNMS.MinionCertificateVerifier.ServiceName }}
           image: {{ .Values.OpenNMS.MinionCertificateVerifier.Image }}
           imagePullPolicy: {{ .Values.OpenNMS.MinionCertificateVerifier.ImagePullPolicy }}
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+              value: "-javaagent:agent/opentelemetry-javaagent.jar -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
+            {{- include "deployment.env" .Values.OpenNMS.MinionCertificateVerifier | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: spring-boot-env
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.MinionCertificateVerifier.Port }}
+          volumeMounts:
+            - name: spring-boot-app-config-volume
+              mountPath: "/app/config"
       {{- if .Values.OpenNMS.MinionCertificateVerifier.PrivateRepoEnabled }}
       imagePullSecrets:
         - name: image-credentials

--- a/minion-certificate-manager/main/pom.xml
+++ b/minion-certificate-manager/main/pom.xml
@@ -25,6 +25,11 @@
     </dependencyManagement>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
@@ -162,6 +167,16 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <container>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
+                    </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
+                </configuration>
                 <executions>
                     <execution>
                         <id>build-docker-image</id>
@@ -169,6 +184,31 @@
                         <goals>
                             <goal>${application.jib.defaultGoal}</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/minion-certificate-verifier/main/pom.xml
+++ b/minion-certificate-verifier/main/pom.xml
@@ -28,6 +28,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>spring-boot-logback-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
@@ -62,7 +67,13 @@
                     <container>
                         <jvmFlags>
                         </jvmFlags>
+                        <extraClasspath>
+                            <entry>${application.jib.app.config}</entry>
+                        </extraClasspath>
                     </container>
+                    <extraDirectories>
+                        <paths>${application.jib.extra.root}</paths>
+                    </extraDirectories>
                 </configuration>
                 <executions>
                     <execution>
@@ -71,6 +82,31 @@
                         <goals>
                             <goal>${application.jib.defaultGoal}</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.opentelemetry.javaagent</groupId>
+                                    <artifactId>opentelemetry-javaagent</artifactId>
+                                    <version>${opentelemetry.version}</version>
+                                    <type>jar</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${application.jib.extra.root}/agent</outputDirectory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -101,6 +101,8 @@ OpenNMS:
       Requests:
         Cpu: '0'
         Memory: '0'
+    env:
+      OTEL_JAVAAGENT_ENABLED: "true" # Enable for local development since it adds useful data
     IngressAnnotations:
       nginx.ingress.kubernetes.io/auth-tls-secret: default/client-root-ca-certificate
       nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"


### PR DESCRIPTION
- Add tracing and JSON logging to new minion certificate services
- Add otel tracing for Cortex, if enabled
- minion-gateway: enable the otel java agent in Tilt

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
