### PR TITLE
BTO-499: Rename Maven module names to use Lokahi

### DIFF
--- a/alert/pom.xml
+++ b/alert/pom.xml
@@ -11,7 +11,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Alert Service</name>
+    <name>OpenNMS Lokahi :: Alert Service</name>
     <description>
         A microservice that processes events produced by other components into alerts.
     </description>

--- a/datachoices/pom.xml
+++ b/datachoices/pom.xml
@@ -11,7 +11,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: DataChoices</name>
+    <name>OpenNMS Lokahi :: DataChoices</name>
     <description>datachoices</description>
 
     <artifactId>datachoices</artifactId>

--- a/events/conf/pom.xml
+++ b/events/conf/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>conf</artifactId>
-    <name>OpenNMS Horizon Stream :: Events Conf</name>
+    <name>OpenNMS Lokahi :: Events Conf</name>
     <properties>
         <sonar.coverage.exclusions>
             src/main/java/org/opennms/horizon/events/**/*

--- a/events/consumer/pom.xml
+++ b/events/consumer/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>consumer</artifactId>
-    <name>OpenNMS Horizon Stream :: Events Consumer</name>
+    <name>OpenNMS Lokahi :: Events Consumer</name>
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/events/grpc/pom.xml
+++ b/events/grpc/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>grpc</artifactId>
-    <name>OpenNMS Horizon Stream :: Events :: Grpc</name>
+    <name>OpenNMS Lokahi :: Events :: Grpc</name>
     <version>0.1.0-SNAPSHOT</version>
 
     <dependencyManagement>

--- a/events/main/pom.xml
+++ b/events/main/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>main</artifactId>
-    <name>OpenNMS Horizon Stream :: Events :: Main</name>
+    <name>OpenNMS Lokahi :: Events :: Main</name>
     <version>0.1.0-SNAPSHOT</version>
     <description>Events Service</description>
     <dependencyManagement>

--- a/events/persistence/pom.xml
+++ b/events/persistence/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>persistence</artifactId>
-    <name>OpenNMS Horizon Stream :: Events :: Persistence</name>
+    <name>OpenNMS Lokahi :: Events :: Persistence</name>
     <version>0.1.0-SNAPSHOT</version>
 
     <properties>

--- a/events/pom.xml
+++ b/events/pom.xml
@@ -11,7 +11,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Events</name>
+    <name>OpenNMS Lokahi :: Events</name>
     <description>
         A microservice that enriches events produced by other components and provides an API to query them.
     </description>

--- a/events/traps/pom.xml
+++ b/events/traps/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.events</groupId>
     <artifactId>traps</artifactId>
-    <name>OpenNMS Horizon Stream :: Events :: Traps</name>
+    <name>OpenNMS Lokahi :: Events :: Traps</name>
     <version>0.1.0-SNAPSHOT</version>
     <dependencyManagement>
         <dependencies>

--- a/external-it/external-horizon-stream-it/pom.xml
+++ b/external-it/external-horizon-stream-it/pom.xml
@@ -11,9 +11,9 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
-    <name>OpenNMS Horizon Stream :: External IT</name>
+    <name>OpenNMS Lokahi :: External IT</name>
     <description>
-        A Spring Boot based application that runs E2E tests against a fully deployed Horizon Stream cluster.
+        A Spring Boot based application that runs E2E tests against a fully deployed Lokahi cluster.
 
         Intended to be used in CI pipelines.
     </description>

--- a/external-it/hs-system-tests/pom.xml
+++ b/external-it/hs-system-tests/pom.xml
@@ -8,9 +8,9 @@
     <artifactId>hs-system-tests</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: System level tests</name>
+    <name>OpenNMS Lokahi :: System level tests</name>
     <description>
-        A System integration test suite to run against a fully deployed Horizon Stream cluster.
+        A System integration test suite to run against a fully deployed Lokahi cluster.
 
         Intended to be used in CI pipelines.
     </description>

--- a/external-it/pom.xml
+++ b/external-it/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: External IT Parent</name>
+    <name>OpenNMS Lokahi :: External IT Parent</name>
 
     <modules>
         <module>external-horizon-stream-it</module>

--- a/inventory/docker-it/pom.xml
+++ b/inventory/docker-it/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>inventory-docker-it</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: Docker IT</name>
+    <name>OpenNMS Lokahi :: Inventory :: Docker IT</name>
     <description>
         Docker build-time Integration Tests for the OpenNMS Inventory.
 

--- a/inventory/main/pom.xml
+++ b/inventory/main/pom.xml
@@ -10,7 +10,7 @@
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: Main</name>
+    <name>OpenNMS Lokahi :: Inventory :: Main</name>
     <description>
         A microservice responsible for tracking the state of the network and how to monitor devices.
     </description>

--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -12,7 +12,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Inventory Parent</name>
+    <name>OpenNMS Lokahi :: Inventory Parent</name>
 
     <artifactId>inventory-parent</artifactId>
     <packaging>pom</packaging>

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>minion-gateway-wiremock-api</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock :: API</name>
+    <name>OpenNMS Lokahi :: Inventory :: TestTools :: Minion Gateway Wiremock :: API</name>
     <description>
         API for mock programming of the Minion Gateway Wiremock for Inventory.
     </description>

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>minion-gateway-wiremock-client</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock :: Client</name>
+    <name>OpenNMS Lokahi :: Inventory :: TestTools :: Minion Gateway Wiremock :: Client</name>
     <description>
         Client for programming the Minion Gateway Wiremock for Inventory.
     </description>

--- a/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>minion-gateway-wiremock-main</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock :: Main</name>
+    <name>OpenNMS Lokahi :: Inventory :: TestTools :: Minion Gateway Wiremock :: Main</name>
     <description>
         Main executable for the Minion Gateway WireMock.
     </description>

--- a/inventory/testtools/minion-gateway-wiremock/pom.xml
+++ b/inventory/testtools/minion-gateway-wiremock/pom.xml
@@ -14,7 +14,7 @@
     <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: TestTools :: Minion Gateway Wiremock</name>
+    <name>OpenNMS Lokahi :: Inventory :: TestTools :: Minion Gateway Wiremock</name>
     <description>
         Parent of the WireMock for the Minion Gateway.
     </description>

--- a/inventory/testtools/pom.xml
+++ b/inventory/testtools/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>testtools</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Inventory :: TestTools</name>
+    <name>OpenNMS Lokahi :: Inventory :: TestTools</name>
     <description>
         Tools to support testing of the Inventory service.
     </description>

--- a/metrics-processor/flows/pom.xml
+++ b/metrics-processor/flows/pom.xml
@@ -7,7 +7,7 @@
       <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Metrics Processor :: Flows</name>
+    <name>OpenNMS Lokahi :: Metrics Processor :: Flows</name>
     <description>
         A microservice responsible for processing flows metrics.
     </description>

--- a/metrics-processor/main/pom.xml
+++ b/metrics-processor/main/pom.xml
@@ -9,7 +9,7 @@
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Metrics Processor :: Main Metrics Processor</name>
+    <name>OpenNMS Lokahi :: Metrics Processor :: Main Metrics Processor</name>
     <description>
         A microservice responsible for processing device metrics.
     </description>

--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Metrics Processor</name>
+    <name>OpenNMS Lokahi :: Metrics Processor</name>
     <description>
         A microservice responsible for processing device metrics.
     </description>

--- a/metrics-processor/timeseries/pom.xml
+++ b/metrics-processor/timeseries/pom.xml
@@ -9,7 +9,7 @@
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Metrics Processor :: Time Series</name>
+    <name>OpenNMS Lokahi :: Metrics Processor :: Time Series</name>
     <description>
         A microservice responsible for processing device metrics.
     </description>

--- a/minion-certificate-manager/docker-it/pom.xml
+++ b/minion-certificate-manager/docker-it/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>minion-certificate-manager-docker-it</artifactId>
 
-    <name>OpenNMS Horizon :: Minion Certificate Manager :: Docker IT</name>
+    <name>OpenNMS Lokahi :: Minion Certificate Manager :: Docker IT</name>
     <description>
         Docker build-time Integration Tests for the OpenNMS Minion Certificate Manager.
 

--- a/minion-certificate-manager/main/pom.xml
+++ b/minion-certificate-manager/main/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
 	<artifactId>certificate-manager-main</artifactId>
-	<name>OpenNMS Horizon Stream :: Minion Certificate Manager :: Main</name>
+	<name>OpenNMS Lokahi :: Minion Certificate Manager :: Main</name>
 	<description>Minion Certificate Manager</description>
 
     <dependencyManagement>

--- a/minion-certificate-manager/pom.xml
+++ b/minion-certificate-manager/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Minion Certificate Manager</name>
+    <name>OpenNMS Lokahi :: Minion Certificate Manager</name>
     <description>
         Manage certificates for Minion on dev environment
     </description>

--- a/minion-certificate-verifier/docker-it/pom.xml
+++ b/minion-certificate-verifier/docker-it/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>certificate-verifier-docker-it</artifactId>
-    <name>OpenNMS Horizon Stream :: Minion Certificate Verifier :: Docker IT</name>
+    <name>OpenNMS Lokahi :: Minion Certificate Verifier :: Docker IT</name>
     <description>
         Docker build-time Integration Tests for the OpenNMS Minion Certificate Verifier.
         Test Containers are used to spin up containers and exercise the public endpoints.

--- a/minion-certificate-verifier/main/pom.xml
+++ b/minion-certificate-verifier/main/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>certificate-verifier-main</artifactId>
-    <name>OpenNMS Horizon Stream :: Minion Certificate Verifier :: Main</name>
+    <name>OpenNMS Lokahi :: Minion Certificate Verifier :: Main</name>
     <description>Minion Certificate Verifier</description>
 
     <dependencyManagement>

--- a/minion-certificate-verifier/pom.xml
+++ b/minion-certificate-verifier/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Minion Certificate Verifier</name>
+    <name>OpenNMS Lokahi :: Minion Certificate Verifier</name>
     <description>
         Manage certificates validation/extraction.
     </description>

--- a/minion-gateway-grpc-proxy/main/pom.xml
+++ b/minion-gateway-grpc-proxy/main/pom.xml
@@ -38,7 +38,7 @@
 
     <artifactId>minion-gateway-main</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Main</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Main</name>
     <description>
         Main executable for the Minion Gateway gRPC Proxy.
     </description>

--- a/minion-gateway-grpc-proxy/pom.xml
+++ b/minion-gateway-grpc-proxy/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>minion-gateway-grpc-proxy</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway gRPC Proxy</name>
+    <name>OpenNMS Lokahi :: Minion Gateway gRPC Proxy</name>
     <description>
         Proxy service for gRPC communication with the Minion Gateway.
         Covers gRPC communications from Minion, and potentially other external services.

--- a/minion-gateway/docker-it/pom.xml
+++ b/minion-gateway/docker-it/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>minion-gateway-docker-it</artifactId>
 
-    <name>OpenNMS Horizon :: Minion Gateway :: Docker IT</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Docker IT</name>
     <description>
         Docker build-time Integration Tests for the OpenNMS Minion Gateway.
 

--- a/minion-gateway/ignite-detector/api/pom.xml
+++ b/minion-gateway/ignite-detector/api/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>minion-gateway-ignite-detector-api</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Ignite Detector :: API</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Ignite Detector :: API</name>
     <description>
         API for the Ignite Detector in the Minion Gateway.
     </description>

--- a/minion-gateway/ignite-detector/client/pom.xml
+++ b/minion-gateway/ignite-detector/client/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>minion-gateway-ignite-detector-client</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Ignite Detector :: Client</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Ignite Detector :: Client</name>
     <description>
         Client implementation for using the Ignite Detector service over Ignite.
     </description>

--- a/minion-gateway/ignite-detector/pom.xml
+++ b/minion-gateway/ignite-detector/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>minion-gateway-ignite-detector-parent</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Ignite Detector</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Ignite Detector</name>
     <description>
         Parent for the Ignite Detector for the Minion Gateway,
         which includes a client and server for processing Detectors

--- a/minion-gateway/ignite-detector/server/pom.xml
+++ b/minion-gateway/ignite-detector/server/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>minion-gateway-ignite-detector-server</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Ignite Detector :: Server</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Ignite Detector :: Server</name>
     <description>
         Server implementation for running Detectors over Ignite.
     </description>

--- a/minion-gateway/ipc-grpc-server/pom.xml
+++ b/minion-gateway/ipc-grpc-server/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>ipc-grpc-server</artifactId>
     <packaging>jar</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: IPC gRPC Server</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: IPC gRPC Server</name>
     <description>Server side of gRPC.</description>
 
     <dependencies>

--- a/minion-gateway/main/pom.xml
+++ b/minion-gateway/main/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>minion-gateway-main</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Main</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Main</name>
     <description>
         Main executable module for the Minion Gateway.
     </description>

--- a/minion-gateway/pom.xml
+++ b/minion-gateway/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway</name>
+    <name>OpenNMS Lokahi :: Minion Gateway</name>
     <description>
         Gateway which serves gRPC connections from Minions and routes traffic to and from Minions.
     </description>

--- a/minion-gateway/rpc-request-server/pom.xml
+++ b/minion-gateway/rpc-request-server/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>rpc-request-server</artifactId>
     <packaging>jar</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: RPC Request Server</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: RPC Request Server</name>
     <description>
         Server processing RPC Requests.
     </description>

--- a/minion-gateway/task-set-service/pom.xml
+++ b/minion-gateway/task-set-service/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>task-set-service</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion Gateway :: Task Set Service</name>
+    <name>OpenNMS Lokahi :: Minion Gateway :: Task Set Service</name>
     <description>
         Service which receives task set definitions in order to track and publish them to downstream consumers.
     </description>

--- a/minion/assembly/pom.xml
+++ b/minion/assembly/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>assembly</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Assembly</name>
+    <name>OpenNMS Lokahi :: Minion :: Assembly</name>
     <packaging>karaf-assembly</packaging>
 
     <dependencies>

--- a/minion/docker-assembly/pom.xml
+++ b/minion/docker-assembly/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>docker-assembly</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Docker</name>
+    <name>OpenNMS Lokahi :: Minion :: Docker</name>
     <description>Create docker image for the application.</description>
 
     <properties>

--- a/minion/docker-it/pom.xml
+++ b/minion/docker-it/pom.xml
@@ -9,9 +9,9 @@
         <version>0.1.0-SNAPSHOT</version>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Docker IT</name>
+    <name>OpenNMS Lokahi :: Minion :: Docker IT</name>
     <description>
-        Docker build-time, Black Box, System Integration Tests for the OpenNMS Horizon project.
+        Docker build-time, Black Box, System Integration Tests for the OpenNMS Lokahi project.
 
         The docker-maven-plugin is used to spin up containers with the Minion and dependencies, then exercise
         Minion functionality.

--- a/minion/icmp/icmp-best/pom.xml
+++ b/minion/icmp/icmp-best/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
   <artifactId>icmp-best</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: Best</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: Best</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/icmp/icmp-ipc/pom.xml
+++ b/minion/icmp/icmp-ipc/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
   <artifactId>icmp-ipc</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: RPC Handler</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: RPC Handler</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/icmp/icmp-jna/pom.xml
+++ b/minion/icmp/icmp-jna/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
   <artifactId>icmp-jna</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: JNA</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: JNA</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/icmp/icmp-jni/pom.xml
+++ b/minion/icmp/icmp-jni/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
   <artifactId>icmp-jni</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: JNI</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: JNI</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/icmp/icmp-jni6/pom.xml
+++ b/minion/icmp/icmp-jni6/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
   <artifactId>icmp-jni6</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: JNI6</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: JNI6</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/icmp/icmp-rpc-common/pom.xml
+++ b/minion/icmp/icmp-rpc-common/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
   <artifactId>icmp-rpc-common</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: RPC Common</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: RPC Common</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/icmp/icmp-shell/pom.xml
+++ b/minion/icmp/icmp-shell/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>icmp-shell</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP :: Shell</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP :: Shell</name>
   <description>Karaf shell commands for ICMP requests and diagnostics</description>
   <packaging>bundle</packaging>
 

--- a/minion/icmp/pom.xml
+++ b/minion/icmp/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>icmp</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: ICMP</name>
+  <name>OpenNMS Lokahi :: Minion :: ICMP</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/minion/minion-3rdParty/pom.xml
+++ b/minion/minion-3rdParty/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>minion-3rdParty</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: 3rd Party</name>
+    <name>OpenNMS Lokahi :: Minion :: 3rd Party</name>
 
     <modules>
         <module>shaded-grpc</module>

--- a/minion/minion-3rdParty/shaded-grpc/pom.xml
+++ b/minion/minion-3rdParty/shaded-grpc/pom.xml
@@ -15,7 +15,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>shaded-grpc</artifactId>
-    <name>OpenNMS Horizon Stream :: Minion :: 3rd Party :: gRPC (shaded)</name>
+    <name>OpenNMS Lokahi :: Minion :: 3rd Party :: gRPC (shaded)</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/minion/minion-3rdParty/shaded-ignite/pom.xml
+++ b/minion/minion-3rdParty/shaded-ignite/pom.xml
@@ -13,7 +13,7 @@
 <!--    jar correctly show that it can be used.-->
 
     <artifactId>shaded-ignite</artifactId>
-    <name>OpenNMS Horizon Stream :: Minion :: 3rd Party :: ignite (shaded)</name>
+    <name>OpenNMS Lokahi :: Minion :: 3rd Party :: ignite (shaded)</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/minion/minion-features/pom.xml
+++ b/minion/minion-features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>minion-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: Features</name>
 
     <dependencies>
 

--- a/minion/minion-flows/flows-features/pom.xml
+++ b/minion/minion-flows/flows-features/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>flows-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNms Horizon :: Minion :: Flows :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: Flows :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-flows/flows-parser/pom.xml
+++ b/minion/minion-flows/flows-parser/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>flows-parser</artifactId>
-  <name>OpenNms Horizon :: Minion :: Flows :: Parser</name>
+  <name>OpenNMS Lokahi :: Minion :: Flows :: Parser</name>
   <packaging>bundle</packaging>
     <build>
         <plugins>

--- a/minion/minion-flows/pom.xml
+++ b/minion/minion-flows/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>minion-flows</artifactId>
-    <name>OpenNMS Horizon :: Minion :: Flows</name>
+    <name>OpenNMS Lokahi :: Minion :: Flows</name>
     <packaging>pom</packaging>
     <modules>
         <module>flows-parser</module>

--- a/minion/minion-grpc/grpc-client/pom.xml
+++ b/minion/minion-grpc/grpc-client/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>grpc-client</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: gRPC :: Client</name>
+    <name>OpenNMS Lokahi :: Minion :: gRPC :: Client</name>
     <description>Client side of gRPC.</description>
 
     <dependencies>

--- a/minion/minion-grpc/grpc-features/pom.xml
+++ b/minion/minion-grpc/grpc-features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>grpc-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: gRPC :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: gRPC :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-grpc/pom.xml
+++ b/minion/minion-grpc/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>minion-grpc</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: gRPC</name>
+    <name>OpenNMS Lokahi :: Minion :: gRPC</name>
 
     <modules>
         <module>grpc-client</module>

--- a/minion/minion-ipc/ipc-echo/pom.xml
+++ b/minion/minion-ipc/ipc-echo/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>ipc-echo</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc :: Echo</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc :: Echo</name>
     <description>Echo module for IPC.</description>
 
     <dependencies>

--- a/minion/minion-ipc/ipc-features/pom.xml
+++ b/minion/minion-ipc/ipc-features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>ipc-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: IPC :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: IPC :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-ipc/ipc-heartbeat/pom.xml
+++ b/minion/minion-ipc/ipc-heartbeat/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>ipc-heartbeat</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc :: Heartbeat</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc :: Heartbeat</name>
     <description>Heartbeat producer.</description>
 
     <dependencies>

--- a/minion/minion-ipc/pom.xml
+++ b/minion/minion-ipc/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>minion-ipc</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc</name>
 
     <modules>
         <module>ipc-echo</module>

--- a/minion/minion-ipc/twin-api/pom.xml
+++ b/minion/minion-ipc/twin-api/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>twin-api</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc :: Twin :: Api</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc :: Twin :: Api</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-ipc/twin-common/pom.xml
+++ b/minion/minion-ipc/twin-common/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>twin-common</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc :: Twin :: Common</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc :: Twin :: Common</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-ipc/twin-core/pom.xml
+++ b/minion/minion-ipc/twin-core/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>twin-core</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc :: Twin :: Core</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc :: Twin :: Core</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-ipc/twin-whiteboard/pom.xml
+++ b/minion/minion-ipc/twin-whiteboard/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>twin-whiteboard</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Ipc :: Twin :: Whiteboard</name>
+    <name>OpenNMS Lokahi :: Minion :: Ipc :: Twin :: Whiteboard</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-observability/observability-features/pom.xml
+++ b/minion/minion-observability/observability-features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>observability-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Observability :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: Observability :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-observability/observability-metrics/pom.xml
+++ b/minion/minion-observability/observability-metrics/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>observability-metrics</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Observability :: Metrics</name>
+    <name>OpenNMS Lokahi :: Minion :: Observability :: Metrics</name>
     <packaging>bundle</packaging>
     <description>Metrics integration</description>
 

--- a/minion/minion-observability/observability-tracing/pom.xml
+++ b/minion/minion-observability/observability-tracing/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>observability-tracing</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenNMS Horizon Stream :: Minion :: Observability :: Tracing</name>
+    <name>OpenNMS Lokahi :: Minion :: Observability :: Tracing</name>
 
     <description>Drop in replacement for horizon / openapi tracing</description>
 

--- a/minion/minion-observability/pom.xml
+++ b/minion/minion-observability/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>observability</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Observability</name>
+    <name>OpenNMS Lokahi :: Minion :: Observability</name>
 
     <modules>
         <module>observability-metrics</module>

--- a/minion/minion-taskset/pom.xml
+++ b/minion/minion-taskset/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>taskset</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TaskSet</name>
+    <name>OpenNMS Lokahi :: Minion :: TaskSet</name>
 
     <modules>
         <module>taskset-ipc</module>

--- a/minion/minion-taskset/taskset-features/pom.xml
+++ b/minion/minion-taskset/taskset-features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>taskset-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TaskSet :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: TaskSet :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-taskset/taskset-ipc/pom.xml
+++ b/minion/minion-taskset/taskset-ipc/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>taskset-ipc</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TaskSet :: IPC</name>
+    <name>OpenNMS Lokahi :: Minion :: TaskSet :: IPC</name>
     <description>TaskSet grpc-ipc-api glue modules</description>
 
     <dependencies>

--- a/minion/minion-taskset/taskset-scheduler/pom.xml
+++ b/minion/minion-taskset/taskset-scheduler/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>taskset-scheduler</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Scheduler</name>
+    <name>OpenNMS Lokahi :: Minion :: Scheduler</name>
     <description>Scheduler for handling tasks by period or cron expression.</description>
 
     <dependencies>

--- a/minion/minion-taskset/taskset-worker/pom.xml
+++ b/minion/minion-taskset/taskset-worker/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>taskset-worker</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TaskSet :: Worker</name>
+    <name>OpenNMS Lokahi :: Minion :: TaskSet :: Worker</name>
     <packaging>bundle</packaging>
     <description>Minion Ignite Worker</description>
 

--- a/minion/minion-traps/features/pom.xml
+++ b/minion/minion-traps/features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>traps-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Traps :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: Traps :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/minion-traps/listener/pom.xml
+++ b/minion/minion-traps/listener/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>traps-listener</artifactId>
-    <name>OpenNMS Horizon Stream :: Minion :: Traps :: Listener</name>
+    <name>OpenNMS Lokahi :: Minion :: Traps :: Listener</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/minion/plugins/azure-plugin/pom.xml
+++ b/minion/plugins/azure-plugin/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>azure-plugin</artifactId>
 
     <packaging>bundle</packaging>
-    <name>OpenNms Horizon :: Minion :: Plugins :: Azure</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins :: Azure</name>
 
     <dependencies>
         <dependency>

--- a/minion/plugins/features/pom.xml
+++ b/minion/plugins/features/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>plugin-features</artifactId>
     <packaging>feature</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Plugin :: Features</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugin :: Features</name>
 
     <dependencies>
         <dependency>

--- a/minion/plugins/icmp-plugin/pom.xml
+++ b/minion/plugins/icmp-plugin/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>icmp-plugin</artifactId>
 
     <packaging>bundle</packaging>
-    <name>OpenNMS Horizon Stream :: Minion :: Plugins :: ICMP</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins :: ICMP</name>
 
     <dependencies>
         <dependency>

--- a/minion/plugins/nodescan-plugin/pom.xml
+++ b/minion/plugins/nodescan-plugin/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>nodescan-plugin</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenNms Horizon Stream:: Minion :: Plugins :: Node Scan</name>
+    <name>OpenNMS Lokahi:: Minion :: Plugins :: Node Scan</name>
 
 
    <properties>

--- a/minion/plugins/plugins-api/pom.xml
+++ b/minion/plugins/plugins-api/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>plugins-api</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Plugins Api</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins Api</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/minion/plugins/pom.xml
+++ b/minion/plugins/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>plugins</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Plugins</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/minion/plugins/registration/pom.xml
+++ b/minion/plugins/registration/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>registration</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Plugins :: Registration</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins :: Registration</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/minion/plugins/shell-commands/pom.xml
+++ b/minion/plugins/shell-commands/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>shell-commands</artifactId>
     <packaging>bundle</packaging>
-    <name>OpenNms Horizon :: Minion :: Plugins :: Shell Commands</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins :: Shell Commands</name>
     <build>
         <plugins>
             <plugin>

--- a/minion/plugins/snmp-plugin/pom.xml
+++ b/minion/plugins/snmp-plugin/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>snmp-plugin</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Minion :: Plugins :: SNMP</name>
+    <name>OpenNMS Lokahi :: Minion :: Plugins :: SNMP</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/minion/pom.xml
+++ b/minion/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Minion</name>
+    <name>OpenNMS Lokahi :: Minion</name>
     <description>
         A Karaf-based Java program that's responsible for monitoring devices on a network.
     </description>

--- a/minion/snmp/pom.xml
+++ b/minion/snmp/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>minion-snmp</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: SNMP</name>
+  <name>OpenNMS Lokahi :: Minion :: SNMP</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/minion/snmp/snmp-ipc/pom.xml
+++ b/minion/snmp/snmp-ipc/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>snmp-ipc</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: SNMP :: IPC</name>
+  <name>OpenNMS Lokahi :: Minion :: SNMP :: IPC</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-api/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>minion-gateway-wiremock-api</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock :: API</name>
+    <name>OpenNMS Lokahi :: Minion :: TestTools :: Minion Gateway Wiremock :: API</name>
     <description>
         API for mock programming of the Minion Gateway Wiremock.
     </description>

--- a/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-client/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>minion-gateway-wiremock-client</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock :: Client</name>
+    <name>OpenNMS Lokahi :: Minion :: TestTools :: Minion Gateway Wiremock :: Client</name>
     <description>
         Client for programming the Minion Gateway Wiremock.
     </description>

--- a/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/minion-gateway-wiremock-main/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>minion-gateway-wiremock-main</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock :: Main</name>
+    <name>OpenNMS Lokahi :: Minion :: TestTools :: Minion Gateway Wiremock :: Main</name>
     <description>
         Main executable for the Minion Gateway WireMock.
     </description>

--- a/minion/testtools/minion-gateway-wiremock/pom.xml
+++ b/minion/testtools/minion-gateway-wiremock/pom.xml
@@ -15,7 +15,7 @@
     <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Minion :: TestTools :: Minion Gateway Wiremock</name>
+    <name>OpenNMS Lokahi :: Minion :: TestTools :: Minion Gateway Wiremock</name>
     <description>
         Parent of the WireMock for the Minion Gateway.
     </description>

--- a/minion/testtools/pom.xml
+++ b/minion/testtools/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>testtools</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: TestTools</name>
+  <name>OpenNMS Lokahi :: Minion :: TestTools</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/notifications/pom.xml
+++ b/notifications/pom.xml
@@ -11,7 +11,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Notifications</name>
+    <name>OpenNMS Lokahi :: Notifications</name>
     <description>A microservice responsible for generating notifications from alerts.</description>
 
 	<artifactId>notifications</artifactId>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <name>OpenNMS Horizon Stream :: Horizon Parent</name>
+    <name>OpenNMS Lokahi :: Lokahi Parent</name>
     <description>
         Top-level Parent POM with standard dependency versions for use across multiple top-level projects.
     </description>

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
 	</parent>
 
-    <name>OpenNMS Horizon Stream :: BFF</name>
+    <name>OpenNMS Lokahi :: BFF</name>
     <description>
         A microservice that provides a GraphQL API for the Vue.js frontend.
 

--- a/shared-lib/alert/pom.xml
+++ b/shared-lib/alert/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>alert-dto</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Alert</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Alert</name>
     <description>The alert service DTO contract.</description>
 
 

--- a/shared-lib/azure/azure-http/pom.xml
+++ b/shared-lib/azure/azure-http/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>azure-http</artifactId>
-    <name>OpenNMS Horizon :: Shared Library :: Azure :: Http</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Azure :: Http</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/shared-lib/azure/pom.xml
+++ b/shared-lib/azure/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>azure-parent</artifactId>
-    <name>OpenNMS Horizon :: Shared Library :: Azure</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Azure</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/shared-lib/azure/proto/pom.xml
+++ b/shared-lib/azure/proto/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.shared.azure</groupId>
     <artifactId>proto</artifactId>
-    <name>OpenNMS Horizon :: Shared Library :: Azure :: Proto</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Azure :: Proto</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/shared-lib/datachoices/pom.xml
+++ b/shared-lib/datachoices/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>datachoices</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon :: Shared Library :: DataChoices</name>
+    <name>OpenNMS Lokahi :: Shared Library :: DataChoices</name>
     <description>The datachoices service contract.</description>
 
     <dependencies>

--- a/shared-lib/events/pom.xml
+++ b/shared-lib/events/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>events</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Events</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Events</name>
     <description>The events service contract.</description>
 
     <dependencies>

--- a/shared-lib/flows/pom.xml
+++ b/shared-lib/flows/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>flows</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Flows</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Flows</name>
     <description>The flow service contracts.</description>
 
     <dependencies>

--- a/shared-lib/horizon-common-lang/pom.xml
+++ b/shared-lib/horizon-common-lang/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>horizon-common-lang</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library:: Lang</name>
+    <name>OpenNMS Lokahi :: Shared Library:: Lang</name>
     <packaging>bundle</packaging>
 
     <description>

--- a/shared-lib/horizon-common-logging/pom.xml
+++ b/shared-lib/horizon-common-logging/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>horizon-common-logging</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library:: Logging</name>
+    <name>OpenNMS Lokahi :: Shared Library:: Logging</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/shared-lib/horizon-common-tag/pom.xml
+++ b/shared-lib/horizon-common-tag/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>horizon-common-tag</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Common Tag</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Common Tag</name>
     <description>The shared </description>
 
 

--- a/shared-lib/horizon-common-utils/pom.xml
+++ b/shared-lib/horizon-common-utils/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>horizon-common-utils</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library:: Utils</name>
+    <name>OpenNMS Lokahi :: Shared Library:: Utils</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/shared-lib/horizon-grpc-common-constants/pom.xml
+++ b/shared-lib/horizon-grpc-common-constants/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>grpc-common-constants</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library:: Constants</name>
+    <name>OpenNMS Lokahi :: Shared Library:: Constants</name>
 
     <dependencies>
         <dependency>

--- a/shared-lib/horizon-ipc/ipc-api/pom.xml
+++ b/shared-lib/horizon-ipc/ipc-api/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>ipc-api</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: IPC :: API</name>
+    <name>OpenNMS Lokahi :: Shared Library :: IPC :: API</name>
     <description>Shallow copy of IPC api.</description>
 
     <dependencies>

--- a/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-contract/pom.xml
+++ b/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-contract/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>ipc-grpc-contract</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: IPC :: gRPC :: Contract</name>
+    <name>OpenNMS Lokahi :: Shared Library :: IPC :: gRPC :: Contract</name>
     <description>The gRPC service contract.</description>
 
     <dependencies>

--- a/shared-lib/horizon-ipc/ipc-grpc/pom.xml
+++ b/shared-lib/horizon-ipc/ipc-grpc/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>ipc-grpc</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library :: IPC :: gRPC</name>
+    <name>OpenNMS Lokahi :: Shared Library :: IPC :: gRPC</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/shared-lib/horizon-ipc/pom.xml
+++ b/shared-lib/horizon-ipc/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>horizon-ipc</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library :: IPC</name>
+    <name>OpenNMS Lokahi :: Shared Library :: IPC</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/shared-lib/icmp-api/pom.xml
+++ b/shared-lib/icmp-api/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>icmp-api</artifactId>
-  <name>OpenNMS Horizon Stream :: Shared Library :: Icmp :: Api</name>
+  <name>OpenNMS Lokahi :: Shared Library :: Icmp :: Api</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/shared-lib/ignite-tasks/pom.xml
+++ b/shared-lib/ignite-tasks/pom.xml
@@ -10,6 +10,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ignite-tasks</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library :: Ignite Tasks</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Ignite Tasks</name>
 
 </project>

--- a/shared-lib/inventory/pom.xml
+++ b/shared-lib/inventory/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>inventory</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Inventory</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Inventory</name>
     <description>The inventory service contract.</description>
 
     <dependencies>

--- a/shared-lib/minion-certificate-manager-api/pom.xml
+++ b/shared-lib/minion-certificate-manager-api/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>minion-certificate-manager-api</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Minion Certificate Manager API</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Minion Certificate Manager API</name>
     <description>The Minion Certificate Manager service contract.</description>
 
 

--- a/shared-lib/minion-gateway/pom.xml
+++ b/shared-lib/minion-gateway/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>minion-gateway</artifactId>
 
-    <name>OpenNMS Horizon Stream :: Shared :: Minion-gateway</name>
+    <name>OpenNMS Lokahi :: Shared :: Minion-gateway</name>
     <description>Minion Gateway contract</description>
 
     <dependencies>

--- a/shared-lib/notifications/pom.xml
+++ b/shared-lib/notifications/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>notifications</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared Library :: Notifications</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Notifications</name>
     <description>The notifications service contract.</description>
 
     <dependencies>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Shared Library</name>
+    <name>OpenNMS Lokahi :: Shared Library</name>
     <description>A library of shared code across different Java-based microservices.</description>
 
     <groupId>org.opennms.horizon.shared</groupId>

--- a/shared-lib/protobuf/pom.xml
+++ b/shared-lib/protobuf/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>protobuf</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library:: Protobuf</name>
+    <name>OpenNMS Lokahi :: Shared Library:: Protobuf</name>
     <packaging>bundle</packaging>
 
     <description>

--- a/shared-lib/shaded-grpc-core/pom.xml
+++ b/shared-lib/shaded-grpc-core/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>horizon-shaded-grpc-core</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library:: Shaded GRPC-CORE</name>
+    <name>OpenNMS Lokahi :: Shared Library:: Shaded GRPC-CORE</name>
     <packaging>bundle</packaging>
 
     <description>

--- a/shared-lib/snmp/agent-config/pom.xml
+++ b/shared-lib/snmp/agent-config/pom.xml
@@ -13,7 +13,7 @@
 
 
     <artifactId>agent-config</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library :: Snmp :: AgentConfig</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Snmp :: AgentConfig</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/shared-lib/snmp/pom.xml
+++ b/shared-lib/snmp/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>snmp-parent</artifactId>
-  <name>OpenNMS Horizon Stream :: Shared Library :: Snmp</name>
+  <name>OpenNMS Lokahi :: Shared Library :: Snmp</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/shared-lib/snmp/proto/pom.xml
+++ b/shared-lib/snmp/proto/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.opennms.horizon.shared.snmp</groupId>
     <artifactId>proto</artifactId>
-    <name>OpenNMS Horizon Stream :: Shared Library :: Snmp :: Proto</name>
+    <name>OpenNMS Lokahi :: Shared Library :: Snmp :: Proto</name>
     <packaging>bundle</packaging>
 
     <dependencies>

--- a/shared-lib/snmp/snmp-api/pom.xml
+++ b/shared-lib/snmp/snmp-api/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>snmp-api</artifactId>
-  <name>OpenNMS Horizon Stream :: Shared Library :: Snmp :: Api</name>
+  <name>OpenNMS Lokahi :: Shared Library :: Snmp :: Api</name>
   <packaging>bundle</packaging>
 
   <dependencies>

--- a/shared-lib/snmp/snmp-impl/pom.xml
+++ b/shared-lib/snmp/snmp-impl/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>snmp-impl</artifactId>
-  <name>OpenNMS Horizon Stream :: Minion :: Snmp :: SNMP IMPL</name>
+  <name>OpenNMS Lokahi :: Minion :: Snmp :: SNMP IMPL</name>
   <description>
     OpenNMS SNMP implementation based on snmp4j.org.
   </description>

--- a/shared-lib/spring-boot-logback-json/pom.xml
+++ b/shared-lib/spring-boot-logback-json/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>spring-boot-logback-json</artifactId>
-    <name>OpenNMS Horizon Stream :: Spring Boot Support :: Logback JSON</name>
+    <name>OpenNMS Lokahi :: Spring Boot Support :: Logback JSON</name>
 
     <dependencies>
         <!-- Since we need to support a few different versions of Spring Boot,

--- a/shared-lib/task-set-service/api/pom.xml
+++ b/shared-lib/task-set-service/api/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>task-set-service-api</artifactId>
     <packaging>bundle</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared :: Task Set Service :: API</name>
+    <name>OpenNMS Lokahi :: Shared :: Task Set Service :: API</name>
     <description>
         API definitions (models + interfaces) for the Task Set Service.
     </description>

--- a/shared-lib/task-set-service/pom.xml
+++ b/shared-lib/task-set-service/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>task-set-service</artifactId>
     <packaging>pom</packaging>
 
-    <name>OpenNMS Horizon Stream :: Shared :: Task Set Service</name>
+    <name>OpenNMS Lokahi :: Shared :: Task Set Service</name>
     <description>
         Task Set Service which receives Task Set Definitions and shares them with downstream consumers.
     </description>

--- a/tooling/ignite-tool/pom.xml
+++ b/tooling/ignite-tool/pom.xml
@@ -10,7 +10,7 @@
         <relativePath>../../parent-pom</relativePath>
     </parent>
 
-    <name>OpenNMS Horizon Stream :: Ignite Tool</name>
+    <name>OpenNMS Lokahi :: Ignite Tool</name>
     <description>
         Tool for connecting to an Ignite cluster, reporting statistics, accessing functionality, and more.
     </description>


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Renames all Maven modules to use "Lokahi" instead of "Horizon" or "Horizon Stream". This isn't used for anything functional so it is fairly low impact. SonarCloud makes use of this field, so this should partially complete BTO-500 after merge.

## Jira link(s)
- https://issues.opennms.org/browse/BTO-499

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->
Should we use "Lōkahi" with the accented letter instead? Tools hook into this when displaying the name of a module, so no accent is the safer option.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
* [ ] Notify devops of changes to the Charts
