### PR TITLE
Basic application tracing support for minion-gateway

### DIFF
--- a/minion-gateway/ipc-grpc-server/pom.xml
+++ b/minion-gateway/ipc-grpc-server/pom.xml
@@ -64,6 +64,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/TenantIDGrpcServerInterceptor.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/grpc/common/TenantIDGrpcServerInterceptor.java
@@ -38,6 +38,8 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
 
 import java.time.Duration;
 import java.util.function.Supplier;
@@ -94,6 +96,11 @@ public class TenantIDGrpcServerInterceptor implements ServerInterceptor {
 //----------------------------------------
 
     private String commonReadContextTenantId(Supplier<String> readTenantIdOp) {
-        return readTenantIdOp.get();
+        var tenantId = readTenantIdOp.get();
+        var span = Span.current();
+        if (span.isRecording()) {
+            span.setAttribute("user", tenantId);
+        }
+        return tenantId;
     }
 }

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -989,6 +989,11 @@
                 <artifactId>logback-jackson</artifactId>
                 <version>${logback.contrib.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>${opentelemetry.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This adds some very basic, but fairly useful, application tracing enhancements to the minion-gateway:

- Tracing: Set the "user" attribute to the tenant ID, if any -- Whenever code calls a method on `TenantIDGrpcServerInterceptor`, the tenantId is added as a span attribute to the current span (if any) with the key `user`. With this, you can do a tag search in a tracing tool to find traces for a specific tenantId, e.g.: `user=opennms-prime`.
- minion-gateway: Start a new span when we call dispatch -- The connections from the minion client to the minion-gateway are long lived and handle many requests, so the lifetime of the trace for the incoming connection is too long to be reasonable to directly contain the traces for all requests. This creates a new top-level trace every time we call `dispatch`, linking it to the connection-level trace, which makes the individual traces more consumable. Note that the span records for the long-lived connection trace won't be emitted until the connection is over, so the if you are looking at recent individual traces, it will often be the case that the parent trace hasn't been seen yet.

One big caveat: due to outstanding OOM issues in the `minion-gateway`, tracing is disabled in the dev environment for now. It is enabled by default in `Tilt`, however.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
